### PR TITLE
Fix spelling errors detected by lintian

### DIFF
--- a/src/backends/unix/signalhandler.c
+++ b/src/backends/unix/signalhandler.c
@@ -49,7 +49,7 @@ printBacktrace(int sig)
 
 	printf("Product:      Yamagi Quake II\n");
 	printf("Version:      %s\n", YQ2VERSION);
-	printf("Plattform:    %s\n", OSTYPE);
+	printf("Platform:     %s\n", OSTYPE);
 	printf("Architecture: %s\n", ARCH);
 	printf("Compiler:     %s\n", __VERSION__);
 	printf("Signal:       %i\n", sig);
@@ -70,7 +70,7 @@ printBacktrace(int sig)
 {
 	printf("Product:      Yamagi Quake II\n");
 	printf("Version:      %s\n", YQ2VERSION);
-	printf("Plattform:    %s\n", OSTYPE);
+	printf("Platform:     %s\n", OSTYPE);
 	printf("Architecture: %s\n", ARCH);
 	printf("Compiler:     %s\n", __VERSION__);
 	printf("Signal:       %i\n", sig);
@@ -97,7 +97,7 @@ signalhandler(int sig)
 	printf("    - game.so (the game.so of the mod you were playing\n");
 	printf("      when the game crashed. baseq2/game.so for the\n");
 	printf("      main game)\n\n");
-	printf(" - Any other data which you think might be usefull\n");
+	printf(" - Any other data which you think might be useful\n");
 	printf("\nThank you very much for your help, making Yamagi Quake\n");
 	printf("II an even better source port. It's much appreciated.\n");
 	printf("\n=======================================================\n\n");

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -1696,7 +1696,7 @@ static const char *xatcredits[] =
     "Chris Toft",
     "Juan Valdes",
     "",
-    "+THANKS TO INTERGRAPH COMPUTER SYTEMS",
+    "+THANKS TO INTERGRAPH COMPUTER SYSTEMS",
     "+IN PARTICULAR:",
     "",
     "Michael T. Nicolaou",

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -838,17 +838,17 @@ ReadGame(const char *filename)
 		if (strcmp(str_game, GAMEVERSION))
 		{
 			fclose(f);
-			gi.error("Savegame from an other game.so.\n");
+			gi.error("Savegame from another game.so.\n");
 		}
 		else if (strcmp(str_os, OSTYPE))
 		{
 			fclose(f);
-			gi.error("Savegame from an other os.\n");
+			gi.error("Savegame from another os.\n");
 		}
 		else if (strcmp(str_arch, ARCH))
 		{
 			fclose(f);
-			gi.error("Savegame from an other architecure.\n");
+			gi.error("Savegame from another architecture.\n");
 		}
 	}
 	else if (!strcmp(str_ver, "YQ2-1"))
@@ -856,12 +856,12 @@ ReadGame(const char *filename)
 		if (strcmp(str_game, GAMEVERSION))
 		{
 			fclose(f);
-			gi.error("Savegame from an other game.so.\n");
+			gi.error("Savegame from another game.so.\n");
 		}
 		else if (strcmp(str_os, OSTYPE_1))
 		{
 			fclose(f);
-			gi.error("Savegame from an other os.\n");
+			gi.error("Savegame from another os.\n");
 		}
 
 		if (!strcmp(str_os, "Windows"))
@@ -870,7 +870,7 @@ ReadGame(const char *filename)
 			if (strcmp(str_arch, "i386"))
 			{
 				fclose(f);
-				gi.error("Savegame from an other architecure.\n");
+				gi.error("Savegame from another architecture.\n");
 			}
 		}
 		else
@@ -878,7 +878,7 @@ ReadGame(const char *filename)
 			if (strcmp(str_arch, ARCH_1))
 			{
 				fclose(f);
-				gi.error("Savegame from an other architecure.\n");
+				gi.error("Savegame from another architecture.\n");
 			}
 		}
 	}


### PR DESCRIPTION
Debian's `lintian` tool checks for common mistakes in source and binary packages. One of its checks is to look for common mis-spellings in the binaries.

Based on a patch by Fabian Greffrath against an earlier version of yquake2.