### PR TITLE
Revamp cvar list (split up in sections, improve gl_*/gl3_* descriptions)

### DIFF
--- a/stuff/cvarlist.md
+++ b/stuff/cvarlist.md
@@ -1,22 +1,19 @@
 Yamagi Quake II Console Variables
----------------------------------
+=================================
 
 This lists explains most console variables (cvars) added by Yamagi
 Quake II. Most of the original clients (Vanilla Quake II) cvars are
-still in place. Please note: There's normally no need to change any
-cvar! Use the menu instead.
+still in place, however the `r_*` renderer cvars have been renamed
+to `gl_*` and there are cvars specific to the OpenGL3.2 renderer that
+stat with `gl3_`.
+Please note: There's normally no need to change any cvar! Use the menu instead.
 
-
-* **al_device**: OpenAL device to use. In most cases there's no need to
-  change this, since the default device is normally the right choice.
+General:
+--------
 
 * **basedir**: Directory from which the game data is loaded. Can be used
   in startup scripts, to test binaries, etc. If not set the directory
   containing the binaries is used.
-
-* **cin_force43**: If set to `1` (the default) cinematics are displayed
-  with an aspect ratio of 4:3, regardless what the actual windows size
-  or resolution is.
 
 * **cl_async**: If set to `1` (the default) the client is asynchronous.
   The client framerate is fixed, the renderer framerate is variable.
@@ -32,6 +29,47 @@ cvar! Use the menu instead.
 * **cl_drawfps**: Shows the framecounter. The shown value is rather
   inaccurate, the imprecision is about 5%.
 
+* **in_grab**: Defines how the mouse is grabbed by Quake IIs window. If
+  set to `0` the mouse is never grabbed and if set to `1` it's always
+  grabbed. If set to `2` (the default) the mouse is grabbed during
+  gameplay and released otherwise.
+
+
+Audio:
+------
+
+* **al_device**: OpenAL device to use. In most cases there's no need to
+  change this, since the default device is normally the right choice.
+
+* **ogg_enable**: Enable Ogg/Vorbis music playback.
+
+* **ogg_ignoretrack0**: Normally Quake II disabled the background music
+  if a major objective has been archived by setting the music track to 0.  
+  Setting this cvar to `1` disables this behavior, the music keeps playing.
+
+* **s_doppler**: If set to `1` (the default) doppler effects are enabled.
+  This is only supported by the OpenAL sound backend.
+
+* **s_openal**: Use OpenAL for sound playback. This is enabled by
+  default.  OpenAL gives a huge quality boost over the classic sound
+  system.
+
+* **s_underwater**: Dampen sounds if submerged. Enabled by default.
+
+
+Graphics (all renderers):
+-------------------------
+
+* Most old `r_*` cvars, but renamed to `gl_*`
+
+* **vid_renderer**: Selects the renderer library. Possible options are
+  `gl1` (the default) for the old OpenGL 1.4 renderer and `gl3` for 
+  the new OpenGL 3.2 renderer.
+
+* **cin_force43**: If set to `1` (the default) cinematics are displayed
+  with an aspect ratio of 4:3, regardless what the actual windows size
+  or resolution is.
+
 * **cl_gun**: Decides weather the gun is drawn. If set to `0` the gun
   is omitted. If set to `1` the gun is only drawn if the FOV is equal
   or smaller than 90. This was the default with Vanilla Quake II. If set
@@ -41,27 +79,18 @@ cvar! Use the menu instead.
 * **fov**: Sets the field of view. If the *horplus* cvar is set to `1`,
   this is forced to 90.
 
-* **gl3_debugcontext**: Enables the OpenGL 3.2 renderers debug context,
-  e.g. prints warnings and errors thrown by the GPU driver. This is a
-  pure debug cvar and has high overhead.
+* **horplus**: If set to 1 (the default) the horplus algorithm is used
+  to calculate an optimal horizontal and vertical field of view, independent
+  of the window or screen aspect ratio or resolution.  
+  If enabled *fov* is forced to `90`.
 
-* **gl3_intensity** / **intensity**: Sets the color intensity. Since
-  OpenGL 1.4 and 3.2 have different scales there're 2 cvar.
-  **intensity** for OpenGL 1.4 and **gl3_intensity** for OpenGL 3.2.
-
-* **gl3_overbrightbits** / **gl_overbrightbits**: Enables overbright
-  bits, brightness scaling of all textures. OpenGL 1.4 is controlled
-  through **gl_overbrightbits** and employs a rather simple algorithm.
-  Possible values are `0` (no overbright bits), `1` (correct lighting
-  for water), `2` (scale by factor 2) and `3` (scale by factor 3).
-  OpenGL 3.2 has a much better algorithm that is controlled by
-  *gl3_overbrightbits*. The cvar gives the scaling factor as a floating
-  point number.
-
-* **gl3_particle_size** / **gl3_particle_fade_factor**: OpenGL 3.2
-  particle attributes. The look and feel of the  OpenGL 1.4 particles
-  can be archived by setting *gl3_particle_size* to `20` and
-  *gl3_particle_fade_factor* to `10`.
+* **vid_gamma**: The value used for gamma correction. Higher value looks
+  brighter. The GL1 renderer uses "Hardware Gamma", setting the Gamma of
+  your whole screen to this value in realtime (except on OSX where it's
+  applied to textures on load and thus needs a `vid_restart` after changing).
+  The GL3 renderer applies this to the window in realtime via shaders
+  (on all platforms).  
+  This is also set by the brightness slider in the video menu.
 
 * **gl_anisotropic**: Anisotropic filtering. Possible values are
   dependent on the GPU driver, most of them support `1`, `2`, `4`, `8`
