### PR TITLE
savegame: ensure that BUILD_DATE is defined

### DIFF
--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -73,6 +73,10 @@
  */
 #define SAVEGAMEVER "YQ2-2"
 
+#ifndef BUILD_DATE
+#define BUILD_DATE __DATE__
+#endif
+
 /*
  * This macros are used to prohibit loading of savegames
  * created on other systems or architectures. This will


### PR DESCRIPTION
The game code does not include common.h, so it needs to redo this
part for builds without SOURCE_DATE_EPOCH, where BUILD_DATE will
not have been passed in from the outside.

Signed-off-by: Simon McVittie <smcv@debian.org>