### PR TITLE
Add support for .override files (backport from r1q2)

### DIFF
--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2011,7 +2011,14 @@ StartGame(void)
 	{
 		CL_Disconnect();
 	}
-
+/*
+	if (!CM_MapWillLoad ("base1"))
+	{
+		Com_Printf ("ERROR: Your Quake II installation is missing the single player data, you cannot start a single player game.\n", LOG_GENERAL);
+		M_PopMenu ();
+		return;
+	}
+*/
     /* disable updates and start the cinematic going */
     cl.servercount = -1;
     M_ForceMenuOff();

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -613,6 +613,8 @@ int CM_PointLeafnum(vec3_t p);
 int CM_BoxLeafnums(vec3_t mins, vec3_t maxs, int *list,
 		int listsize, int *topnode);
 
+qboolean CM_MapWillLoad (const char *name);
+
 int CM_LeafContents(int leafnum);
 int CM_LeafCluster(int leafnum);
 int CM_LeafArea(int leafnum);

--- a/src/server/sv_cmd.c
+++ b/src/server/sv_cmd.c
@@ -199,8 +199,19 @@ SV_GameMap_f(void)
 		SV_WipeSavegame("current");
 	}
 	else
-	{
-		/* save the map just exited */
+	{	// save the map just exited
+		if (!strchr (map, '.') && !strchr (map, '$'))
+		{
+			Com_sprintf (expanded, sizeof(expanded), "maps/%s.bsp", map);
+
+			//r1: check it exists
+            		//if (FS_LoadFile (expanded, NULL) == -1)
+			if (!CM_MapWillLoad (expanded))
+			{
+				Com_Printf ("Can't find map '%s'\n", LOG_GENERAL, map);
+				return;
+			}
+		}		
 		if (sv.state == ss_game)
 		{
 			/* clear all the client inuse flags before saving so that

--- a/src/server/sv_cmd.c
+++ b/src/server/sv_cmd.c
@@ -274,9 +274,11 @@ SV_Map_f(void)
 	{
 		Com_sprintf(expanded, sizeof(expanded), "maps/%s.bsp", map);
 
-		if (FS_LoadFile(expanded, NULL) == -1)
-		{
-			Com_Printf("Can't find %s\n", expanded);
+		//r1: check it exists
+     		//if (FS_LoadFile (expanded, NULL) == -1)
+		if (!CM_MapWillLoad (expanded))
+		{			
+			Com_Printf ("Can't find map '%s'\n", LOG_GENERAL, map);
 			return;
 		}
 	}


### PR DESCRIPTION
.override files are files containing the entities on a map (i.e. base2.override). It's usually used for entity manipulation (i.e. adding CTF support to a non-CTF map, complete with weapon/item balance) without touching the original map.