### PR TITLE
GL3: Render Model shadows last, refactor gl3_mesh.c

### DIFF
--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -887,6 +887,8 @@ GL3_DrawEntitiesOnList(void)
 		return;
 	}
 
+	GL3_ResetShadowAliasModels();
+
 	/* draw non-transparent first */
 	for (i = 0; i < gl3_newrefdef.num_entities; i++)
 	{
@@ -975,7 +977,10 @@ GL3_DrawEntitiesOnList(void)
 		}
 	}
 
+	GL3_DrawAliasShadows();
+
 	glDepthMask(1); /* back to writing */
+
 }
 
 static int

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -462,6 +462,8 @@ extern void GL3_MarkLeaves(void);
 
 // gl3_mesh.c
 extern void GL3_DrawAliasModel(entity_t *e);
+extern void GL3_ResetShadowAliasModels(void);
+extern void GL3_DrawAliasShadows(void);
 extern void GL3_ShutdownMeshes(void);
 
 // gl3_shaders.c


### PR DESCRIPTION
The model shadows are rendered after all entities are rendered, fixes #194 

refactored gl3_mesh.c to use less global variables (see commit for details)
