### PR TITLE
Remove constraints on the size of the render window

### DIFF
--- a/src/client/cl_screen.c
+++ b/src/client/cl_screen.c
@@ -343,10 +343,7 @@ SCR_CalcVrect(void)
 	size = scr_viewsize->value;
 
 	scr_vrect.width = viddef.width * size / 100;
-	scr_vrect.width &= ~7;
-
 	scr_vrect.height = viddef.height * size / 100;
-	scr_vrect.height &= ~1;
 
 	scr_vrect.x = (viddef.width - scr_vrect.width) / 2;
 	scr_vrect.y = (viddef.height - scr_vrect.height) / 2;


### PR DESCRIPTION
In the original code, the width of the render window is forced to be a multiple of 8, as well as its height to be a multiple of 2. For resolutions like 1366x768, the constraint on the width causes a border to exist on the sides of the screen, since 1366 is not a multiple of 8.

If the complete removal of these constraints may cause some sort of problem, a change only to the width constraint may be considered.
