### PR TITLE
AL_InitUnderwaterFilter wasn't being compiled conditionally

### DIFF
--- a/src/client/sound/openal.c
+++ b/src/client/sound/openal.c
@@ -677,6 +677,7 @@ AL_InitStreamSource()
 static void
 AL_InitUnderwaterFilter()
 {
+#if !defined (__APPLE__)
 	/* Generate a filter */
 	qalGenFilters(1, &underwaterFilter);
 
@@ -698,6 +699,7 @@ AL_InitUnderwaterFilter()
 	/* The effect */
 	qalFilterf(underwaterFilter, AL_LOWPASS_GAIN, 1.5);
 	qalFilterf(underwaterFilter, AL_LOWPASS_GAINHF, 0.25);
+#endif
 }
 
 /*


### PR DESCRIPTION
A preprocessor filter was added to AL_InitUnderwaterFilter so it won't compile on OSX. Tested on my OSX Mountain Lion (10.8.2) box.
