### PR TITLE
Fix crash on Windows if MSAA is set to a value the driver doesn't support

### DIFF
--- a/src/backends/generic/vid.c
+++ b/src/backends/generic/vid.c
@@ -177,11 +177,18 @@ VID_CheckChanges(void)
 		cls.disable_screen = true;
 
 		// Proceed to reboot the refresher
-		if(!VID_LoadRefresh() && (strcmp(vid_renderer->string, "gl1") != 0))
+		if(!VID_LoadRefresh())
 		{
-			Com_Printf("\n ... trying again with standard OpenGL1.x renderer ... \n\n");
-			Cvar_Set("vid_renderer", "gl1");
-			VID_LoadRefresh();
+			if (strcmp(vid_renderer->string, "gl1") != 0)
+			{
+				Com_Printf("\n ... trying again with standard OpenGL1.x renderer ... \n\n");
+				Cvar_Set("vid_renderer", "gl1");
+				VID_LoadRefresh();
+			}
+			else
+			{
+				Com_Error(ERR_FATAL, "Couldn't load a rendering backend!\n");
+			}
 		}
 		cls.disable_screen = false;
 	}

--- a/src/client/refresh/gl/r_main.c
+++ b/src/client/refresh/gl/r_main.c
@@ -1344,6 +1344,17 @@ R_SetMode(void)
 		else if (err == rserr_invalid_mode)
 		{
 			R_Printf(PRINT_ALL, "ref_gl::R_SetMode() - invalid mode\n");
+			if (gl_msaa_samples->value != 0.0f)
+			{
+				R_Printf(PRINT_ALL, "gl_msaa_samples was %d - will try again with gl_msaa_samples = 0\n", (int)gl_msaa_samples->value);
+				ri.Cvar_SetValue("gl_msaa_samples", 0.0f);
+				gl_msaa_samples->modified = false;
+
+				if ((err = SetMode_impl(&vid.width, &vid.height, gl_mode->value, 0)) == rserr_ok)
+				{
+					return true;
+				}
+			}
 			if(gl_mode->value == gl_state.prev_mode)
 			{
 				// trying again would result in a crash anyway, give up already

--- a/src/client/refresh/gl/r_sdl.c
+++ b/src/client/refresh/gl/r_sdl.c
@@ -360,6 +360,11 @@ int RI_PrepareForWindow(void)
 			SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 0);
 		}
 	}
+	else
+	{
+		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 0);
+		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 0);
+	}
 
 	/* Initiate the flags */
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -409,6 +414,14 @@ int RI_InitContext(void* win)
 	// context is created implicitly with window, nothing to do here
 
 #endif
+
+	const char* glver = (char *)glGetString(GL_VERSION);
+	sscanf(glver, "%d.%d", &gl_config.major_version, &gl_config.minor_version);
+	if (gl_config.major_version < 1 || (gl_config.major_version == 1 && gl_config.minor_version < 4))
+	{
+		R_Printf(PRINT_ALL, "R_InitContext(): Got an OpenGL version %d.%d context - need (at least) 1.4!\n", gl_config.major_version, gl_config.minor_version);
+		return false;
+	}
 
 	if (gl_msaa_samples->value)
 	{

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -406,6 +406,17 @@ GL3_SetMode(void)
 		{
 			R_Printf(PRINT_ALL, "ref_gl3::GL3_SetMode() - invalid mode\n");
 
+			if (gl_msaa_samples->value != 0.0f)
+			{
+				R_Printf(PRINT_ALL, "gl_msaa_samples was %d - will try again with gl_msaa_samples = 0\n", (int)gl_msaa_samples->value);
+				ri.Cvar_SetValue("gl_msaa_samples", 0.0f);
+				gl_msaa_samples->modified = false;
+
+				if ((err = SetMode_impl(&vid.width, &vid.height, gl_mode->value, 0)) == rserr_ok)
+				{
+					return true;
+				}
+			}
 			if(gl_mode->value == gl3state.prev_mode)
 			{
 				// trying again would result in a crash anyway, give up already

--- a/src/client/refresh/gl3/gl3_sdl.c
+++ b/src/client/refresh/gl3/gl3_sdl.c
@@ -113,6 +113,11 @@ int GL3_PrepareForWindow(void)
 			SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 0);
 		}
 	}
+	else
+	{
+		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 0);
+		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 0);
+	}
 
 	/* Initiate the flags */
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -131,7 +136,7 @@ enum {
 	QGL_DEBUG_SEVERITY_NOTIFICATION = 0x826B
 };
 
-static void
+static void APIENTRY
 DebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
               const GLchar *message, const void *userParam)
 {
@@ -230,12 +235,17 @@ int GL3_InitContext(void* win)
 
 	if(!gladLoadGLLoader(SDL_GL_GetProcAddress))
 	{
-		R_Printf(PRINT_ALL, "R_InitContext(): loading OpenGL function pointers failed!\n");
+		R_Printf(PRINT_ALL, "GL3_InitContext(): ERROR: loading OpenGL function pointers failed!\n");
+		return false;
+	}
+	else if (GLVersion.major < 3 || (GLVersion.major == 3 && GLVersion.minor < 2))
+	{
+		R_Printf(PRINT_ALL, "GL3_InitContext(): ERROR: glad only got GL version %d.%d!\n", GLVersion.major, GLVersion.minor);
 		return false;
 	}
 	else
 	{
-		R_Printf(PRINT_ALL, "Successfully loaded OpenGL function pointers using glad!\n");
+		R_Printf(PRINT_ALL, "Successfully loaded OpenGL function pointers using glad, got version %d.%d!\n", GLVersion.major, GLVersion.minor);
 	}
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)


### PR DESCRIPTION
(This has been lying around for almost 3 monts, totally forgot to merge this before..)

For some fucking reason, if you set an unsupported
SDL_GL_MULTISAMPLESAMPLES value on Windows (at least Win10 with Intel GPU
drivers, there 16 is unsupported), creating the Window and OpenGL context
will succeed, but you'll get Microsofts stupid GDI OpenGL software
implementation that only supports OpenGL 1.1.
Before these fixes, the GL3 renderer would just crash and the GL1 renderer
would fail to load, which caused the game to run in the background:
No Window, no Input, but sound was playing..

Now this problem should be handled properly and if initialization fails,
the rendering backend will be considered not working, and it will
try the gl1 backend next, and if that also fails it'll give up and exit
the game.