### PR TITLE
Added .ent file support (from KMQuake2, it works!)

### DIFF
--- a/src/common/collision.c
+++ b/src/common/collision.c
@@ -1612,7 +1612,7 @@ CMod_LoadVisibility(lump_t *l)
 void
 CMod_LoadEntityString(lump_t *l, char *name)
 {
-	// Knightmare- .ent file support
+	// Port from Knightmare's kmquake2: support for .ent files.
 	if (sv_entfile->value)
 	{
 		char	s[MAX_QPATH];
@@ -1640,27 +1640,22 @@ CMod_LoadEntityString(lump_t *l, char *name)
 				return;
 			}
 		}
-		else if (bufLen != -1)	// catch too-small entfile
+		else if (bufLen != -1)	// If the .ent file is too small, don't load.
 		{
 			Com_Printf ("CMod_LoadEntityString: .ent file %s too small.\n", s);
 			FS_FreeFile (buffer);
 		}
 		// fall back to bsp entity string if no .ent file loaded
 	}
-	// end Knightmare
+	// End of the kmquake2 .ent file support port.
 
 	numentitychars = l->filelen;
 
-/*	if (l->filelen > MAX_MAP_ENTSTRING)
-	{
-		Com_Error(ERR_DROP, "Map has too large entity lump");
-	}
-
-	memcpy(map_entitystring, cmod_base + l->fileofs, l->filelen);
-*/
+	// if (l->filelen > MAX_MAP_ENTSTRING)
 	if (l->filelen + 1 > sizeof(map_entitystring)) // jit fix
-	//if (l->filelen > MAX_MAP_ENTSTRING)
+	{
 		Com_Error (ERR_DROP, "Map has too large entity lump");
+	}
 
 	memcpy (map_entitystring, cmod_base + l->fileofs, l->filelen);
 	map_entitystring[l->filelen] = 0; // jit entity bug - null terminate the entity string! 
@@ -1751,7 +1746,7 @@ CM_LoadMap(char *name, qboolean clientload, unsigned *checksum)
 	CMod_LoadAreas(&header.lumps[LUMP_AREAS]);
 	CMod_LoadAreaPortals(&header.lumps[LUMP_AREAPORTALS]);
 	CMod_LoadVisibility(&header.lumps[LUMP_VISIBILITY]);
-	CMod_LoadEntityString(&header.lumps[LUMP_ENTITIES], name);
+	CMod_LoadEntityString(&header.lumps[LUMP_ENTITIES], name); // Adding the last parameter from the .ent support kmquake2 port.
 
 	FS_FreeFile(buf);
 
@@ -1760,7 +1755,7 @@ CM_LoadMap(char *name, qboolean clientload, unsigned *checksum)
 	memset(portalopen, 0, sizeof(portalopen));
 	FloodAreaConnections();
 
-	strcpy (map_name, name);
+	strcpy(map_name, name);
 
 	return &map_cmodels[0];
 }

