### PR TITLE
A few fixes for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ endif
 CFLAGS += -fvisibility=hidden
 LDFLAGS += -fvisibility=hidden
 
-ifneq ($(YQ2_OSTYPE), $(filter $(YQ2_OSTYPE), Darwin, OpenBSD))
+ifneq ($(YQ2_OSTYPE), $(filter $(YQ2_OSTYPE), Darwin OpenBSD))
 # for some reason the OSX & OpenBSD linker doesn't support this
 LDFLAGS += -Wl,--no-undefined
 endif
@@ -451,7 +451,7 @@ ifeq ($(YQ2_OSTYPE), OpenBSD)
 release/quake2 : CFLAGS += -DUSE_OPENAL -DDEFAULT_OPENAL_DRIVER='"libopenal.so"' -DDLOPEN_OPENAL
 else ifeq ($(YQ2_OSTYPE), Darwin)
 release/quake2 : CFLAGS += -DUSE_OPENAL -DDEFAULT_OPENAL_DRIVER='"libopenal.dylib"' -I/usr/local/opt/openal-soft/include -DDLOPEN_OPENAL
-release/quake2 : LDFLAGS += -L/usr/local/opt/openal-soft/lib
+release/quake2 : LDFLAGS += -L/usr/local/opt/openal-soft/lib -rpath /usr/local/opt/openal-soft/lib
 else
 release/quake2 : CFLAGS += -DUSE_OPENAL -DDEFAULT_OPENAL_DRIVER='"libopenal.so.1"' -DDLOPEN_OPENAL
 endif
@@ -460,7 +460,7 @@ release/quake2 : CFLAGS += -DUSE_OPENAL
 release/quake2 : LDFLAGS += -lopenal
 ifeq ($(YQ2_OSTYPE), Darwin)
 release/quake2 : CFLAGS += -I/usr/local/opt/openal-soft/include
-release/quake2 : LDFLAGS += -L/usr/local/opt/openal-soft/lib
+release/quake2 : LDFLAGS += -L/usr/local/opt/openal-soft/lib -rpath /usr/local/opt/openal-soft/lib
 endif # Darwin
 endif # !DLOPEN_OPENAL
 endif # WITH_OPENAL

--- a/src/client/sound/ogg.c
+++ b/src/client/sound/ogg.c
@@ -761,7 +761,10 @@ OGG_PauseCmd(void)
 	}
 
 #ifdef USE_OPENAL
-	AL_UnqueueRawSamples();
+	if (sound_started == SS_OAL)
+	{
+		AL_UnqueueRawSamples();
+	}
 #endif
 }
 


### PR DESCRIPTION
As described in original pull request #248 (where commit was too cumbersome). Due to a couple of issues on OSX the Makefile can be improved (along with bug fix in code that highlighted due to Makefile issues).
1. The filter seems to include an extra comma that causes an error in Make.
1. Homebrew does not install openal-soft completely due to OpenAL included in OSX.  Either set LD_LIBRARY_PATH to point to it or we can compile with rpath to point to it (and we assume location anyway).  
1. Due to issues with setting LD_LIBRARY_PATH my first few tests failed to load the OpenAL library and causes an error when Ogg_Pause tries to stop the stream at end of first level in lift.  Make sure we test for OpenAL.

Now just need to find out why the shutting down text seems corrupted as described in https://github.com/yquake2/yquake2/pull/248#issuecomment-338304417