### PR TITLE
Optional configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /release/
+*.mk

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@
 #  - Windows (MinGW)                                     #
 # ------------------------------------------------------ #
 
+# ====================================================== #
+#     !!! DO NOT ALTER ANYTHING BELOW THIS LINE !!!      #
+# ====================================================== #
+
 # User configurable options
 # -------------------------
 
@@ -87,9 +91,14 @@ OSX_ARCH:=-arch i386 -arch x86_64
 # Contents/Resources
 OSX_APP:=yes
 
-# ====================================================== #
-#     !!! DO NOT ALTER ANYTHING BELOW THIS LINE !!!      #
-# ====================================================== #
+# This is an optional configuration file, it'll be used in
+# case of presence.
+CONFIG_FILE := config.mk
+
+# In case a of a configuration file being present, we'll just use it
+ifeq ($(wildcard $(CONFIG_FILE)), $(CONFIG_FILE))
+include $(CONFIG_FILE)
+endif
 
 # Detect the OS
 ifdef SystemRoot
@@ -292,7 +301,6 @@ endif
 # ----------
 
 # Phony targets
-#.PHONY : all client game icon refresher server
 .PHONY : all client game icon server
 
 # ----------


### PR DESCRIPTION
Ability to read an optional configuration file
which is read if exists, we can even decide
which configuration file (default is config.mk) to use at
the command line like this:

`$ make # it will read config.mk if exists`
`$ make CONFIG_FILE=my-badass-conf.mk`
`$ make CONFIG_FILE=no-retexturing.mk`

As always, build variables still can be set as well by command line.

`$ make WITH_SYSTEMWIDE=/media/cdrom/quake2-data CONFIG_FILE=my-badass-conf.mk`