--- a/src/common/collision.c
+++ b/src/common/collision.c
@@ -1612,7 +1612,9 @@ CMod_LoadVisibility(lump_t *l)
 void
 CMod_LoadEntityString(lump_t *l, char *name)
 {
-	// Port from Knightmare's kmquake2: support for .ent files.
+	/*
+	 * Port from Knightmare's kmquake2: support for .ent files.
+	 */
 	if (sv_entfile->value)
 	{
 		char	s[MAX_QPATH];
@@ -1625,7 +1627,7 @@ CMod_LoadEntityString(lump_t *l, char *name)
 		bufLen = FS_LoadFile (s, (void **)&buffer);
 		if (buffer != NULL && bufLen > 1)
 		{
-			if (bufLen + 1 > sizeof(map_entitystring)) // jit fix
+			if (bufLen + 1 > sizeof(map_entitystring)) /* jit fix */
 			{
 				Com_Printf ("CMod_LoadEntityString: .ent file %s too large: %i > %i.\n", s, bufLen, sizeof(map_entitystring));
 				FS_FreeFile (buffer);
@@ -1635,30 +1637,33 @@ CMod_LoadEntityString(lump_t *l, char *name)
 				Com_Printf ("CMod_LoadEntityString: .ent file %s loaded.\n", s);
 				numentitychars = bufLen;
 				memcpy (map_entitystring, buffer, bufLen);
-				map_entitystring[bufLen] = 0; // jit entity bug - null terminate the entity string! 
+				map_entitystring[bufLen] = 0; /* jit entity bug - null terminate the entity string! */
 				FS_FreeFile (buffer);
 				return;
 			}
 		}
-		else if (bufLen != -1)	// If the .ent file is too small, don't load.
+		/* If the .ent file is too small, don't load. */
+		else if (bufLen != -1)
 		{
 			Com_Printf ("CMod_LoadEntityString: .ent file %s too small.\n", s);
 			FS_FreeFile (buffer);
 		}
-		// fall back to bsp entity string if no .ent file loaded
+		/* Fall back to bsp entity string if no .ent file loaded */
 	}
-	// End of the kmquake2 .ent file support port.
+	/* 
+	 * End of the kmquake2 .ent file support port.
+	 */
 
 	numentitychars = l->filelen;
 
-	// if (l->filelen > MAX_MAP_ENTSTRING)
-	if (l->filelen + 1 > sizeof(map_entitystring)) // jit fix
+	/* if (l->filelen > MAX_MAP_ENTSTRING) */
+	if (l->filelen + 1 > sizeof(map_entitystring)) /* jit fix */
 	{
 		Com_Error(ERR_DROP, "Map has too large entity lump");
 	}
 
 	memcpy(map_entitystring, cmod_base + l->fileofs, l->filelen);
-	map_entitystring[l->filelen] = 0; // jit entity bug - null terminate the entity string! 
+	map_entitystring[l->filelen] = 0; /* jit entity bug - null terminate the entity string! */
 }
 
 /*
@@ -1746,7 +1751,8 @@ CM_LoadMap(char *name, qboolean clientload, unsigned *checksum)
 	CMod_LoadAreas(&header.lumps[LUMP_AREAS]);
 	CMod_LoadAreaPortals(&header.lumps[LUMP_AREAPORTALS]);
 	CMod_LoadVisibility(&header.lumps[LUMP_VISIBILITY]);
-	CMod_LoadEntityString(&header.lumps[LUMP_ENTITIES], name); // Adding the last parameter from the .ent support kmquake2 port.
+	/* From kmquake2: adding an extra parameter for .ent support. */
+	CMod_LoadEntityString(&header.lumps[LUMP_ENTITIES], name);
 
 	FS_FreeFile(buf);
 

--- a/src/common/collision.c
+++ b/src/common/collision.c
@@ -1654,10 +1654,10 @@ CMod_LoadEntityString(lump_t *l, char *name)
 	// if (l->filelen > MAX_MAP_ENTSTRING)
 	if (l->filelen + 1 > sizeof(map_entitystring)) // jit fix
 	{
-		Com_Error (ERR_DROP, "Map has too large entity lump");
+		Com_Error(ERR_DROP, "Map has too large entity lump");
 	}
 
-	memcpy (map_entitystring, cmod_base + l->fileofs, l->filelen);
+	memcpy(map_entitystring, cmod_base + l->fileofs, l->filelen);
 	map_entitystring[l->filelen] = 0; // jit entity bug - null terminate the entity string! 
 }
 

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -720,8 +720,8 @@ extern cvar_t *dedicated;
 extern cvar_t *host_speeds;
 extern cvar_t *log_stats;
 
