### PR TITLE
Optionally link libopenal at compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ WITH_OGG:=yes
 # installed
 WITH_OPENAL:=yes
 
+# Enables optional runtime loading of OpenAL (dlopen
+# or similar).
+# If set to "no", the library is linked in at compile
+# time in the normal way.
+DLOPEN_OPENAL:=yes
+
 # Use SDL2 instead of SDL1.2. Disables CD audio support,
 # because SDL2 has none. Use OGG/Vorbis music instead :-)
 # On Windows sdl-config isn't used, so make sure that
@@ -398,15 +404,20 @@ release/quake2 : LDFLAGS += -lvorbis -lvorbisfile -logg
 endif
 
 ifeq ($(WITH_OPENAL),yes)
+ifeq ($(DLOPEN_OPENAL),yes)
 ifeq ($(OSTYPE), OpenBSD)
-release/quake2 : CFLAGS += -DUSE_OPENAL -DDEFAULT_OPENAL_DRIVER='"libopenal.so"'
+release/quake2 : CFLAGS += -DUSE_OPENAL -DDEFAULT_OPENAL_DRIVER='"libopenal.so"' -DDLOPEN_OPENAL
 else ifeq ($(OSTYPE), Darwin)
 release/quake2 : CFLAGS += -DUSE_OPENAL -DDEFAULT_OPENAL_DRIVER='"libopenal.dylib"' -I/usr/local/opt/openal-soft/include
 release/quake2 : LDFLAGS += -L/usr/local/opt/openal-soft/lib
 else
-release/quake2 : CFLAGS += -DUSE_OPENAL -DDEFAULT_OPENAL_DRIVER='"libopenal.so.1"'
+release/quake2 : CFLAGS += -DUSE_OPENAL -DDEFAULT_OPENAL_DRIVER='"libopenal.so.1"' -DDLOPEN_OPENAL
 endif
-endif
+else # !DLOPEN_OPENAL
+release/quake2 : CFLAGS += -DUSE_OPENAL
+release/quake2 : LDFLAGS += -lopenal
+endif # !DLOPEN_OPENAL
+endif # WITH_OPENAL
 
 ifeq ($(WITH_ZIP),yes)
 release/quake2 : CFLAGS += -DZIP -DNOUNCRYPT

--- a/src/backends/unix/system.c
+++ b/src/backends/unix/system.c
@@ -480,7 +480,21 @@ Sys_GetHomeDir(void)
 void *
 Sys_GetProcAddress(void *handle, const char *sym)
 {
-	return dlsym(handle, sym);
+    if (handle == NULL)
+    {
+#ifdef RTLD_DEFAULT
+        return dlsym(RTLD_DEFAULT, sym);
+#else
+        /* POSIX suggests that this is a portable equivalent */
+        static void *global_namespace = NULL;
+
+        if (global_namespace == NULL)
+            global_namespace = dlopen(NULL, RTLD_GLOBAL|RTLD_LAZY);
+
+        return dlsym(global_namespace, sym);
+#endif
+    }
+    return dlsym(handle, sym);
 }
 
 void *


### PR DESCRIPTION
In Linux distributions, having the executable depend on the right
libraries and arrange for them to be installed is straightforward,
and there's a lot of infrastructure for tracking which library
version a particular executable needs, including making sure we have
a version that contains all of the symbols that were used. Loading
libopenal at runtime defeats that infrastructure.

The ability to substitute a different-but-compatible libopenal,
or operate with reduced functionality without libopenal, might
still be desirable for generic/portable binary releases.

The CMake build system already linked the executable to
${OPENAL_LIBRARY} anyway, so it is already a hard dependency in that
build system.