### PR TITLE
GL3 shadows

### DIFF
--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -123,8 +123,8 @@ cvar_t *gl_zfix;
 cvar_t *gl_fullbright;
 cvar_t *gl_modulate;
 cvar_t *gl_lightmap;
-cvar_t *gl_shadows; // TODO: do we really need 2 cvars for shadows here?
-cvar_t *gl_stencilshadow;
+cvar_t *gl_shadows;
+// no gl_stencilshadows, always use stencil (if available)
 
 cvar_t *gl_dynamic;
 
@@ -234,7 +234,6 @@ GL3_Register(void)
 
 	gl_lightmap = ri.Cvar_Get("gl_lightmap", "0", 0);
 	gl_shadows = ri.Cvar_Get("gl_shadows", "0", CVAR_ARCHIVE);
-	gl_stencilshadow = ri.Cvar_Get("gl_stencilshadow", "0", CVAR_ARCHIVE);
 
 	gl_modulate = ri.Cvar_Get("gl_modulate", "1", CVAR_ARCHIVE);
 	gl_zfix = ri.Cvar_Get("gl_zfix", "0", 0);
@@ -1589,7 +1588,7 @@ GL3_Clear(void)
 	}
 
 	/* stencilbuffer shadows */
-	if (gl_shadows->value && have_stencil && gl_stencilshadow->value)
+	if (gl_shadows->value && have_stencil)
 	{
 		glClearStencil(1);
 		glClear(GL_STENCIL_BUFFER_BIT);

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -508,7 +508,7 @@ extern cvar_t *gl3_particle_fade_factor;
 
 extern cvar_t *gl_modulate;
 extern cvar_t *gl_lightmap;
-extern cvar_t *gl_stencilshadow;
+extern cvar_t *gl_shadows;
 
 extern cvar_t *gl_dynamic;
 


### PR DESCRIPTION
Simple shadows for GL3, enable with `gl_shadows 1`.

Look like GL1 `gl_shadows` + `gl_stencilshadows`, so it uses the stencil buffer to avoid ugly artifacts, but it still overlaps at edges etc,  no fancy shadow volumes here. 