### PR TITLE
QGL renundancy cleanup

### DIFF
--- a/src/backends/generic/qgl.c
+++ b/src/backends/generic/qgl.c
@@ -52,18 +52,26 @@ void ( APIENTRY *qglClientActiveTextureARB ) ( GLenum );
 
 /* ========================================================================= */
 
+void QGL_EXT_Reset ( void )
+{
+	qglLockArraysEXT          = NULL;
+	qglUnlockArraysEXT 	      = NULL;
+	qglPointParameterfEXT     = NULL;
+	qglPointParameterfvEXT    = NULL;
+	qglColorTableEXT          = NULL;
+	qgl3DfxSetPaletteEXT      = NULL;
+	qglMultiTexCoord2fARB     = NULL;
+	qglActiveTextureARB       = NULL;
+	qglClientActiveTextureARB = NULL;
+}
+
+/* ========================================================================= */
+
 void
 QGL_Shutdown ( void )
 {
-	qglLockArraysEXT = NULL;
-	qglUnlockArraysEXT = NULL;
-	qglPointParameterfEXT = NULL;
-	qglPointParameterfvEXT = NULL;
-	qglColorTableEXT = NULL;
-	qgl3DfxSetPaletteEXT = NULL;
-	qglMultiTexCoord2fARB = NULL;
-	qglActiveTextureARB = NULL;
-	qglClientActiveTextureARB = NULL;
+	// Reset GL extension pointers
+	QGL_EXT_Reset();
 }
 
 /* ========================================================================= */
@@ -71,15 +79,8 @@ QGL_Shutdown ( void )
 qboolean
 QGL_Init (void)
 {
-	qglLockArraysEXT = NULL;
-	qglUnlockArraysEXT = NULL;
-	qglPointParameterfEXT = NULL;
-	qglPointParameterfvEXT = NULL;
-	qglColorTableEXT = NULL;
-	qgl3DfxSetPaletteEXT = NULL;
-	qglMultiTexCoord2fARB = NULL;
-	qglActiveTextureARB = NULL;
-	qglClientActiveTextureARB = NULL;
+	// Reset GL extension pointers
+	QGL_EXT_Reset();
 	return true;
 }
 

--- a/src/backends/generic/vid.c
+++ b/src/backends/generic/vid.c
@@ -170,9 +170,6 @@ VID_LoadRefresh(void)
 	// Log it!
 	Com_Printf("----- refresher initialization -----\n");
 
-	// Get refresher API exports
-	//R_GetRefAPI();
-
 	/* Init IN (Mouse) */
 	in_state.IN_CenterView_fp = IN_CenterView;
 	in_state.Key_Event_fp = Do_Key_Event;


### PR DESCRIPTION
Despite QGL is only handling OpenGL extensions, there was a little code renundancy.
QGL_EXT_Reset sets all extension pointers to NULL.
