### PR TITLE
Fix the MacOS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,10 +360,10 @@ client:
 	$(MAKE) release/quake2
 
 ifeq ($(YQ2_OSTYPE), Darwin)
-build/client/%.o : %.m
+build/client/%.o : %.c
 	@echo "===> CC $<"
 	${Q}mkdir -p $(@D)
-	${Q}$(CC) $(OSX_ARCH) -x objective-c -c $< -o $@
+	${Q}$(CC) $(OSX_ARCH) -x objective-c -c $(CFLAGS) $(SDLCFLAGS) $(ZIPCFLAGS) $(INCLUDE)  $< -o $@
 else
 build/client/%.o: %.c
 	@echo "===> CC $<"


### PR DESCRIPTION
There were issues with the macOS build.

`
===> Building quake2
/Applications/Xcode.app/Contents/Developer/usr/bin/make release/quake2
make[1]: *** No rule to make target `build/client/src/backends/generic/misc.o', needed by `release/quake2'.  Stop.
make: *** [client] Error 2
`

`Elkan:yquake2 Elkan$ make -v
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.
This program built for i386-apple-darwin11.3.0
`

This fixes the build on MacOS.