### PR TITLE
Change openal options in Makefile to fix build failure on Mac OSX 10.…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ WITH_OPENAL:=yes
 # similar). If set to "no", the library is linked in at
 # compile time in the normal way. On Windows this option
 # is ignored, OpenAL is always loaded at runtime.
-DLOPEN_OPENAL:=yes
+DLOPEN_OPENAL:=no
 
 # Use SDL2 instead of SDL1.2. Disables CD audio support,
 # because SDL2 has none. Use OGG/Vorbis music instead :-)
@@ -235,6 +235,8 @@ else ifeq ($(OSTYPE),OpenBSD)
 INCLUDE := -I/usr/local/include
 else ifeq ($(OSTYPE),Windows)
 INCLUDE := -I/custom/include
+else ifeq ($(OSTYPE), Darwin)
+INCLUDE := -I/usr/local/opt/openal-soft/include
 endif
 
 # ----------
@@ -249,7 +251,7 @@ LDFLAGS := -L/usr/local/lib -lm
 else ifeq ($(OSTYPE),Windows)
 LDFLAGS := -L/custom/lib -lws2_32 -lwinmm
 else ifeq ($(OSTYPE), Darwin)
-LDFLAGS := $(OSX_ARCH) -lm
+LDFLAGS := $(OSX_ARCH) -lm -L/usr/local/opt/openal-soft/lib
 endif
 
 # ----------


### PR DESCRIPTION
…9.5\n\n

Hi. This is my first pull request ever. I'm on Mac OSX 10.9.5.

1. Building immediately after forking:
```
Undefined symbols for architecture x86_64:
"_alBuffer3f", referenced from:
      _QAL_Init in qal.o
[and a bunch of similar errors and...]
 ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [release/quake2] Error 1
make: *** [client] Error 2
```

2. Building after setting DLOPEN_OPENAL = no:
```
ld: library not found for -lopenal
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [release/quake2] Error 1
make: *** [client] Error 2
```

3. Setting DLOPEN_OPENAL back to yes, and adding Darwin openal to the INCLUDE and LDFLAGS blocks results in the same errors as 1.

4. Setting DLOPEN_OPENAL = no and leaving the new openal additions builds successfully and appears to have no bugs.

I do not know exactly why this is happening. I am not familiar with makefiles.

Thanks for your work on this project! I was overjoyed to get Quake 2 running on my Mac laptop!