### PR TITLE
Patch to allow ignoring default music playback behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,12 @@
 # User configurable options
 # -------------------------
 
+# Ignores original playback behaviour when goals are reached. Unfortunately
+# this stops CD/OGG playback for the rest of the level and must be manually
+# restarted. To retain this behaviour leave as yes, otherwise change to no.
+WITH_OLDPLAYBACK:=no
+
+
 # Enables CD audio playback. CD audio playback is used
 # for the background music and doesn't add any further
 # dependencies. It should work on all platforms where
@@ -79,7 +85,7 @@ OSX_ARCH:=-arch $(shell uname -m | sed -e s/i.86/i386/)
 # The app-bundle itself will not be created, but the runtime paths
 # will be set to expect the game-data in *.app/
 # Contents/Resources
-OSX_APP:=yes
+OSX_APP:=no
 
 # This is an optional configuration file, it'll be used in
 # case of presence.
@@ -171,6 +177,13 @@ CFLAGS += -DSYSTEMWIDE
 ifneq ($(WITH_SYSTEMDIR),"")
 CFLAGS += -DSYSTEMDIR=\"$(WITH_SYSTEMDIR)\"
 endif
+endif
+
+# ----------
+
+# Enable old playback behaviour
+ifeq ($(WITH_OLDPLAYBACK),yes)
+CFLAGS += -DWITH_OLDPLAYBACK
 endif
 
 # ----------
@@ -306,6 +319,7 @@ config:
 	@echo "WITH_ZIP = $(WITH_ZIP)"
 	@echo "WITH_SYSTEMWIDE = $(WITH_SYSTEMWIDE)"
 	@echo "WITH_SYSTEMDIR = $(WITH_SYSTEMDIR)"
+	@echo "WITH_OLDPLAYBACK = $(WITH_OLDPLAYBACK)"
 	@echo "============================"
 	@echo ""
 ifeq ($(WITH_SDL2),yes)

--- a/src/game/g_target.c
+++ b/src/game/g_target.c
@@ -300,12 +300,12 @@ use_target_goal(edict_t *ent, edict_t *other /* unused */, edict_t *activator /*
 	gi.sound(ent, CHAN_VOICE, ent->noise_index, 1, ATTN_NORM, 0);
 
 	level.found_goals++;
-
+#ifdef WITH_OLDPLAYBACK
 	if (level.found_goals == level.total_goals)
 	{
 		gi.configstring(CS_CDTRACK, "0");
 	}
-
+#endif
 	G_UseTargets(ent, activator);
 	G_FreeEdict(ent);
 }

--- a/src/game/g_utils.c
+++ b/src/game/g_utils.c
@@ -274,11 +274,12 @@ G_UseTargets(edict_t *ent, edict_t *activator)
 			else if (!Q_stricmp(t->classname,"target_goal"))
 			{
 				level.total_goals--;
-
+#ifdef WITH_OLDPLAYBACK
 				if (level.found_goals >= level.total_goals)
 				{
 					gi.configstring (CS_CDTRACK, "0");
 				}
+#endif
 			}
 
 			G_FreeEdict(t);


### PR DESCRIPTION
Standard client behaviour is to stop or pause music playback on attainment of a goal. This is ambiguously applied and does not restart music except on a map reload. This patch ignores that behaviour where applicable via a compile-time definition. Ideally, it should be a cvar but this is an initial idea with low impact on the source.