### PR TITLE
Apply gl_overbrightbits to regular meshes.

### DIFF
--- a/src/client/refresh/r_mesh.c
+++ b/src/client/refresh/r_mesh.c
@@ -668,6 +668,21 @@ R_DrawAliasModel(entity_t *e)
 		}
 	}
 
+
+    /* Apply gl_overbrightbits to the mesh. If we don't do this they will appear slightly dimmer relative to
+       walls. Also note that gl_overbrightbits is only applied to walls when gl_ext_mtexcombine is set to 1,
+       so we'll also want to check that; otherwise we'll end up in the reverse situation and the meshes will
+       appear too bright. */
+    if (gl_config.mtexcombine)
+    {
+        for (i = 0; i < 3; ++i)
+        {
+            shadelight[i] *= gl_overbrightbits->value;
+        }
+    }
+    
+
+
 	/* ir goggles color override */
 	if (r_newrefdef.rdflags & RDF_IRGOGGLES && currententity->flags &
 		RF_IR_VISIBLE)

--- a/src/client/refresh/r_mesh.c
+++ b/src/client/refresh/r_mesh.c
@@ -673,7 +673,7 @@ R_DrawAliasModel(entity_t *e)
        walls. Also note that gl_overbrightbits is only applied to walls when gl_ext_mtexcombine is set to 1,
        so we'll also want to check that; otherwise we'll end up in the reverse situation and the meshes will
        appear too bright. */
-    if (gl_config.mtexcombine)
+    if (gl_config.mtexcombine && gl_overbrightbits->value)
     {
         for (i = 0; i < 3; ++i)
         {

--- a/src/client/refresh/r_surf.c
+++ b/src/client/refresh/r_surf.c
@@ -941,9 +941,8 @@ R_DrawBrushModel(entity_t *e)
 	e->angles[2] = -e->angles[2];
 
 	R_EnableMultitexture(true);
+
 	R_SelectTexture(GL_TEXTURE0_ARB);
-	R_TexEnv(GL_REPLACE);
-	R_SelectTexture(GL_TEXTURE1_ARB);
 
 	if (!gl_config.mtexcombine)
 	{
@@ -1175,8 +1174,6 @@ R_DrawWorld(void)
 		R_EnableMultitexture(true);
 
 		R_SelectTexture(GL_TEXTURE0_ARB);
-		R_TexEnv(GL_REPLACE);
-		R_SelectTexture(GL_TEXTURE1_ARB);
 
 		if (!gl_config.mtexcombine)
 		{
@@ -1212,7 +1209,7 @@ R_DrawWorld(void)
 			else
 			{
 				glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB_EXT, GL_MODULATE);
-				glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_RGB_EXT, GL_TEXTURE);
+			    glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_RGB_EXT, GL_TEXTURE);
 				glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE1_RGB_EXT, GL_PREVIOUS_EXT);
 				glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA_EXT, GL_MODULATE);
 				glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_ALPHA_EXT, GL_TEXTURE);


### PR DESCRIPTION
This addresses issue #54. This commit also removes a couple of redundant OpenGL calls.