### PR TITLE
Fix the q2ded build

### DIFF
--- a/src/common/pmove.c
+++ b/src/common/pmove.c
@@ -1378,11 +1378,13 @@ Pmove(pmove_t *pmove)
 
 	if (pm->s.pm_type == PM_FREEZE)
 	{
+#if !defined(DEDICATED_ONLY)
         if (cl.attractloop) {
             PM_CalculateViewHeightForDemo();
             PM_CalculateWaterLevelForDemo();
             PM_UpdateUnderwaterSfx();
         }
+#endif
 
 		return; /* no movement at all */
 	}


### PR DESCRIPTION
This fixes the dedicated server build.  The global cl variable, declared in client/cl_main.c, shouldn't be used in the server build.
