### PR TITLE
fixed build for pre ansi c99 compilers

### DIFF
--- a/src/common/unzip/ioapi.h
+++ b/src/common/unzip/ioapi.h
@@ -21,6 +21,11 @@
 #define ZLIB_FILEFUNC_MODE_EXISTING (4)
 #define ZLIB_FILEFUNC_MODE_CREATE   (8)
 
+#if PRE_ANSI_C89
+#define OF(args) ()
+#else
+#define OF(args) args
+#endif
 
 #ifndef ZCALLBACK
 


### PR DESCRIPTION
Patch prevents such errors during building as:

src/common/unzip/ioapi.h:38:44: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘**attribute**’ before ‘OF’

and makes it buildable for such systems.
