### PR TITLE
Add underwater sfx for SDL backend

### DIFF
--- a/src/backends/sdl/sound.c
+++ b/src/backends/sdl/sound.c
@@ -68,6 +68,119 @@ static int soundtime;
 
 /* ------------------------------------------------------------------ */
 
+/* =============================== */
+/* Low-pass filter */
+/* Based on OpenAL implementation. */
+
+/* Filter's context */
+typedef struct {
+    float a;
+    float gain_hf;
+    portable_samplepair_t history[2];
+    qboolean is_history_initialized;
+} LpfContext;
+
+static const int lpf_reference_frequency = 5000;
+static const float lpf_default_gain_hf = 0.25F;
+
+static LpfContext lpf_context;
+static qboolean lpf_is_enabled;
+
+static void lpf_initialize(
+    LpfContext* lpf_context,
+    float gain_hf,
+    int target_frequency)
+{
+    assert(target_frequency > 0);
+    assert(lpf_context);
+
+    float g;
+    float cw;
+    float a;
+
+    const float k_2_pi = 6.283185307F;
+
+    g = gain_hf;
+
+    if (g < 0.01F)
+        g = 0.01F;
+    else if (gain_hf > 1.0F)
+        g = 1.0F;
+
+    cw = cosf((k_2_pi * lpf_reference_frequency) / target_frequency);
+
+    a = 0.0F;
+
+    if (g < 0.9999F) {
+        a = (1.0F - (g * cw) - sqrtf((2.0F * g * (1.0F - cw)) -
+            (g * g * (1.0F - (cw * cw))))) / (1.0F - g);
+    }
+
+    lpf_context->a = a;
+    lpf_context->gain_hf = gain_hf;
+    lpf_context->is_history_initialized = false;
+}
+
+static void lpf_update_samples(
+    LpfContext* lpf_context,
+    int sample_count,
+    portable_samplepair_t* samples)
+{
+    assert(lpf_context);
+    assert(sample_count >= 0);
+    assert(samples);
+
+    int s;
+    float a;
+    portable_samplepair_t y;
+    portable_samplepair_t* history;
+
+    if (sample_count <= 0)
+        return;
+
+    a = lpf_context->a;
+    history = lpf_context->history;
+
+    if (!lpf_context->is_history_initialized) {
+        lpf_context->is_history_initialized = true;
+
+        for (s = 0; s < 2; ++s) {
+            history[s].left = 0;
+            history[s].right = 0;
+        }
+    }
+
+    for (s = 0; s < sample_count; ++s) {
+        /* Update left channel */
+
+        y.left = samples[s].left;
+
+        y.left = (int)(y.left + a * (history[0].left - y.left));
+        history[0].left = y.left;
+
+        y.left = (int)(y.left + a * (history[1].left - y.left));
+        history[1].left = y.left;
+
+
+        /* Update right channel */
+
+        y.right = samples[s].right;
+
+        y.right = (int)(y.right + a * (history[0].right - y.right));
+        history[0].right = y.right;
+
+        y.right = (int)(y.right + a * (history[1].right - y.right));
+        history[1].right = y.right;
+
+
+        /* Update sample */
+        samples[s] = y;
+    }
+}
+
+/* End of low-pass filter stuff */
+/* ============================ */
+
 /*
  * Transfers a mixed "paint buffer" to
  * the SDL output buffer and places it
@@ -344,32 +457,8 @@ SDL_PaintChannels(int endtime)
 			break;
 		}
 
-		/* clear the paint buffer */
-		if (s_rawend < paintedtime)
-		{
-			memset(paintbuffer, 0, (end - paintedtime)
-					* sizeof(portable_samplepair_t));
-		}
-		else
-		{
-			/* copy from the streaming sound source */
-			int s;
-			int stop;
-
-			stop = (end < s_rawend) ? end : s_rawend;
-
-			for (i = paintedtime; i < stop; i++)
-			{
-				s = i & (MAX_RAW_SAMPLES - 1);
-				paintbuffer[i - paintedtime] = s_rawsamples[s];
-			}
-
-			for ( ; i < end; i++)
-			{
-				memset(&paintbuffer[i - paintedtime], 0,
-				   sizeof(paintbuffer[i - paintedtime]));
-			}
-		}
+		memset(paintbuffer, 0, (end - paintedtime)
+				* sizeof(portable_samplepair_t));
 
 		/* paint in the channels. */
 		ch = channels;
@@ -436,6 +525,27 @@ SDL_PaintChannels(int endtime)
 						ch->sfx = NULL;
 					}
 				}
+			}
+		}
+
+        if (lpf_is_enabled && snd_is_underwater)
+            lpf_update_samples(&lpf_context, end - paintedtime, paintbuffer);
+        else
+            lpf_context.is_history_initialized = false;
+
+		if (s_rawend >= paintedtime)
+		{
+			/* add from the streaming sound source */
+			int s;
+			int stop;
+
+			stop = (end < s_rawend) ? end : s_rawend;
+
+			for (i = paintedtime; i < stop; i++)
+			{
+				s = i & (MAX_RAW_SAMPLES - 1);
+				paintbuffer[i - paintedtime].left += s_rawsamples[s].left;
+                paintbuffer[i - paintedtime].right += s_rawsamples[s].right;
 			}
 		}
 
