### PR TITLE
Enable GL_ARB_texture_non_power_of_two on modern graphics hardware

### DIFF
--- a/src/client/refresh/header/local.h
+++ b/src/client/refresh/header/local.h
@@ -366,6 +366,7 @@ typedef struct
 	qboolean mtexcombine;
 
 	qboolean anisotropic;
+	qboolean tex_npot;
 	float max_anisotropy;
 } glconfig_t;
 

--- a/src/client/refresh/r_image.c
+++ b/src/client/refresh/r_image.c
@@ -625,7 +625,10 @@ R_BuildPalettedTexture(unsigned char *paletted_texture, unsigned char *scaled,
 	}
 }
 
+// Windows headers don't define this constant.
+#ifndef GL_GENERATE_MIPMAP
 #define GL_GENERATE_MIPMAP 0x8191
+#endif
 
 qboolean
 R_Upload32Native(unsigned *data, int width, int height, qboolean mipmap)

--- a/src/client/refresh/r_main.c
+++ b/src/client/refresh/r_main.c
@@ -1256,6 +1256,12 @@ R_Init(void *hinstance, void *hWnd)
 		Cvar_SetValue("gl_anisotropic_avail", 0.0);
 	}
 
+	if (strstr(gl_config.extensions_string, "GL_ARB_texture_non_power_of_two"))
+	{
+		VID_Printf(PRINT_ALL, "...using GL_ARB_texture_non_power_of_two\n");
+		gl_config.tex_npot = true;
+	}
+
 	gl_config.mtexcombine = false;
 
 	if (strstr(gl_config.extensions_string, "GL_ARB_texture_env_combine"))


### PR DESCRIPTION
If the extension is present, which should be the case for all hardware currently in use, this allows using all of Quake 2's textures in their original size, which especially makes the models look a lot better.
