### PR TITLE
Fix IPV6 networking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,10 +360,10 @@ client:
 	$(MAKE) release/quake2
 
 ifeq ($(YQ2_OSTYPE), Darwin)
-build/client/%.o : %.m
+build/client/%.o : %.c
 	@echo "===> CC $<"
 	${Q}mkdir -p $(@D)
-	${Q}$(CC) $(OSX_ARCH) -x objective-c -c $< -o $@
+	${Q}$(CC) $(OSX_ARCH) -x objective-c -c $(CFLAGS) $(SDLCFLAGS) $(ZIPCFLAGS) $(INCLUDE)  $< -o $@
 else
 build/client/%.o: %.c
 	@echo "===> CC $<"

--- a/src/backends/unix/network.c
+++ b/src/backends/unix/network.c
@@ -829,7 +829,7 @@ NET_Socket(char *net_interface, int port, netsrc_t type, int family)
 	if (!net_interface || !net_interface[0] ||
 		!Q_stricmp(net_interface, "localhost"))
 	{
-		Host = (family == AF_INET6) ? "::1" : "0.0.0.0";
+		Host = (family == AF_INET6) ? "::/0" : "0.0.0.0";
 	}
 	else
 	{

--- a/src/backends/unix/network.c
+++ b/src/backends/unix/network.c
@@ -829,7 +829,7 @@ NET_Socket(char *net_interface, int port, netsrc_t type, int family)
 	if (!net_interface || !net_interface[0] ||
 		!Q_stricmp(net_interface, "localhost"))
 	{
-		Host = (family == AF_INET6) ? "::" : "0.0.0.0";
+		Host = (family == AF_INET6) ? "::1" : "0.0.0.0";
 	}
 	else
 	{

--- a/src/backends/windows/network.c
+++ b/src/backends/windows/network.c
@@ -821,7 +821,7 @@ NET_IPSocket(char *net_interface, int port, netsrc_t type, int family)
 	if (!net_interface || !net_interface[0] ||
 		!stricmp(net_interface, "localhost"))
 	{
-		Host = (family == AF_INET6) ? "::1" : "0.0.0.0";
+		Host = (family == AF_INET6) ? "::/0" : "0.0.0.0";
 	}
 	else
 	{


### PR DESCRIPTION
When hosting or joining a server via a IPV6 address no connection can be made. This is because of the ipv6 address '::' which should be '::1'. This PR fixes this mistake.