### PR TITLE
quake2.exe => yquake2.exe; quake2.exe wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -976,8 +976,8 @@ release/yquake2.exe : $(CLIENT_OBJS) icon
 	${Q}$(CC) build/icon/icon.res $(CLIENT_OBJS) $(LDFLAGS) $(SDLLDFLAGS) -o $@
 	$(Q)strip $@
 # the wrappper, quick'n'dirty
-release/quake2.exe : src/win-wrapper/wrapper.c
-	$(Q)$(CC) -Wall src/win-wrapper/wrapper.c -o $@
+release/quake2.exe : src/win-wrapper/wrapper.c icon
+	$(Q)$(CC) -Wall build/icon/icon.res src/win-wrapper/wrapper.c -o $@
 	$(Q)strip $@
 else
 release/quake2 : $(CLIENT_OBJS)

--- a/Makefile
+++ b/Makefile
@@ -382,8 +382,10 @@ cleanall:
 # The client
 ifeq ($(YQ2_OSTYPE), Windows)
 client:
-	@echo "===> Building quake2.exe"
+	@echo "===> Building yquake2.exe"
 	${Q}mkdir -p release
+	$(MAKE) release/yquake2.exe
+	@echo "===> Building quake2.exe Wrapper"
 	$(MAKE) release/quake2.exe
 
 build/client/%.o: %.c
@@ -392,28 +394,28 @@ build/client/%.o: %.c
 	${Q}$(CC) -c $(CFLAGS) $(SDLCFLAGS) $(INCLUDE) -o $@ $<
 
 ifeq ($(WITH_CDA),yes)
-release/quake2.exe : CFLAGS += -DCDA
+release/yquake2.exe : CFLAGS += -DCDA
 endif
 
 ifeq ($(WITH_OGG),yes)
-release/quake2.exe : CFLAGS += -DOGG
-release/quake2.exe : LDFLAGS += -lvorbisfile -lvorbis -logg
+release/yquake2.exe : CFLAGS += -DOGG
+release/yquake2.exe : LDFLAGS += -lvorbisfile -lvorbis -logg
 endif
 
 ifeq ($(WITH_OPENAL),yes)
-release/quake2.exe : CFLAGS += -DUSE_OPENAL -DDEFAULT_OPENAL_DRIVER='"openal32.dll"' -DDLOPEN_OPENAL
+release/yquake2.exe : CFLAGS += -DUSE_OPENAL -DDEFAULT_OPENAL_DRIVER='"openal32.dll"' -DDLOPEN_OPENAL
 endif
 
 ifeq ($(WITH_ZIP),yes)
-release/quake2.exe : CFLAGS += -DZIP -DNOUNCRYPT
-release/quake2.exe : LDFLAGS += -lz
+release/yquake2.exe : CFLAGS += -DZIP -DNOUNCRYPT
+release/yquake2.exe : LDFLAGS += -lz
 endif
 
 ifeq ($(WITH_SDL2),yes)
-release/quake2.exe : CFLAGS += -DSDL2
+release/yquake2.exe : CFLAGS += -DSDL2
 endif
 
-release/quake2.exe : LDFLAGS += -mwindows
+release/yquake2.exe : LDFLAGS += -mwindows
 
 else # not Windows
 
@@ -969,9 +971,13 @@ GAME_DEPS= $(GAME_OBJS:.o=.d)
 
 # release/quake2
 ifeq ($(YQ2_OSTYPE), Windows)
-release/quake2.exe : $(CLIENT_OBJS) icon
+release/yquake2.exe : $(CLIENT_OBJS) icon
 	@echo "===> LD $@"
 	${Q}$(CC) build/icon/icon.res $(CLIENT_OBJS) $(LDFLAGS) $(SDLLDFLAGS) -o $@
+	$(Q)strip $@
+# the wrappper, quick'n'dirty
+release/quake2.exe : src/win-wrapper/wrapper.c
+	$(Q)$(CC) -Wall src/win-wrapper/wrapper.c -o $@
 	$(Q)strip $@
 else
 release/quake2 : $(CLIENT_OBJS)