-// Ported from kmquake2: .ent file support
-extern cvar_t *sv_entfile;			// whether to use .ent file
+/* Ported from kmquake2: .ent file support - whether to use .ent file or not */
+extern cvar_t *sv_entfile;
 
 /* Hack for portable client */
 extern qboolean is_portable;

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -720,8 +720,8 @@ extern cvar_t *dedicated;
 extern cvar_t *host_speeds;
 extern cvar_t *log_stats;
 
-// Knightmare
-extern	cvar_t *sv_entfile;			// whether to use .ent file
+// Ported from kmquake2: .ent file support
+extern cvar_t *sv_entfile;			// whether to use .ent file
 
 /* Hack for portable client */
 extern qboolean is_portable;

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -720,6 +720,9 @@ extern cvar_t *dedicated;
 extern cvar_t *host_speeds;
 extern cvar_t *log_stats;
 
+// Knightmare
+extern	cvar_t *sv_entfile;			// whether to use .ent file
+
 /* Hack for portable client */
 extern qboolean is_portable;
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -49,7 +49,7 @@ cvar_t *maxclients; /* rename sv_maxclients */
 cvar_t *sv_showclamp;
 cvar_t *hostname;
 cvar_t *public_server; /* should heartbeats be sent */
-cvar_t *sv_entfile;			// whether to use .ent file
+cvar_t *sv_entfile; /* From kmquake2: whether to use .ent file */
 
 void Master_Shutdown(void);
 void SV_ConnectionlessPacket(void);
@@ -610,7 +610,8 @@ SV_Init(void)
 
 	public_server = Cvar_Get("public", "0", 0);
 
-	sv_entfile = Cvar_Get("sv_entfile", "1", CVAR_ARCHIVE); // From kmquake2: whether to use .ent file
+	/* From kmquake2: whether to use .ent file. */
+	sv_entfile = Cvar_Get("sv_entfile", "1", CVAR_ARCHIVE);
 
 	SZ_Init(&net_message, net_message_buffer, sizeof(net_message_buffer));
 }

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -49,7 +49,7 @@ cvar_t *maxclients; /* rename sv_maxclients */
 cvar_t *sv_showclamp;
 cvar_t *hostname;
 cvar_t *public_server; /* should heartbeats be sent */
-cvar_t	*sv_entfile;			// whether to use .ent file
+cvar_t *sv_entfile;			// whether to use .ent file
 
 void Master_Shutdown(void);
 void SV_ConnectionlessPacket(void);

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -49,6 +49,7 @@ cvar_t *maxclients; /* rename sv_maxclients */
 cvar_t *sv_showclamp;
 cvar_t *hostname;
 cvar_t *public_server; /* should heartbeats be sent */
+cvar_t	*sv_entfile;			// whether to use .ent file
 
 void Master_Shutdown(void);
 void SV_ConnectionlessPacket(void);
@@ -608,6 +609,8 @@ SV_Init(void)
 	sv_airaccelerate = Cvar_Get("sv_airaccelerate", "0", CVAR_LATCH);
 
 	public_server = Cvar_Get("public", "0", 0);
+
+	sv_entfile = Cvar_Get ("sv_entfile", "1", CVAR_ARCHIVE); // whether to use .ent file
 
 	SZ_Init(&net_message, net_message_buffer, sizeof(net_message_buffer));
 }

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -610,7 +610,7 @@ SV_Init(void)
 
 	public_server = Cvar_Get("public", "0", 0);
 
-	sv_entfile = Cvar_Get ("sv_entfile", "1", CVAR_ARCHIVE); // whether to use .ent file
+	sv_entfile = Cvar_Get("sv_entfile", "1", CVAR_ARCHIVE); // From kmquake2: whether to use .ent file
 
 	SZ_Init(&net_message, net_message_buffer, sizeof(net_message_buffer));
 }


### PR DESCRIPTION
.ent file support for external .ent files (drop them in the maps/ directory) for trivial entity manipulation without having to modify the map. **It finally works!** Ported from KMQuake2. Open to changes, though.