### PR TITLE
Don't use -Wl,--no-undefined on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,8 +252,8 @@ endif
 CFLAGS += -fvisibility=hidden
 LDFLAGS += -fvisibility=hidden
 
-ifneq ($(YQ2_OSTYPE), Darwin)
-# for some reason the OSX linker doesn't support this
+ifneq ($(YQ2_OSTYPE), $(filter $(YQ2_OSTYPE), Darwin, OpenBSD))
+# for some reason the OSX & OpenBSD linker doesn't support this
 LDFLAGS += -Wl,--no-undefined
 endif
 


### PR DESCRIPTION
Breaks the build since version 7.00

Results in errors (a lot cropped):
```
===> LD release/baseq2/game.so                                                                                                                                                                                                    
cc build/baseq2/src/common/shared/flash.o build/baseq2/src/common/shared/rand.o build/baseq2/src/common/shared/shared.o build/baseq2/src/game/g_ai.o build/baseq2/src/game/g_chase.o build/baseq2/src/game/g_cmds.o build/baseq2/s
rc/game/g_combat.o build/baseq2/src/game/g_func.o build/baseq2/src/game/g_items.o build/baseq2/src/game/g_main.o build/baseq2/src/game/g_misc.o build/baseq2/src/game/g_monster.o build/baseq2/src/game/g_phys.o build/baseq2/src/
game/g_spawn.o build/baseq2/src/game/g_svcmds.o build/baseq2/src/game/g_target.o build/baseq2/src/game/g_trigger.o build/baseq2/src/game/g_turret.o build/baseq2/src/game/g_utils.o build/baseq2/src/game/g_weapon.o build/baseq2/
src/game/monster/berserker/berserker.o build/baseq2/src/game/monster/boss2/boss2.o build/baseq2/src/game/monster/boss3/boss3.o build/baseq2/src/game/monster/boss3/boss31.o build/baseq2/src/game/monster/boss3/boss32.o build/bas
eq2/src/game/monster/brain/brain.o build/baseq2/src/game/monster/chick/chick.o build/baseq2/src/game/monster/flipper/flipper.o build/baseq2/src/game/monster/float/float.o build/baseq2/src/game/monster/flyer/flyer.o build/baseq
2/src/game/monster/gladiator/gladiator.o build/baseq2/src/game/monster/gunner/gunner.o build/baseq2/src/game/monster/hover/hover.o build/baseq2/src/game/monster/infantry/infantry.o build/baseq2/src/game/monster/insane/insane.o
 build/baseq2/src/game/monster/medic/medic.o build/baseq2/src/game/monster/misc/move.o build/baseq2/src/game/monster/mutant/mutant.o build/baseq2/src/game/monster/parasite/parasite.o build/baseq2/src/game/monster/soldier/soldi
er.o build/baseq2/src/game/monster/supertank/supertank.o build/baseq2/src/game/monster/tank/tank.o build/baseq2/src/game/player/client.o build/baseq2/src/game/player/hud.o build/baseq2/src/game/player/trail.o build/baseq2/src/
game/player/view.o build/baseq2/src/game/player/weapon.o build/baseq2/src/game/savegame/savegame.o -L/usr/local/lib -lm -fvisibility=hidden -Wl,--no-undefined -shared -o release/baseq2/game.so
build/baseq2/src/common/shared/shared.o: In function `Q_fabs':                                                   
src/common/shared/shared.c:299: undefined reference to `__stack_smash_handler'                                   
build/baseq2/src/common/shared/shared.o: In function `BoxOnPlaneSide2':                                          
src/common/shared/shared.c:364: undefined reference to `__stack_smash_handler'                                   
build/baseq2/src/common/shared/shared.o: In function `FloatSwap':                                                
src/common/shared/shared.c:858: undefined reference to `__stack_smash_handler'                                   
build/baseq2/src/common/shared/shared.o: In function `tolower':                                                  
/usr/include/ctype.h:150: undefined reference to `_tolower_tab_'                                                 
build/baseq2/src/common/shared/shared.o: In function `Info_Validate':                                            
src/common/shared/shared.c:1292: undefined reference to `strchr'                                                 
src/common/shared/shared.c:1297: undefined reference to `strchr'                                                 
build/baseq2/src/common/shared/shared.o: In function `Swap_Init':                                                
src/common/shared/shared.c:895: undefined reference to `__stack_smash_handler'                                   
build/baseq2/src/common/shared/shared.o: In function `Info_ValueForKey':                                              
src/common/shared/shared.c:1207: undefined reference to `strcmp'                                                 
src/common/shared/shared.c:1219: undefined reference to `__stack_smash_handler'                                  
build/baseq2/src/common/shared/shared.o: In function `Info_RemoveKey':                                           
src/common/shared/shared.c:1229: undefined reference to `strchr'                                                 
src/common/shared/shared.c:1272: undefined reference to `strcmp'                                                 
src/common/shared/shared.c:1283: undefined reference to `__stack_smash_handler'                                  
src/common/shared/shared.c:1274: undefined reference to `strlen'                                                 
src/common/shared/shared.c:1274: undefined reference to `memmove'     
build/baseq2/src/common/shared/shared.o: In function `Com_sprintf':                                              
src/common/shared/shared.c:1088: undefined reference to `vsnprintf'                                              
src/common/shared/shared.c:1095: undefined reference to `__stack_smash_handler'
build/baseq2/src/common/shared/shared.o: In function `Info_SetValueForKey':                                      
src/common/shared/shared.c:1312: undefined reference to `strchr'                                                 
src/common/shared/shared.c:1312: undefined reference to `strchr'           
```
the diff results in a passing build