--- a/src/win-wrapper/wrapper.c
+++ b/src/win-wrapper/wrapper.c
@@ -1,0 +1,95 @@
+/*
+ * Just a trivial stupid wrapper quake2.exe that starts yquake2.exe.
+ * It calls it with the whole path (assuming it's in same directory as this wrapper)
+ * and passes the commandline
+ *
+ * This should allow us to rename the real executable to yquake2.exe (to hopefully
+ * avoid trouble with whatever stupid thing interferes with mouse input once
+ * console has been opened if the games executable is called quake2.exe)
+ * while avoiding confusion for people upgrading their yq2 installation who still have
+ * shortcuts (possibly in Steam) to quake2.exe that would otherwise launch an old version.
+ *
+ * Can be built with just
+ *   $ gcc -Wall -o quake2.exe wrapper.c
+ * in our mingw build environment, will only depend on kernel32.dll and MSVCRT.DLL then,
+ * which should be available on every Windows installation.
+ * 
+ * (C) 2017 Daniel Gibson
+ * License:
+ *  This software is dual-licensed to the public domain and under the following
+ *  license: you are granted a perpetual, irrevocable license to copy, modify,
+ *  publish, and distribute this file as you see fit.
+ *  No warranty implied; use at your own risk.
+ *
+ * So you can do whatever you want with this code, including copying it
+ * (or parts of it) into your own source.
+ */
+
+#include <windows.h>
+#include <wchar.h>
+#include <stdio.h>
+
+static const WCHAR WRAPPED_EXE[] = L"yquake2.exe";
+
+int main(int argc, char** argv)
+{
+	WCHAR* cmdLine = GetCommandLineW();
+	WCHAR exePath[2048];
+	WCHAR* lastBackSlash = exePath;
+	int maxLenSafe = sizeof(exePath)/sizeof(WCHAR) - wcslen(WRAPPED_EXE);
+
+	// get full path to this executable..
+	DWORD len = GetModuleFileNameW(NULL, exePath, maxLenSafe);
+	if(len <= 0 || len == maxLenSafe) {
+		// an error occured, clear exe path
+		exePath[0] = 0;
+	} else {
+		// .. cut off executable name (after last backslash in path)
+		lastBackSlash = wcsrchr(exePath, L'\\');
+		if(lastBackSlash != NULL) {
+			lastBackSlash[1] = 0;
+		} else {
+			// if there was no backslash, fall back to using only the wrapped exe name
+			// (appended to empty exePath buffer)
+			lastBackSlash = exePath;
+			lastBackSlash[0] = 0;
+		}
+	}
+
+	// .. append wrapped executable name to path ..
+	// should be safe, because maxLenSafe subtracted WRAPPED_EXE's length
+	// (and that's very conservative, we removed the original .exe name after all)
+	wcscat(lastBackSlash, WRAPPED_EXE);
+
+	// .. and start the wrapped executable
+	{
+		STARTUPINFOW si = {0};
+		PROCESS_INFORMATION pi = {0};
+		BOOL ret = FALSE;
+		si.cb = sizeof(si);
+
+		ret = CreateProcessW(exePath, cmdLine,
+		                     NULL,  // process security attributes
+		                     NULL,  // thread security attributes
+		                     FALSE, // don't inherit handles
+		                     0,     // no creation flag
+		                     NULL,  // environment block - no changes, use ours
+		                     NULL,  // don't change CWD
+		                     &si, &pi);
+
+		if(!ret)
+		{
+			fprintf(stderr, "Couldn't CreateProcess() (%ld).\n", GetLastError());
+			return 1;
+		}
+
+		// wait for wrapped exe to exit
+		WaitForSingleObject(pi.hProcess, INFINITE);
+
+		// close the process and thread object handles
+		CloseHandle(pi.hProcess);
+		CloseHandle(pi.hThread);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Apparently something (possibly nvidia's driver) on some windows installations has some stupid application profile for quake2.exe that breaks mouse input if the console has been opened, see #257 
    
The workaround is to rename quake2.exe to yquake2.exe and provide a wrapper quake2.exe that just calls the real one for backwards compatibility.