### PR TITLE
Use CMake 'GREATER' instead of 'GREATER_EQUAL'.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -fno-strict-aliasing -fwrap
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-braces")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	if (CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 8.0)
+	if (CMAKE_CXX_COMPILER_VERSION GREATER 7.99)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-truncation -Wno-format-overflow")
 	endif()
 endif()


### PR DESCRIPTION
Hi,
'GREATER_EQUAL' was introduced in CMake 3.7:
https://cmake.org/cmake/help/v3.7/release/3.7.html#commands
CMakeList.txt states that minimum required version of CMake is 3.0. So please use 'GREATER' instead of 'GREATER_EQUAL'.
Please also note, that Ubuntu 16.04 has CMake 3.5, so using 'GREATER_EQUAL' will break build process for this platform.
Best regards,