@@ -82,6 +111,13 @@ cvar! Use the menu instead.
 * **gl_farsee**: Normally Quake II renders only up to 4096 units. If set
   to `1` the limit is increased to 8192 units.
 
+* **gl_maxfps**: The maximum framerate, if `cl_async` is `1`. Otherwise
+  `cl_maxfps` is used as maximum framerate. See `cl_async` description
+  above for more information.  
+  *Note* that vsync (`gl_swapinterval`) also restricts the framerate to
+  the monitor refresh rate, so if vsync is enabled, you won't get more than
+  60fps on most displays (or 120 on a 120hz display etc).
+
 * **gl_msaa_samples**: Full scene anti aliasing samples. The number of
   samples is dependent on the GPU driver, most drivers support at least
   `2`, `4` and `8` samples. If an invalid value is set the value is
@@ -101,29 +137,46 @@ cvar! Use the menu instead.
   overlapping surfaces to mitigate the flickering. This may lead to
   small render errors.
 
-* **horplus**: If set to 1 (the default) the horplus algorithm is used
-  to calculate an optimal FOX. If enabled *fov* is forced to `90`.
+Graphics (GL1 only):
+--------------------
 
-* **in_grab**: Defines how the mouse is grabbed by Quake IIs window. If
-  set to `0` the mouse is never grabbed and if set to `1` it's always
-  grabbed. If set to `2` (the default) the mouse is grabbed during
-  gameplay and released otherwise.
+* **intensity**: Sets the color intensity used for 3D rendering.
+  Must be a floating point value, at least `1.0` - default is `2.0`.  
+  Applied when textures are loaded, so it needs a `vid_restart`!
 
-* **ogg_enable**: Enable Ogg/Vorbis playback.
+* **gl_overbrightbits**: Enables overbright bits, brightness scaling of
+  lightmaps and models. Higher values make shadows less dark.  
+  Possible values are `0` (no overbright bits), `1` (correct lighting
+  for water), `2` (scale by factor 2) and `3` (scale by factor 3).  
+  Applied in realtime, does not need `vid_restart`.
 
-* **ogg_ignoretrack0**: Normally Quake II disabled the background music
-  if a major objective has been archived. Setting this cvar to `1`
-  disables this, the music keeps playing.
+* **gl_stencilshadow**: If `gl_shadows` is set to `1`, this makes them look
+  a bit better (no flickering) by using the stencil buffer.
+  (This is always done in GL3, so not configurable there)
 
-* **s_doppler**: If set to `1` (the default) doppler effects are enabled.
-  This is only supported by the OpenAL sound backend.
+Graphics (GL3 only):
+--------------------
 
-* **s_openal**: Use OpenAL for sound playback. This is enabled by
-  default.  OpenAL gives a huge quality boost over the classic sound
-  system.
+* **gl3_debugcontext**: Enables the OpenGL 3.2 renderers debug context,
+  e.g. prints warnings and errors emmitted by the GPU driver.  
+  Not supported on OSX. This is a pure debug cvar and slows down rendering.
 
-* **s_underwater**: Dampen sounds if submerged. Enabled by default.
+* **gl3_intensity**: Sets the color intensity used for 3D rendering.
+  Similar to GL1 `intensity`, but more flexible: can be any value between
+  0.0 (completely dark) and 256.0 (very bright).
+  Good values are between `1.0` and `2.0`, default is `1.5`.
+  Applied in realtime via shader, so it does *not* need a `vid_restart`.
 
-* **vid_renderer**: Selects the renderer library. Possible options are
-  `gl1` (the default) for OpenGL 1.4 and `gl3` for OpenGL 3.2.
+* **gl3_intensity_2D**: The same for 2D rendering (HUD, menu, console, videos)
 
+* **gl3_overbrightbits**: Enables overbright bits, brightness scaling of
+  lightmaps and models. Higher values make shadows less dark.  
+  Similar to GL1's `gl_overbrightbits`, but allows any floating point number.  
+  Default is `1.3`. In the OpenGL3.2 renderer, no lighting fixes for water
+  are needed, so `1.0` has no special meaning.
+
+* **gl3_particle_size**: The size of particles - Default is `40`.
+
+* **gl3_particle_fade_factor**: "softness" of particles: higher values
+  look less soft. Defaults to `1.2`.  
+  A value of `10` looks similar to the GL1 particles.


### PR DESCRIPTION
split up into General, Audio, Generic Rendering, GL1 and GL3.