@@ -999,6 +1109,18 @@ SDL_Update(void)
 	int total;
 	unsigned int endtime;
 
+    if (s_underwater->modified) {
+        s_underwater->modified = false;
+        lpf_is_enabled = ((int)s_underwater->value != 0);
+    }
+
+    if (s_underwater_gain_hf->modified) {
+        s_underwater_gain_hf->modified = false;
+
+        lpf_initialize(
+            &lpf_context, s_underwater_gain_hf->value, backend->speed);
+    }
+
 	/* if the loading plaque is up, clear everything
 	   out to make sure we aren't looping a dirty
 	   SDL buffer while loading */
@@ -1330,6 +1452,10 @@ SDL_BackendInit(void)
 	samplesize = (backend->samples * (backend->samplebits / 8));
 	backend->buffer = calloc(1, samplesize);
 	s_numchannels = MAX_CHANNELS;
+
+    s_underwater->modified = true;
+    s_underwater_gain_hf->modified = true;
+    lpf_initialize(&lpf_context, lpf_default_gain_hf, backend->speed);
 
 	SDL_UpdateScaletable();
 	SDL_PauseAudio(0);

--- a/src/client/sound/header/local.h
+++ b/src/client/sound/header/local.h
@@ -164,6 +164,8 @@ extern cvar_t *s_show;
 extern cvar_t *s_mixahead;
 extern cvar_t *s_testsound;
 extern cvar_t *s_ambient;
+extern cvar_t* s_underwater;
+extern cvar_t* s_underwater_gain_hf;
 
 /*
  * Globals
@@ -180,6 +182,9 @@ extern vec3_t listener_origin;
 extern vec3_t listener_forward;
 extern vec3_t listener_right;
 extern vec3_t listener_up;
+
+extern qboolean snd_is_underwater;
+extern qboolean snd_is_underwater_enabled;
 
 /*
  * Returns the header infos

--- a/src/client/sound/sound.c
+++ b/src/client/sound/sound.c
@@ -56,6 +56,8 @@ cvar_t *s_khz;
 cvar_t *s_mixahead;
 cvar_t *s_show;
 cvar_t *s_ambient;
+cvar_t* s_underwater;
+cvar_t* s_underwater_gain_hf;
 
 channel_t channels[MAX_CHANNELS];
 int num_sfx;
@@ -70,6 +72,8 @@ sndstarted_t sound_started = SS_NOT;
 sound_t sound;
 static qboolean s_registering;
 
+qboolean snd_is_underwater;
+qboolean snd_is_underwater_enabled;
 /* ----------------------------------------------------------------- */
 
 /*
@@ -1015,6 +1019,8 @@ S_Init(void)
 	s_show = Cvar_Get("s_show", "0", 0);
 	s_testsound = Cvar_Get("s_testsound", "0", 0);
 	s_ambient = Cvar_Get("s_ambient", "1", 0);
+    s_underwater = Cvar_Get("s_underwater", "1", CVAR_ARCHIVE);
+    s_underwater_gain_hf = Cvar_Get("s_underwater_gain_hf", "0.25", CVAR_ARCHIVE);
 
 	Cmd_AddCommand("play", S_Play);
 	Cmd_AddCommand("stopsound", S_StopAllSounds);

--- a/src/common/pmove.c
+++ b/src/common/pmove.c
@@ -26,6 +26,7 @@
  */
 
 #include "header/common.h"
+#include "../client/sound/header/local.h"
 
 #if !defined(DEDICATED_ONLY) && defined(USE_OPENAL)
 void AL_Underwater();
@@ -1270,7 +1271,7 @@ PM_ClampAngles(void)
 void
 Pmove(pmove_t *pmove)
 {
-#if !defined(DEDICATED_ONLY) && defined(USE_OPENAL)
+#if !defined(DEDICATED_ONLY)
 	static int underwater;
 #endif
 
@@ -1414,17 +1415,25 @@ Pmove(pmove_t *pmove)
 	/* set groundentity, watertype, and waterlevel for final spot */
 	PM_CatagorizePosition();
 
-#if !defined(DEDICATED_ONLY) && defined(USE_OPENAL)
+#if !defined(DEDICATED_ONLY)
 	if ((pm->waterlevel == 3) && !underwater)
 	{
 		underwater = 1;
-		AL_Underwater();
+        snd_is_underwater = 1;
+#ifdef USE_OPENAL
+        if (snd_is_underwater_enabled)
+            AL_Underwater();
+#endif
 	}
 
 	if (((pm->waterlevel < 3) && underwater))
 	{
 		underwater = 0;
-		AL_Overwater();
+        snd_is_underwater = 0;
+#ifdef USE_OPENAL
+        if (snd_is_underwater_enabled)
+            AL_Overwater();
+#endif
 	}
 #endif
 


### PR DESCRIPTION
Underwater sound effect for SDL backend.

New console variables (affects both backends: SDL and OpenAL):
- **s_underwater**  
  Enables (non-zero value) or disables (zero value) the effect.  
  Default value: 1.0
- **s_underwater_gain_hf**  
  Controls a gain of high frequencies.  
  The higher the value - the weaker the effect.  
  Default value: 0.25  
  Range of values: [0.0; 1.0]  

Changes take effect immediately - you do not need to restart sound system with **snd_restart**.  
