### PR TITLE
Softrender cleanup

### DIFF
--- a/src/backends/unix/shared/hunk.c
+++ b/src/backends/unix/shared/hunk.c
@@ -47,14 +47,16 @@
 #endif
 
 byte *membase;
-int maxhunksize;
-int curhunksize;
+size_t maxhunksize;
+size_t curhunksize;
 
 void *
 Hunk_Begin(int maxsize)
 {
+
 	/* reserve a huge chunk of memory, but don't commit any yet */
-	maxhunksize = maxsize + sizeof(size_t);
+	/* plus 32 bytes for cacheline */
+	maxhunksize = maxsize + sizeof(size_t) + 32;
 	curhunksize = 0;
 
 	membase = mmap(0, maxhunksize, PROT_READ | PROT_WRITE,
@@ -65,9 +67,9 @@ Hunk_Begin(int maxsize)
 		Sys_Error("unable to virtual allocate %d bytes", maxsize);
 	}
 
-	*((int *)membase) = curhunksize;
+	*((size_t *)membase) = curhunksize;
 
-	return membase + sizeof(int);
+	return membase + sizeof(size_t);
 }
 
 void *
@@ -76,14 +78,14 @@ Hunk_Alloc(int size)
 	byte *buf;
 
 	/* round to cacheline */
-	size = (size + 63) & ~63;
+	size = (size + 31) & ~31;
 
 	if (curhunksize + size > maxhunksize)
 	{
 		Sys_Error("Hunk_Alloc overflow");
 	}
 
-	buf = membase + sizeof(int) + curhunksize;
+	buf = membase + sizeof(size_t) + curhunksize;
 	curhunksize += size;
 	return buf;
 }
@@ -94,10 +96,10 @@ Hunk_End(void)
 	byte *n = NULL;
 
 #if defined(__linux__)
-	n = (byte *)mremap(membase, maxhunksize, curhunksize + sizeof(int), 0);
+	n = (byte *)mremap(membase, maxhunksize, curhunksize + sizeof(size_t), 0);
 #elif defined(__FreeBSD__)
 	size_t old_size = maxhunksize;
-	size_t new_size = curhunksize + sizeof(int);
+	size_t new_size = curhunksize + sizeof(size_t);
 	void *unmap_base;
 	size_t unmap_len;
 
@@ -121,7 +123,7 @@ Hunk_End(void)
  #endif
 
 	size_t old_size = maxhunksize;
-	size_t new_size = curhunksize + sizeof(int);
+	size_t new_size = curhunksize + sizeof(size_t);
 	void *unmap_base;
 	size_t unmap_len;
 	long page_size;
@@ -152,7 +154,7 @@ Hunk_End(void)
 		Sys_Error("Hunk_End: Could not remap virtual block (%d)", errno);
 	}
 
-	*((int *)membase) = curhunksize + sizeof(int);
+	*((size_t *)membase) = curhunksize + sizeof(size_t);
 
 	return curhunksize;
 }
@@ -164,9 +166,9 @@ Hunk_Free(void *base)
 	{
 		byte *m;
 
-		m = ((byte *)base) - sizeof(int);
+		m = ((byte *)base) - sizeof(size_t);
 
-		if (munmap(m, *((int *)m)))
+		if (munmap(m, *((size_t *)m)))
 		{
 			Sys_Error("Hunk_Free: munmap failed (%d)", errno);
 		}

--- a/src/backends/unix/shared/hunk.c
+++ b/src/backends/unix/shared/hunk.c
@@ -54,7 +54,7 @@ void *
 Hunk_Begin(int maxsize)
 {
 	/* reserve a huge chunk of memory, but don't commit any yet */
-	maxhunksize = maxsize + sizeof(int);
+	maxhunksize = maxsize + sizeof(size_t);
 	curhunksize = 0;
 
 	membase = mmap(0, maxhunksize, PROT_READ | PROT_WRITE,
@@ -76,7 +76,7 @@ Hunk_Alloc(int size)
 	byte *buf;
 
 	/* round to cacheline */
-	size = (size + 31) & ~31;
+	size = (size + 63) & ~63;
 
 	if (curhunksize + size > maxhunksize)
 	{

--- a/src/client/refresh/gl1/gl1_md2.c
+++ b/src/client/refresh/gl1/gl1_md2.c
@@ -27,7 +27,7 @@
 #include "header/local.h"
 
 void
-LoadMD2(model_t *mod, void *buffer)
+LoadMD2(model_t *mod, void *buffer, int modfilelen)
 {
 	int i, j;
 	dmdl_t *pinmodel, *pheader;
@@ -36,6 +36,7 @@ LoadMD2(model_t *mod, void *buffer)
 	daliasframe_t *pinframe, *poutframe;
 	int *pincmd, *poutcmd;
 	int version;
+	int ofs_end;
 
 	pinmodel = (dmdl_t *)buffer;
 
@@ -47,7 +48,13 @@ LoadMD2(model_t *mod, void *buffer)
 				mod->name, version, ALIAS_VERSION);
 	}
 
-	pheader = Hunk_Alloc(LittleLong(pinmodel->ofs_end));
+	ofs_end = LittleLong(pinmodel->ofs_end);
+	if (ofs_end < 0 || ofs_end > modfilelen)
+		ri.Sys_Error (ERR_DROP, "model %s file size(%d) too small, should be %d", mod->name,
+				   modfilelen, ofs_end);
+
+	mod->extradata = Hunk_Begin(modfilelen);
+	pheader = Hunk_Alloc(ofs_end);
 
 	/* byte swap the header fields and sanity check */
 	for (i = 0; i < sizeof(dmdl_t) / 4; i++)

--- a/src/client/refresh/gl1/gl1_model.c
+++ b/src/client/refresh/gl1/gl1_model.c
@@ -36,9 +36,9 @@ int mod_numknown;
 int registration_sequence;
 byte *mod_base;
 
-void LoadSP2(model_t *mod, void *buffer);
-void Mod_LoadBrushModel(model_t *mod, void *buffer);
-void LoadMD2(model_t *mod, void *buffer);
+void LoadSP2(model_t *mod, void *buffer, int modfilelen);
+void Mod_LoadBrushModel(model_t *mod, void *buffer, int modfilelen);
+void LoadMD2(model_t *mod, void *buffer, int modfilelen);
 void LM_BuildPolygonFromSurface(msurface_t *fa);
 void LM_CreateSurfaceLightmap(msurface_t *surf);
 void LM_EndBuildingLightmaps(void);
@@ -210,18 +210,15 @@ Mod_ForName(char *name, qboolean crash)
 	switch (LittleLong(*(unsigned *)buf))
 	{
 		case IDALIASHEADER:
-			loadmodel->extradata = Hunk_Begin(0x200000);
-			LoadMD2(mod, buf);
+			LoadMD2(mod, buf, modfilelen);
 			break;
 
 		case IDSPRITEHEADER:
-			loadmodel->extradata = Hunk_Begin(0x10000);
-			LoadSP2(mod, buf);
+			LoadSP2(mod, buf, modfilelen);
 			break;
 
 		case IDBSPHEADER:
-			loadmodel->extradata = Hunk_Begin(0x2000000);
-			Mod_LoadBrushModel(mod, buf);
+			Mod_LoadBrushModel(mod, buf, modfilelen);
 			break;
 
 		default:
@@ -825,12 +822,15 @@ Mod_LoadPlanes(lump_t *l)
 }
 
 void
-Mod_LoadBrushModel(model_t *mod, void *buffer)
+Mod_LoadBrushModel(model_t *mod, void *buffer, int modfilelen)
 {
 	int i;
 	dheader_t *header;
 	mmodel_t *bm;
 
+	// map use short indexes that we convert to pointers
+	// pointer size / 2 bytes
+	loadmodel->extradata = Hunk_Begin(modfilelen * sizeof(void*) / 2);
 	loadmodel->type = mod_brush;
 
 	if (loadmodel != mod_known)

--- a/src/client/refresh/gl1/gl1_model.c
+++ b/src/client/refresh/gl1/gl1_model.c
@@ -220,7 +220,7 @@ Mod_ForName(char *name, qboolean crash)
 			break;
 
 		case IDBSPHEADER:
-			loadmodel->extradata = Hunk_Begin(0x1000000);
+			loadmodel->extradata = Hunk_Begin(0x2000000);
 			Mod_LoadBrushModel(mod, buf);
 			break;
 
@@ -688,6 +688,8 @@ Mod_LoadLeafs(lump_t *l)
 
 	for (i = 0; i < count; i++, in++, out++)
 	{
+		unsigned firstleafface;
+
 		for (j = 0; j < 3; j++)
 		{
 			out->minmaxs[j] = LittleShort(in->mins[j]);
@@ -700,9 +702,15 @@ Mod_LoadLeafs(lump_t *l)
 		out->cluster = LittleShort(in->cluster);
 		out->area = LittleShort(in->area);
 
-		out->firstmarksurface = loadmodel->marksurfaces +
-								LittleShort(in->firstleafface);
-		out->nummarksurfaces = LittleShort(in->numleaffaces);
+		// make unsigned long from signed short
+		firstleafface = LittleShort(in->firstleafface) & 0xFFFF;
+		out->nummarksurfaces = LittleShort(in->numleaffaces) & 0xFFFF;
+
+		out->firstmarksurface = loadmodel->marksurfaces + firstleafface;
+		if ((firstleafface + out->nummarksurfaces) > loadmodel->nummarksurfaces)
+		{
+			ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: wrong marksurfaces position in %s",loadmodel->name);
+		}
 	}
 }
 

--- a/src/client/refresh/gl1/gl1_sp2.c
+++ b/src/client/refresh/gl1/gl1_sp2.c
@@ -35,6 +35,7 @@ LoadSP2(model_t *mod, void *buffer)
 	int i;
 
 	sprin = (dsprite_t *)buffer;
+	mod->extradata = Hunk_Begin(modfilelen);
 	sprout = Hunk_Alloc(modfilelen);
 
 	sprout->ident = LittleLong(sprin->ident);

--- a/src/client/refresh/gl3/gl3_md2.c
+++ b/src/client/refresh/gl3/gl3_md2.c
@@ -27,7 +27,7 @@
 #include "header/local.h"
 
 void
-GL3_LoadMD2(gl3model_t *mod, void *buffer)
+GL3_LoadMD2(gl3model_t *mod, void *buffer, int modfilelen)
 {
 	int i, j;
 	dmdl_t *pinmodel, *pheader;
@@ -36,6 +36,7 @@ GL3_LoadMD2(gl3model_t *mod, void *buffer)
 	daliasframe_t *pinframe, *poutframe;
 	int *pincmd, *poutcmd;
 	int version;
+	int ofs_end;
 
 	pinmodel = (dmdl_t *)buffer;
 
@@ -47,7 +48,13 @@ GL3_LoadMD2(gl3model_t *mod, void *buffer)
 				mod->name, version, ALIAS_VERSION);
 	}
 
-	pheader = Hunk_Alloc(LittleLong(pinmodel->ofs_end));
+	ofs_end = LittleLong(pinmodel->ofs_end);
+	if (ofs_end < 0 || ofs_end > modfilelen)
+		ri.Sys_Error (ERR_DROP, "model %s file size(%d) too small, should be %d", mod->name,
+				   modfilelen, ofs_end);
+
+	mod->extradata = Hunk_Begin(modfilelen);
+	pheader = Hunk_Alloc(ofs_end);
 
 	/* byte swap the header fields and sanity check */
 	for (i = 0; i < sizeof(dmdl_t) / 4; i++)

--- a/src/client/refresh/gl3/gl3_model.c
+++ b/src/client/refresh/gl3/gl3_model.c
@@ -708,12 +708,15 @@ Mod_LoadPlanes(lump_t *l)
 }
 
 static void
-Mod_LoadBrushModel(gl3model_t *mod, void *buffer)
+Mod_LoadBrushModel(gl3model_t *mod, void *buffer, int modfilelen)
 {
 	int i;
 	dheader_t *header;
 	mmodel_t *bm;
 
+	// map use short indexes that we convert to pointers
+	// pointer size / 2 bytes
+	loadmodel->extradata = Hunk_Begin(modfilelen * sizeof(void*) / 2);
 	loadmodel->type = mod_brush;
 
 	if (loadmodel != mod_known)
@@ -807,7 +810,7 @@ GL3_Mod_FreeAll(void)
 	}
 }
 
-extern void GL3_LoadMD2(gl3model_t *mod, void *buffer);
+extern void GL3_LoadMD2(gl3model_t *mod, void *buffer, int modfilelen);
 extern void GL3_LoadSP2(gl3model_t *mod, void *buffer, int modfilelen);
 
 /*
@@ -893,18 +896,15 @@ Mod_ForName(char *name, qboolean crash)
 	switch (LittleLong(*(unsigned *)buf))
 	{
 		case IDALIASHEADER:
-			loadmodel->extradata = Hunk_Begin(0x200000);
-			GL3_LoadMD2(mod, buf);
+			GL3_LoadMD2(mod, buf, modfilelen);
 			break;
 
 		case IDSPRITEHEADER:
-			loadmodel->extradata = Hunk_Begin(0x10000);
 			GL3_LoadSP2(mod, buf, modfilelen);
 			break;
 
 		case IDBSPHEADER:
-			loadmodel->extradata = Hunk_Begin(0x2000000);
-			Mod_LoadBrushModel(mod, buf);
+			Mod_LoadBrushModel(mod, buf, modfilelen);
 			break;
 
 		default:

--- a/src/client/refresh/gl3/gl3_model.c
+++ b/src/client/refresh/gl3/gl3_model.c
@@ -571,6 +571,8 @@ Mod_LoadLeafs(lump_t *l)
 
 	for (i = 0; i < count; i++, in++, out++)
 	{
+		unsigned firstleafface;
+
 		for (j = 0; j < 3; j++)
 		{
 			out->minmaxs[j] = LittleShort(in->mins[j]);
@@ -583,9 +585,15 @@ Mod_LoadLeafs(lump_t *l)
 		out->cluster = LittleShort(in->cluster);
 		out->area = LittleShort(in->area);
 
-		out->firstmarksurface = loadmodel->marksurfaces +
-								LittleShort(in->firstleafface);
-		out->nummarksurfaces = LittleShort(in->numleaffaces);
+		// make unsigned long from signed short
+		firstleafface = LittleShort(in->firstleafface) & 0xFFFF;
+		out->nummarksurfaces = LittleShort(in->numleaffaces) & 0xFFFF;
+
+		out->firstmarksurface = loadmodel->marksurfaces + firstleafface;
+		if ((firstleafface + out->nummarksurfaces) > loadmodel->nummarksurfaces)
+		{
+			ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: wrong marksurfaces position in %s",loadmodel->name);
+		}
 	}
 }
 
@@ -895,7 +903,7 @@ Mod_ForName(char *name, qboolean crash)
 			break;
 
 		case IDBSPHEADER:
-			loadmodel->extradata = Hunk_Begin(0x1000000);
+			loadmodel->extradata = Hunk_Begin(0x2000000);
 			Mod_LoadBrushModel(mod, buf);
 			break;
 

--- a/src/client/refresh/gl3/gl3_sp2.c
+++ b/src/client/refresh/gl3/gl3_sp2.c
@@ -33,6 +33,7 @@ GL3_LoadSP2(gl3model_t *mod, void *buffer, int modfilelen)
 	int i;
 
 	sprin = (dsprite_t *)buffer;
+	mod->extradata = Hunk_Begin(modfilelen);
 	sprout = Hunk_Alloc(modfilelen);
 
 	sprout->ident = LittleLong(sprin->ident);

--- a/src/client/refresh/soft/header/local.h
+++ b/src/client/refresh/soft/header/local.h
@@ -496,14 +496,16 @@ extern edge_t	**newedges;
 extern edge_t	**removeedges;
 
 typedef struct {
-	pixel_t		*pdest;
-	zvalue_t	*pz;
-	int		count;
+	int		u, v, count;
 	pixel_t		*ptex;
 	int		sfrac, tfrac, light;
 	zvalue_t	zi;
 } spanpackage_t;
 extern spanpackage_t	*triangle_spans, *triangles_max;
+
+void R_PolysetDrawSpans8_33(const entity_t *currententity, spanpackage_t *pspanpackage);
+void R_PolysetDrawSpans8_66(const entity_t *currententity, spanpackage_t *pspanpackage);
+void R_PolysetDrawSpans8_Opaque(const entity_t *currententity, spanpackage_t *pspanpackage);
 
 extern byte	**warp_rowptr;
 extern int	*warp_column;

--- a/src/client/refresh/soft/header/local.h
+++ b/src/client/refresh/soft/header/local.h
@@ -446,7 +446,6 @@ extern mplane_t        screenedge[4];
 extern vec3_t  r_origin;
 
 extern entity_t	r_worldentity;
-extern model_t	*currentmodel;
 extern vec3_t	modelorg;
 extern vec3_t	r_entorigin;
 
@@ -463,20 +462,19 @@ extern  qboolean	insubmodel;
 
 void R_DrawAlphaSurfaces(const entity_t *currententity);
 
-void R_DrawSprite(entity_t *currententity);
+void R_DrawSprite(entity_t *currententity, const model_t *currentmodel);
 
-void R_RenderFace(entity_t *currententity, msurface_t *fa, int clipflags);
+void R_RenderFace(entity_t *currententity, const model_t *currentmodel, msurface_t *fa, int clipflags);
 void R_RenderBmodelFace(entity_t *currententity, bedge_t *pedges, msurface_t *psurf);
 void R_TransformFrustum(void);
 
-void R_DrawSubmodelPolygons(entity_t *currententity, const model_t *pmodel, int clipflags, mnode_t *topnode);
-void R_DrawSolidClippedSubmodelPolygons(entity_t *currententity, const model_t *pmodel, mnode_t *topnode);
+void R_DrawSubmodelPolygons(entity_t *currententity, const model_t *currentmodel, int clipflags, mnode_t *topnode);
+void R_DrawSolidClippedSubmodelPolygons(entity_t *currententity, const model_t *currentmodel, mnode_t *topnode);
 
-void R_AliasDrawModel(entity_t *currententity);
+void R_AliasDrawModel(entity_t *currententity, const model_t *currentmodel);
 void R_BeginEdgeFrame(void);
 void R_ScanEdges(surf_t *surface);
 void R_PushDlights(const model_t *model);
-
 void R_RotateBmodel(const entity_t *currententity);
 
 extern int	c_faceclip;

--- a/src/client/refresh/soft/header/local.h
+++ b/src/client/refresh/soft/header/local.h
@@ -367,7 +367,7 @@ void D_DrawZSpans(espan_t *pspans);
 void TurbulentPow2(espan_t *pspan);
 void NonTurbulentPow2(espan_t *pspan); //PGM
 
-surfcache_t *D_CacheSurface (msurface_t *surface, int miplevel);
+surfcache_t *D_CacheSurface(const entity_t *currententity, msurface_t *surface, int miplevel);
 
 extern int	d_vrectx, d_vrecty, d_vrectright_particle, d_vrectbottom_particle;
 
@@ -447,7 +447,6 @@ extern vec3_t  r_origin;
 
 extern entity_t	r_worldentity;
 extern model_t	*currentmodel;
-extern entity_t	 *currententity;
 extern vec3_t	modelorg;
 extern vec3_t	r_entorigin;
 
@@ -462,23 +461,23 @@ extern msurface_t	*r_alpha_surfaces;
 //
 extern  qboolean	insubmodel;
 
-void R_DrawAlphaSurfaces(void);
+void R_DrawAlphaSurfaces(const entity_t *currententity);
 
-void R_DrawSprite(void);
+void R_DrawSprite(entity_t *currententity);
 
-void R_RenderFace(msurface_t *fa, int clipflags);
-void R_RenderBmodelFace(bedge_t *pedges, msurface_t *psurf);
+void R_RenderFace(entity_t *currententity, msurface_t *fa, int clipflags);
+void R_RenderBmodelFace(entity_t *currententity, bedge_t *pedges, msurface_t *psurf);
 void R_TransformFrustum(void);
 
-void R_DrawSubmodelPolygons(model_t *pmodel, int clipflags, mnode_t *topnode);
-void R_DrawSolidClippedSubmodelPolygons(model_t *pmodel, mnode_t *topnode);
+void R_DrawSubmodelPolygons(entity_t *currententity, const model_t *pmodel, int clipflags, mnode_t *topnode);
+void R_DrawSolidClippedSubmodelPolygons(entity_t *currententity, const model_t *pmodel, mnode_t *topnode);
 
-void R_AliasDrawModel(void);
+void R_AliasDrawModel(entity_t *currententity);
 void R_BeginEdgeFrame(void);
 void R_ScanEdges(surf_t *surface);
-void R_PushDlights(model_t *model);
+void R_PushDlights(const model_t *model);
 
-extern void R_RotateBmodel (void);
+void R_RotateBmodel(const entity_t *currententity);
 
 extern int	c_faceclip;
 extern int	r_polycount;
@@ -525,8 +524,8 @@ extern int	r_outoftriangles;
 
 extern mvertex_t	*r_pcurrentvertbase;
 
-void R_DrawTriangle(const finalvert_t *a, const finalvert_t *b, const finalvert_t *c);
-void R_AliasClipTriangle (const finalvert_t *index0, const finalvert_t *index1, finalvert_t *index2);
+void R_DrawTriangle(const entity_t *currententity, const finalvert_t *a, const finalvert_t *b, const finalvert_t *c);
+void R_AliasClipTriangle(const entity_t *currententity, const finalvert_t *index0, const finalvert_t *index1, finalvert_t *index2);
 
 
 extern float	r_time1;
@@ -543,7 +542,7 @@ extern model_t		 *r_worldmodel;
 void R_PrintAliasStats (void);
 void R_PrintTimes (void);
 void R_PrintDSpeeds (void);
-void R_LightPoint (vec3_t p, vec3_t color);
+void R_LightPoint (const entity_t *currententity, vec3_t p, vec3_t color);
 void R_SetupFrame (void);
 
 extern  refdef_t		r_newrefdef;

--- a/src/client/refresh/soft/sw_aclip.c
+++ b/src/client/refresh/soft/sw_aclip.c
@@ -217,7 +217,7 @@ R_AliasClipTriangle
 ================
 */
 void
-R_AliasClipTriangle (const finalvert_t *index0, const finalvert_t *index1, finalvert_t *index2)
+R_AliasClipTriangle(const entity_t *currententity, const finalvert_t *index0, const finalvert_t *index1, finalvert_t *index2)
 {
 	int				i, k, pingpong;
 	unsigned		clipflags;
@@ -304,6 +304,6 @@ R_AliasClipTriangle (const finalvert_t *index0, const finalvert_t *index1, final
 	// draw triangles
 	for (i=1 ; i<k-1 ; i++)
 	{
-		R_DrawTriangle(&fv[pingpong][0], &fv[pingpong][i], &fv[pingpong][i+1]);
+		R_DrawTriangle(currententity, &fv[pingpong][0], &fv[pingpong][i], &fv[pingpong][i+1]);
 	}
 }

--- a/src/client/refresh/soft/sw_alias.c
+++ b/src/client/refresh/soft/sw_alias.c
@@ -482,7 +482,7 @@ R_AliasSetupSkin
 ===============
 */
 static qboolean
-R_AliasSetupSkin(const entity_t *currententity)
+R_AliasSetupSkin(const entity_t *currententity, const model_t *currentmodel)
 {
 	image_t *pskindesc;
 
@@ -616,7 +616,7 @@ R_AliasSetupFrames
 =================
 */
 static void
-R_AliasSetupFrames(const entity_t *currententity, dmdl_t *pmdl)
+R_AliasSetupFrames(const entity_t *currententity, const model_t *currentmodel, dmdl_t *pmdl)
 {
 	int thisframe = currententity->frame;
 	int lastframe = currententity->oldframe;
@@ -701,7 +701,7 @@ R_AliasDrawModel
 ================
 */
 void
-R_AliasDrawModel(entity_t *currententity)
+R_AliasDrawModel(entity_t *currententity, const model_t *currentmodel)
 {
 	s_pmdl = (dmdl_t *)currentmodel->extradata;
 
@@ -730,7 +730,7 @@ R_AliasDrawModel(entity_t *currententity)
 	** we have to set our frame pointers and transformations before
 	** doing any real work
 	*/
-	R_AliasSetupFrames(currententity, s_pmdl);
+	R_AliasSetupFrames(currententity, currentmodel, s_pmdl);
 	R_AliasSetUpTransform(currententity);
 
 	// see if the bounding box lets us trivially reject, also sets
@@ -746,7 +746,7 @@ R_AliasDrawModel(entity_t *currententity)
 	}
 
 	// set up the skin and verify it exists
-	if ( !R_AliasSetupSkin(currententity) )
+	if ( !R_AliasSetupSkin(currententity, currentmodel) )
 	{
 		R_Printf( PRINT_ALL, "R_AliasDrawModel %s: NULL skin found\n",
 			currentmodel->name);

--- a/src/client/refresh/soft/sw_alias.c
+++ b/src/client/refresh/soft/sw_alias.c
@@ -330,6 +330,7 @@ R_AliasSetUpTransform(const entity_t *currententity)
 	// TODO: should use a look-up table
 	// TODO: could cache lazily, stored in the entity
 	//
+	// AngleVectors never change angles, we can convert from const
 	AngleVectors((float *)currententity->angles, s_alias_forward, s_alias_right, s_alias_up );
 
 	// TODO: can do this with simple matrix rearrangement

--- a/src/client/refresh/soft/sw_alias.c
+++ b/src/client/refresh/soft/sw_alias.c
@@ -59,7 +59,7 @@ static const float	r_avertexnormals[NUMVERTEXNORMALS][3] = {
 
 
 static void R_AliasTransformVector(const vec3_t in, vec3_t out, const float m[3][4]);
-static void R_AliasTransformFinalVerts(int numpoints, finalvert_t *fv, dtrivertx_t *oldv, dtrivertx_t *newv );
+static void R_AliasTransformFinalVerts(const entity_t *currententity, int numpoints, finalvert_t *fv, dtrivertx_t *oldv, dtrivertx_t *newv );
 
 void R_AliasProjectAndClipTestFinalVert(finalvert_t *fv);
 
@@ -170,7 +170,7 @@ R_AliasCheckFrameBBox( daliasframe_t *frame, float worldxf[3][4] )
 }
 
 static int
-R_AliasCheckBBox (void)
+R_AliasCheckBBox (const entity_t *currententity)
 {
 	unsigned long ccodes[2] = { 0, 0 };
 
@@ -223,7 +223,7 @@ General clipped case
 */
 
 static void
-R_AliasPreparePoints (finalvert_t *verts, const finalvert_t *verts_max)
+R_AliasPreparePoints (const entity_t *currententity, finalvert_t *verts, const finalvert_t *verts_max)
 {
 	int		i;
 	dstvert_t	*pstverts;
@@ -236,10 +236,11 @@ R_AliasPreparePoints (finalvert_t *verts, const finalvert_t *verts_max)
 		return;
 	}
 
-	R_AliasTransformFinalVerts( s_pmdl->num_xyz,
-		                    verts,	// destination for transformed verts
-				    r_lastframe->verts,	// verts from the last frame
-				    r_thisframe->verts	// verts from this frame
+	R_AliasTransformFinalVerts(currententity,
+				   s_pmdl->num_xyz,
+				   verts,	// destination for transformed verts
+				   r_lastframe->verts,	// verts from the last frame
+				   r_thisframe->verts	// verts from this frame
 				);
 
 	// clip and draw all triangles
@@ -271,11 +272,11 @@ R_AliasPreparePoints (finalvert_t *verts, const finalvert_t *verts_max)
 			if ( ! (pfv[0]->flags | pfv[1]->flags | pfv[2]->flags) )
 			{
 				// totally unclipped
-				R_DrawTriangle(pfv[2], pfv[1], pfv[0]);
+				R_DrawTriangle(currententity, pfv[2], pfv[1], pfv[0]);
 			}
 			else
 			{
-				R_AliasClipTriangle (pfv[2], pfv[1], pfv[0]);
+				R_AliasClipTriangle(currententity, pfv[2], pfv[1], pfv[0]);
 			}
 		}
 	}
@@ -303,11 +304,11 @@ R_AliasPreparePoints (finalvert_t *verts, const finalvert_t *verts_max)
 			if ( ! (pfv[0]->flags | pfv[1]->flags | pfv[2]->flags) )
 			{
 				// totally unclipped
-				R_DrawTriangle(pfv[0], pfv[1], pfv[2]);
+				R_DrawTriangle(currententity, pfv[0], pfv[1], pfv[2]);
 			}
 			else
 			{	// partially clipped
-				R_AliasClipTriangle (pfv[0], pfv[1], pfv[2]);
+				R_AliasClipTriangle(currententity, pfv[0], pfv[1], pfv[2]);
 			}
 		}
 	}
@@ -320,20 +321,16 @@ R_AliasSetUpTransform
 ================
 */
 static void
-R_AliasSetUpTransform (void)
+R_AliasSetUpTransform(const entity_t *currententity)
 {
 	int				i;
 	static float	viewmatrix[3][4];
-	vec3_t			angles;
 
 	// TODO: should really be stored with the entity instead of being reconstructed
 	// TODO: should use a look-up table
 	// TODO: could cache lazily, stored in the entity
 	//
-	angles[ROLL] = currententity->angles[ROLL];
-	angles[PITCH] = currententity->angles[PITCH];
-	angles[YAW] = currententity->angles[YAW];
-	AngleVectors( angles, s_alias_forward, s_alias_right, s_alias_up );
+	AngleVectors((float *)currententity->angles, s_alias_forward, s_alias_right, s_alias_up );
 
 	// TODO: can do this with simple matrix rearrangement
 	memset( aliasworldtransform, 0, sizeof( aliasworldtransform ) );
@@ -389,7 +386,7 @@ R_AliasTransformFinalVerts
 ================
 */
 static void
-R_AliasTransformFinalVerts( int numpoints, finalvert_t *fv, dtrivertx_t *oldv, dtrivertx_t *newv )
+R_AliasTransformFinalVerts(const entity_t *currententity, int numpoints, finalvert_t *fv, dtrivertx_t *oldv, dtrivertx_t *newv )
 {
 	int i;
 
@@ -485,7 +482,7 @@ R_AliasSetupSkin
 ===============
 */
 static qboolean
-R_AliasSetupSkin (void)
+R_AliasSetupSkin(const entity_t *currententity)
 {
 	image_t *pskindesc;
 
@@ -527,7 +524,7 @@ R_AliasSetupLighting
 ================
 */
 static void
-R_AliasSetupLighting (void)
+R_AliasSetupLighting(entity_t *currententity)
 {
 	alight_t lighting;
 	float lightvec[3] = {-1, 0, 0};
@@ -542,7 +539,7 @@ R_AliasSetupLighting (void)
 	}
 	else
 	{
-		R_LightPoint (currententity->origin, light);
+		R_LightPoint (currententity, currententity->origin, light);
 	}
 
 	// save off light value for server to look at (BIG HACK!)
@@ -619,7 +616,7 @@ R_AliasSetupFrames
 =================
 */
 static void
-R_AliasSetupFrames( dmdl_t *pmdl )
+R_AliasSetupFrames(const entity_t *currententity, dmdl_t *pmdl)
 {
 	int thisframe = currententity->frame;
 	int lastframe = currententity->oldframe;
@@ -650,7 +647,7 @@ R_AliasSetupFrames( dmdl_t *pmdl )
 ** Precomputes lerp coefficients used for the whole frame.
 */
 static void
-R_AliasSetUpLerpData( dmdl_t *pmdl, float backlerp )
+R_AliasSetUpLerpData(entity_t *currententity, dmdl_t *pmdl, float backlerp)
 {
 	float	frontlerp;
 	vec3_t	translation, vectors[3];
@@ -691,21 +688,21 @@ R_AliasSetUpLerpData( dmdl_t *pmdl, float backlerp )
 
 finalvert_t *finalverts = NULL, *finalverts_max = NULL;
 
+extern void (*d_pdrawspans)(const entity_t *currententity, spanpackage_t *pspanpackage);
+void R_PolysetDrawSpans8_Opaque(const entity_t *currententity, spanpackage_t *pspanpackage);
+void R_PolysetDrawSpans8_33(const entity_t *currententity, spanpackage_t *pspanpackage);
+void R_PolysetDrawSpans8_66(const entity_t *currententity, spanpackage_t *pspanpackage);
+void R_PolysetDrawSpansConstant8_33(const entity_t *currententity, spanpackage_t *pspanpackage);
+void R_PolysetDrawSpansConstant8_66(const entity_t *currententity, spanpackage_t *pspanpackage);
+
 /*
 ================
 R_AliasDrawModel
 ================
 */
 void
-R_AliasDrawModel (void)
+R_AliasDrawModel(entity_t *currententity)
 {
-	extern void (*d_pdrawspans)(void *);
-	extern void R_PolysetDrawSpans8_Opaque( void * );
-	extern void R_PolysetDrawSpans8_33( void * );
-	extern void R_PolysetDrawSpans8_66( void * );
-	extern void R_PolysetDrawSpansConstant8_33( void * );
-	extern void R_PolysetDrawSpansConstant8_66( void * );
-
 	s_pmdl = (dmdl_t *)currentmodel->extradata;
 
 	if ( r_lerpmodels->value == 0 )
@@ -733,12 +730,12 @@ R_AliasDrawModel (void)
 	** we have to set our frame pointers and transformations before
 	** doing any real work
 	*/
-	R_AliasSetupFrames( s_pmdl );
-	R_AliasSetUpTransform();
+	R_AliasSetupFrames(currententity, s_pmdl);
+	R_AliasSetUpTransform(currententity);
 
 	// see if the bounding box lets us trivially reject, also sets
 	// trivial accept status
-	if ( R_AliasCheckBBox() == BBOX_TRIVIAL_REJECT )
+	if ( R_AliasCheckBBox(currententity) == BBOX_TRIVIAL_REJECT )
 	{
 		if ( currententity->flags & RF_WEAPONMODEL )
 		{
@@ -749,7 +746,7 @@ R_AliasDrawModel (void)
 	}
 
 	// set up the skin and verify it exists
-	if ( !R_AliasSetupSkin () )
+	if ( !R_AliasSetupSkin(currententity) )
 	{
 		R_Printf( PRINT_ALL, "R_AliasDrawModel %s: NULL skin found\n",
 			currentmodel->name);
@@ -759,7 +756,7 @@ R_AliasDrawModel (void)
 	}
 
 	r_amodels_drawn++;
-	R_AliasSetupLighting ();
+	R_AliasSetupLighting(currententity);
 
 	/*
 	** select the proper span routine based on translucency
@@ -843,14 +840,14 @@ R_AliasDrawModel (void)
 	/*
 	** compute this_frame and old_frame addresses
 	*/
-	R_AliasSetUpLerpData( s_pmdl, currententity->backlerp );
+	R_AliasSetUpLerpData(currententity, s_pmdl, currententity->backlerp);
 
 	if (currententity->flags & RF_DEPTHHACK)
 		s_ziscale = (float)0x8000 * (float)SHIFT16XYZ_MULT * 3.0;
 	else
 		s_ziscale = (float)0x8000 * (float)SHIFT16XYZ_MULT;
 
-	R_AliasPreparePoints (finalverts, finalverts_max);
+	R_AliasPreparePoints(currententity, finalverts, finalverts_max);
 
 	if ( currententity->flags & RF_WEAPONMODEL )
 	{

--- a/src/client/refresh/soft/sw_bsp.c
+++ b/src/client/refresh/soft/sw_bsp.c
@@ -24,7 +24,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //
 // current entity info
 //
-entity_t	*currententity;
 vec3_t		modelorg;	// modelorg is the viewpoint reletive to
 				// the currently rendering entity
 vec3_t		r_entorigin;	// the currently rendering entity in world
@@ -75,7 +74,7 @@ R_RotateBmodel
 ================
 */
 void
-R_RotateBmodel (void)
+R_RotateBmodel(const entity_t *currententity)
 {
 	float	angle, s, c, temp1[3][3], temp2[3][3], temp3[3][3];
 
@@ -157,7 +156,7 @@ Clip a bmodel poly down the world bsp tree
 ================
 */
 static void
-R_RecursiveClipBPoly (bedge_t *pedges, mnode_t *pnode, msurface_t *psurf)
+R_RecursiveClipBPoly(entity_t *currententity, bedge_t *pedges, mnode_t *pnode, msurface_t *psurf)
 {
 	bedge_t		*psideedges[2], *pnextedge, *ptedge;
 	int		i, side, lastside;
@@ -318,12 +317,12 @@ R_RecursiveClipBPoly (bedge_t *pedges, mnode_t *pnode, msurface_t *psurf)
 						}
 
 						r_currentbkey = ((mleaf_t *)pn)->key;
-						R_RenderBmodelFace (psideedges[i], psurf);
+						R_RenderBmodelFace(currententity, psideedges[i], psurf);
 					}
 				}
 				else
 				{
-					R_RecursiveClipBPoly (psideedges[i], pnode->children[i],
+					R_RecursiveClipBPoly(currententity, psideedges[i], pnode->children[i],
 									  psurf);
 				}
 			}
@@ -339,7 +338,7 @@ Bmodel crosses multiple leafs
 ================
 */
 void
-R_DrawSolidClippedSubmodelPolygons (model_t *pmodel, mnode_t *topnode)
+R_DrawSolidClippedSubmodelPolygons(entity_t *currententity, const model_t *pmodel, mnode_t *topnode)
 {
 	int			i, j, lindex;
 	vec_t		dot;
@@ -403,9 +402,9 @@ R_DrawSolidClippedSubmodelPolygons (model_t *pmodel, mnode_t *topnode)
 		pbedge[j-1].pnext = NULL; // mark end of edges
 
 		if ( !( psurf->texinfo->flags & ( SURF_TRANS66 | SURF_TRANS33 ) ) )
-			R_RecursiveClipBPoly (pbedge, topnode, psurf);
+			R_RecursiveClipBPoly(currententity, pbedge, topnode, psurf);
 		else
-			R_RenderBmodelFace( pbedge, psurf );
+			R_RenderBmodelFace(currententity, pbedge, psurf );
 	}
 }
 
@@ -418,7 +417,7 @@ All in one leaf
 ================
 */
 void
-R_DrawSubmodelPolygons (model_t *pmodel, int clipflags, mnode_t *topnode)
+R_DrawSubmodelPolygons(entity_t *currententity, const model_t *pmodel, int clipflags, mnode_t *topnode)
 {
 	int			i;
 	vec_t		dot;
@@ -444,7 +443,7 @@ R_DrawSubmodelPolygons (model_t *pmodel, int clipflags, mnode_t *topnode)
 			r_currentkey = ((mleaf_t *)topnode)->key;
 
 			// FIXME: use bounding-box-based frustum clipping info?
-			R_RenderFace (psurf, clipflags);
+			R_RenderFace(currententity, psurf, clipflags);
 		}
 	}
 }
@@ -458,7 +457,7 @@ R_RecursiveWorldNode
 ================
 */
 static void
-R_RecursiveWorldNode (mnode_t *node, int clipflags)
+R_RecursiveWorldNode (entity_t *currententity, mnode_t *node, int clipflags)
 {
 	int c;
 	vec3_t acceptpt, rejectpt;
@@ -571,7 +570,7 @@ R_RecursiveWorldNode (mnode_t *node, int clipflags)
 			side = 1;
 
 		// recurse down the children, front side first
-		R_RecursiveWorldNode (node->children[side], clipflags);
+		R_RecursiveWorldNode (currententity, node->children[side], clipflags);
 
 		// draw stuff
 		c = node->numsurfaces;
@@ -589,7 +588,7 @@ R_RecursiveWorldNode (mnode_t *node, int clipflags)
 					if ((surf->flags & SURF_PLANEBACK) &&
 						(surf->visframe == r_framecount))
 					{
-						R_RenderFace (surf, clipflags);
+						R_RenderFace (currententity, surf, clipflags);
 					}
 
 					surf++;
@@ -602,7 +601,7 @@ R_RecursiveWorldNode (mnode_t *node, int clipflags)
 					if (!(surf->flags & SURF_PLANEBACK) &&
 						(surf->visframe == r_framecount))
 					{
-						R_RenderFace (surf, clipflags);
+						R_RenderFace (currententity, surf, clipflags);
 					}
 
 					surf++;
@@ -614,11 +613,9 @@ R_RecursiveWorldNode (mnode_t *node, int clipflags)
 		}
 
 		// recurse down the back side
-		R_RecursiveWorldNode (node->children[!side], clipflags);
+		R_RecursiveWorldNode (currententity, node->children[!side], clipflags);
 	}
 }
-
-
 
 /*
 ================
@@ -638,11 +635,10 @@ R_RenderWorld (void)
 
 	// auto cycle the world frame for texture animation
 	r_worldentity.frame = (int)(r_newrefdef.time*2);
-	currententity = &r_worldentity;
 
 	VectorCopy (r_origin, modelorg);
 	currentmodel = r_worldmodel;
 	r_pcurrentvertbase = currentmodel->vertexes;
 
-	R_RecursiveWorldNode (currentmodel->nodes, ALIAS_XY_CLIP_MASK);
+	R_RecursiveWorldNode (&r_worldentity, currentmodel->nodes, ALIAS_XY_CLIP_MASK);
 }

--- a/src/client/refresh/soft/sw_bsp.c
+++ b/src/client/refresh/soft/sw_bsp.c
@@ -46,9 +46,6 @@ static bedge_t		bedges[MAX_BMODEL_EDGES];
 
 static mvertex_t	*pfrontenter, *pfrontexit;
 
-static qboolean		makeclippededge;
-
-
 //===========================================================================
 
 /*
@@ -164,7 +161,8 @@ R_RecursiveClipBPoly(entity_t *currententity, bedge_t *pedges, mnode_t *pnode, m
 	mplane_t	*splitplane, tplane;
 	mvertex_t	*pvert, *plastvert, *ptvert;
 	mnode_t		*pn;
-	int			area;
+	int		area;
+	qboolean	makeclippededge;
 
 	psideedges[0] = psideedges[1] = NULL;
 
@@ -252,13 +250,12 @@ R_RecursiveClipBPoly(entity_t *currententity, bedge_t *pedges, mnode_t *pnode, m
 			{
 				// entering for front, exiting for back
 				pfrontenter = ptvert;
-				makeclippededge = true;
 			}
 			else
 			{
 				pfrontexit = ptvert;
-				makeclippededge = true;
 			}
+			makeclippededge = true;
 		}
 		else
 		{

--- a/src/client/refresh/soft/sw_edge.c
+++ b/src/client/refresh/soft/sw_edge.c
@@ -738,7 +738,6 @@ static msurface_t		*pface;
 static surfcache_t		*pcurrentcache;
 static vec3_t			transformed_modelorg;
 static vec3_t			world_transformed_modelorg;
-static vec3_t			local_modelorg;
 
 /*
 =============
@@ -887,6 +886,7 @@ D_TurbulentSurf(surf_t *s)
 	if (s->insubmodel)
 	{
 		entity_t *currententity;
+		vec3_t local_modelorg;
 
 		// FIXME: we don't want to do all this for every polygon!
 		// TODO: store once at start of frame
@@ -979,6 +979,8 @@ D_SolidSurf (surf_t *s)
 
 	if (s->insubmodel)
 	{
+		vec3_t local_modelorg;
+
 		// FIXME: we don't want to do all this for every polygon!
 		// TODO: store once at start of frame
 		currententity = s->entity;

--- a/src/client/refresh/soft/sw_edge.c
+++ b/src/client/refresh/soft/sw_edge.c
@@ -55,10 +55,6 @@ static int	miplevel;
 
 float	scale_for_mip;
 
-// FIXME: should go away
-extern void	R_RotateBmodel (void);
-extern void	R_TransformFrustum (void);
-
 static void R_GenerateSpans (void);
 static void R_GenerateSpansBackward (void);
 
@@ -691,7 +687,7 @@ R_ScanEdges (surf_t *surface)
 
 		// flush the span list if we can't be sure we have enough spans left for
 		// the next scan
-		if (span_p > max_span_p)
+		if (span_p >= max_span_p)
 		{
 			// Draw stuff on screen
 			D_DrawSurfaces (surface);
@@ -877,7 +873,7 @@ D_TurbulentSurf
 =================
 */
 static void
-D_TurbulentSurf (surf_t *s)
+D_TurbulentSurf(surf_t *s)
 {
 	d_zistepu = s->d_zistepu;
 	d_zistepv = s->d_zistepv;
@@ -890,16 +886,17 @@ D_TurbulentSurf (surf_t *s)
 
 	if (s->insubmodel)
 	{
+		entity_t *currententity;
+
 		// FIXME: we don't want to do all this for every polygon!
 		// TODO: store once at start of frame
-		currententity = s->entity;	//FIXME: make this passed in to
-						// R_RotateBmodel ()
+		currententity = s->entity;
 		VectorSubtract (r_origin, currententity->origin,
 				local_modelorg);
 		TransformVector (local_modelorg, transformed_modelorg);
 
-		R_RotateBmodel ();	// FIXME: don't mess with the frustum,
-							// make entity passed in
+		R_RotateBmodel(currententity);	// FIXME: don't mess with the frustum,
+						// make entity passed in
 	}
 
 	D_CalcGradients (pface);
@@ -923,7 +920,6 @@ D_TurbulentSurf (surf_t *s)
 		// FIXME: we don't want to do this every time!
 		// TODO: speed up
 		//
-		currententity = NULL;	// &r_worldentity;
 		VectorCopy (world_transformed_modelorg,
 					transformed_modelorg);
 		VectorCopy (base_vpn, vpn);
@@ -975,6 +971,8 @@ Normal surface cached, texture mapped surface
 static void
 D_SolidSurf (surf_t *s)
 {
+	entity_t *currententity;
+
 	d_zistepu = s->d_zistepu;
 	d_zistepv = s->d_zistepv;
 	d_ziorigin = s->d_ziorigin;
@@ -983,12 +981,11 @@ D_SolidSurf (surf_t *s)
 	{
 		// FIXME: we don't want to do all this for every polygon!
 		// TODO: store once at start of frame
-		currententity = s->entity;	// FIXME: make this passed in to
-						// R_RotateBmodel ()
-		VectorSubtract (r_origin, currententity->origin, local_modelorg);
-		TransformVector (local_modelorg, transformed_modelorg);
+		currententity = s->entity;
+		VectorSubtract(r_origin, currententity->origin, local_modelorg);
+		TransformVector(local_modelorg, transformed_modelorg);
 
-		R_RotateBmodel ();	// FIXME: don't mess with the frustum,
+		R_RotateBmodel(currententity);	// FIXME: don't mess with the frustum,
 					// make entity passed in
 	}
 	else
@@ -998,7 +995,7 @@ D_SolidSurf (surf_t *s)
 	miplevel = D_MipLevelForScale(s->nearzi * scale_for_mip * pface->texinfo->mipadjust);
 
 	// FIXME: make this passed in to D_CacheSurface
-	pcurrentcache = D_CacheSurface (pface, miplevel);
+	pcurrentcache = D_CacheSurface (currententity, pface, miplevel);
 
 	cacheblock = (pixel_t *)pcurrentcache->data;
 	cachewidth = pcurrentcache->width;
@@ -1022,7 +1019,6 @@ D_SolidSurf (surf_t *s)
 		VectorCopy (base_vup, vup);
 		VectorCopy (base_vright, vright);
 		R_TransformFrustum ();
-		currententity = NULL;	//&r_worldentity;
 	}
 }
 
@@ -1068,8 +1064,6 @@ May be called more than once a frame if the surf list overflows (higher res)
 static void
 D_DrawSurfaces (surf_t *surface)
 {
-	// currententity = NULL;
-	// &r_worldentity;
 	VectorSubtract (r_origin, vec3_origin, modelorg);
 	TransformVector (modelorg, transformed_modelorg);
 	VectorCopy (transformed_modelorg, world_transformed_modelorg);
@@ -1098,7 +1092,6 @@ D_DrawSurfaces (surf_t *surface)
 	else
 		D_DrawflatSurfaces (surface);
 
-	currententity = NULL;	//&r_worldentity;
 	VectorSubtract (r_origin, vec3_origin, modelorg);
 	R_TransformFrustum ();
 }

--- a/src/client/refresh/soft/sw_light.c
+++ b/src/client/refresh/soft/sw_light.c
@@ -90,7 +90,7 @@ R_PushDlights
 =============
 */
 void
-R_PushDlights (model_t *model)
+R_PushDlights (const model_t *model)
 {
 	int		i;
 	dlight_t	*l;
@@ -217,7 +217,7 @@ R_LightPoint
 ===============
 */
 void
-R_LightPoint (vec3_t p, vec3_t color)
+R_LightPoint (const entity_t *currententity, vec3_t p, vec3_t color)
 {
 	vec3_t		end;
 	float		r;

--- a/src/client/refresh/soft/sw_main.c
+++ b/src/client/refresh/soft/sw_main.c
@@ -46,7 +46,6 @@ char		skyname[MAX_QPATH];
 vec3_t		skyaxis;
 
 refdef_t	r_newrefdef;
-model_t		*currentmodel;
 
 model_t		*r_worldmodel;
 
@@ -655,12 +654,12 @@ R_DrawEntitiesOnList (void)
 			modelorg[0] = -r_origin[0];
 			modelorg[1] = -r_origin[1];
 			modelorg[2] = -r_origin[2];
-			VectorCopy( vec3_origin, r_entorigin );
-			R_DrawBeam( currententity );
+			VectorCopy(vec3_origin, r_entorigin);
+			R_DrawBeam(currententity);
 		}
 		else
 		{
-			currentmodel = currententity->model;
+			const model_t *currentmodel = currententity->model;
 			if (!currentmodel)
 			{
 				R_DrawNullModel();
@@ -672,11 +671,11 @@ R_DrawEntitiesOnList (void)
 			switch (currentmodel->type)
 			{
 			case mod_sprite:
-				R_DrawSprite(currententity);
+				R_DrawSprite(currententity, currentmodel);
 				break;
 
 			case mod_alias:
-				R_AliasDrawModel(currententity);
+				R_AliasDrawModel(currententity, currentmodel);
 				break;
 
 			default:
@@ -705,7 +704,7 @@ R_DrawEntitiesOnList (void)
 		}
 		else
 		{
-			currentmodel = currententity->model;
+			const model_t *currentmodel = currententity->model;
 			if (!currentmodel)
 			{
 				R_DrawNullModel();
@@ -717,11 +716,11 @@ R_DrawEntitiesOnList (void)
 			switch (currentmodel->type)
 			{
 			case mod_sprite:
-				R_DrawSprite(currententity);
+				R_DrawSprite(currententity, currentmodel);
 				break;
 
 			case mod_alias:
-				R_AliasDrawModel(currententity);
+				R_AliasDrawModel(currententity, currentmodel);
 				break;
 
 			default:
@@ -909,7 +908,7 @@ R_DrawBEntitiesOnList (void)
 	for (i=0 ; i<r_newrefdef.num_entities ; i++)
 	{
 		entity_t *currententity = &r_newrefdef.entities[i];
-		currentmodel = currententity->model;
+		const model_t *currentmodel = currententity->model;
 		if (!currentmodel)
 			continue;
 		if (currentmodel->nummodelsurfaces == 0)

--- a/src/client/refresh/soft/sw_main.c
+++ b/src/client/refresh/soft/sw_main.c
@@ -642,7 +642,7 @@ R_DrawEntitiesOnList (void)
 	// all bmodels have already been drawn by the edge list
 	for (i=0 ; i<r_newrefdef.num_entities ; i++)
 	{
-		currententity = &r_newrefdef.entities[i];
+		entity_t *currententity = &r_newrefdef.entities[i];
 
 		if ( currententity->flags & RF_TRANSLUCENT )
 		{
@@ -672,11 +672,11 @@ R_DrawEntitiesOnList (void)
 			switch (currentmodel->type)
 			{
 			case mod_sprite:
-				R_DrawSprite ();
+				R_DrawSprite(currententity);
 				break;
 
 			case mod_alias:
-				R_AliasDrawModel ();
+				R_AliasDrawModel(currententity);
 				break;
 
 			default:
@@ -690,7 +690,7 @@ R_DrawEntitiesOnList (void)
 
 	for (i=0 ; i<r_newrefdef.num_entities ; i++)
 	{
-		currententity = &r_newrefdef.entities[i];
+		entity_t *currententity = &r_newrefdef.entities[i];
 
 		if ( !( currententity->flags & RF_TRANSLUCENT ) )
 			continue;
@@ -717,11 +717,11 @@ R_DrawEntitiesOnList (void)
 			switch (currentmodel->type)
 			{
 			case mod_sprite:
-				R_DrawSprite ();
+				R_DrawSprite(currententity);
 				break;
 
 			case mod_alias:
-				R_AliasDrawModel ();
+				R_AliasDrawModel(currententity);
 				break;
 
 			default:
@@ -908,7 +908,7 @@ R_DrawBEntitiesOnList (void)
 
 	for (i=0 ; i<r_newrefdef.num_entities ; i++)
 	{
-		currententity = &r_newrefdef.entities[i];
+		entity_t *currententity = &r_newrefdef.entities[i];
 		currentmodel = currententity->model;
 		if (!currentmodel)
 			continue;
@@ -939,7 +939,7 @@ R_DrawBEntitiesOnList (void)
 		r_pcurrentvertbase = currentmodel->vertexes;
 
 		// FIXME: stop transforming twice
-		R_RotateBmodel ();
+		R_RotateBmodel(currententity);
 
 		// calculate dynamic lighting for bmodel
 		R_PushDlights (currentmodel);
@@ -948,14 +948,14 @@ R_DrawBEntitiesOnList (void)
 		{
 			// not a leaf; has to be clipped to the world BSP
 			r_clipflags = clipflags;
-			R_DrawSolidClippedSubmodelPolygons (currentmodel, topnode);
+			R_DrawSolidClippedSubmodelPolygons(currententity, currentmodel, topnode);
 		}
 		else
 		{
 			// falls entirely in one leaf, so we just put all the
 			// edges in the edge list and let 1/z sorting handle
 			// drawing order
-			R_DrawSubmodelPolygons (currentmodel, clipflags, topnode);
+			R_DrawSubmodelPolygons(currententity, currentmodel, clipflags, topnode);
 		}
 
 		// put back world rotation and frustum clipping
@@ -1079,7 +1079,7 @@ R_CalcPalette (void)
 //=======================================================================
 
 static void
-R_SetLightLevel (void)
+R_SetLightLevel (const entity_t *currententity)
 {
 	vec3_t		light;
 
@@ -1090,7 +1090,7 @@ R_SetLightLevel (void)
 	}
 
 	// save off light value for server to look at (BIG HACK!)
-	R_LightPoint (r_newrefdef.vieworg, light);
+	R_LightPoint (currententity, r_newrefdef.vieworg, light);
 	r_lightlevel->value = 150.0 * light[0];
 }
 
@@ -1151,10 +1151,10 @@ RE_RenderFrame (refdef_t *fd)
 		dp_time2 = SDL_GetTicks();
 
 	// Perform pixel palette blending ia the pics/colormap.pcx lower part lookup table.
-	R_DrawAlphaSurfaces();
+	R_DrawAlphaSurfaces(&r_worldentity);
 
 	// Save off light value for server to look at (BIG HACK!)
-	R_SetLightLevel ();
+	R_SetLightLevel (&r_worldentity);
 
 	if (r_dowarp)
 		D_WarpScreen ();

--- a/src/client/refresh/soft/sw_model.c
+++ b/src/client/refresh/soft/sw_model.c
@@ -26,13 +26,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 model_t	*loadmodel;
 
-static void Mod_LoadSpriteModel (model_t *mod, void *buffer);
-static void Mod_LoadBrushModel (model_t *mod, void *buffer);
-static void Mod_LoadAliasModel (model_t *mod, void *buffer);
+static void Mod_LoadSpriteModel(model_t *mod, void *buffer, int modfilelen);
+static void Mod_LoadBrushModel(model_t *mod, void *buffer, int modfilelen);
+static void Mod_LoadAliasModel(model_t *mod, void *buffer, int modfilelen);
 
 static byte	mod_novis[MAX_MAP_LEAFS/8];
 
-#define	MAX_MOD_KNOWN	256
+#define	MAX_MOD_KNOWN	512
 static model_t	mod_known[MAX_MOD_KNOWN];
 static int	mod_numknown;
 
@@ -40,7 +40,6 @@ static int	mod_numknown;
 static model_t	mod_inline[MAX_MOD_KNOWN];
 
 int	registration_sequence;
-static int	modfilelen;
 
 //===============================================================================
 
@@ -100,7 +99,7 @@ Mod_ForName (char *name, qboolean crash)
 {
 	model_t	*mod;
 	unsigned *buf;
-	int		i;
+	int	i, modfilelen;
 
 	if (!name[0])
 		ri.Sys_Error (ERR_DROP,"Mod_ForName: NULL name");
@@ -162,28 +161,25 @@ Mod_ForName (char *name, qboolean crash)
 	switch (LittleLong(*(unsigned *)buf))
 	{
 	case IDALIASHEADER:
-		loadmodel->extradata = Hunk_Begin (0x200000);
-		Mod_LoadAliasModel (mod, buf);
+		Mod_LoadAliasModel(mod, buf, modfilelen);
 		break;
 
 	case IDSPRITEHEADER:
-		loadmodel->extradata = Hunk_Begin (0x10000);
-		Mod_LoadSpriteModel (mod, buf);
+		Mod_LoadSpriteModel(mod, buf, modfilelen);
 		break;
 
 	case IDBSPHEADER:
-		loadmodel->extradata = Hunk_Begin (0x2000000);
-		Mod_LoadBrushModel (mod, buf);
+		Mod_LoadBrushModel(mod, buf, modfilelen);
 		break;
 
 	default:
-		ri.Sys_Error (ERR_DROP,"Mod_NumForName: unknown fileid for %s", mod->name);
+		ri.Sys_Error(ERR_DROP,"Mod_NumForName: unknown fileid for %s", mod->name);
 		break;
 	}
 
-	loadmodel->extradatasize = Hunk_End ();
+	loadmodel->extradatasize = Hunk_End();
 
-	ri.FS_FreeFile (buf);
+	ri.FS_FreeFile(buf);
 
 	return mod;
 }
@@ -266,7 +262,7 @@ Mod_LoadLighting (lump_t *l)
 		return;
 	}
 	size = l->filelen/3;
-	loadmodel->lightdata = Hunk_Alloc (size);
+	loadmodel->lightdata = Hunk_Alloc(size);
 	in = (void *)(mod_base + l->fileofs);
 	for (i=0 ; i<size ; i++, in+=3)
 	{
@@ -322,7 +318,7 @@ Mod_LoadVisibility (lump_t *l)
 		loadmodel->vis = NULL;
 		return;
 	}
-	loadmodel->vis = Hunk_Alloc ( l->filelen);
+	loadmodel->vis = Hunk_Alloc(l->filelen);
 	memcpy (loadmodel->vis, mod_base + l->fileofs, l->filelen);
 
 	loadmodel->vis->numclusters = LittleLong (loadmodel->vis->numclusters);
@@ -350,7 +346,7 @@ Mod_LoadVertexes (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	out = Hunk_Alloc ( (count+8)*sizeof(*out));		// extra for skybox
+	out = Hunk_Alloc((count+8)*sizeof(*out));		// extra for skybox
         /*
          * PATCH: eliasm
          *
@@ -387,7 +383,7 @@ Mod_LoadSubmodels (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	out = Hunk_Alloc ( count*sizeof(*out));
+	out = Hunk_Alloc(count*sizeof(*out));
 
 	loadmodel->submodels = out;
 	loadmodel->numsubmodels = count;
@@ -422,7 +418,7 @@ Mod_LoadEdges (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	out = Hunk_Alloc ( (count + 13) * sizeof(*out));	// extra for skybox
+	out = Hunk_Alloc((count + 13) * sizeof(*out));	// extra for skybox
 
 	loadmodel->edges = out;
 	loadmodel->numedges = count;
@@ -451,7 +447,7 @@ Mod_LoadTexinfo (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		ri.Sys_Error (ERR_DROP,"Mod_LoadTexinfo: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	out = Hunk_Alloc ( (count+6)*sizeof(*out));	// extra for skybox
+	out = Hunk_Alloc((count+6)*sizeof(*out));	// extra for skybox
 
 	loadmodel->texinfo = out;
 	loadmodel->numtexinfo = count;
@@ -588,7 +584,7 @@ Mod_LoadFaces (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	out = Hunk_Alloc ( (count+6)*sizeof(*out));	// extra for skybox
+	out = Hunk_Alloc((count+6)*sizeof(*out));	// extra for skybox
 
 	loadmodel->surfaces = out;
 	loadmodel->numsurfaces = count;
@@ -695,7 +691,7 @@ Mod_LoadNodes (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	out = Hunk_Alloc ( count*sizeof(*out));
+	out = Hunk_Alloc(count*sizeof(*out));
 
 	loadmodel->nodes = out;
 	loadmodel->numnodes = count;
@@ -746,7 +742,7 @@ Mod_LoadLeafs (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	out = Hunk_Alloc ( count*sizeof(*out));
+	out = Hunk_Alloc(count*sizeof(*out));
 
 	loadmodel->leafs = out;
 	loadmodel->numleafs = count;
@@ -794,7 +790,7 @@ Mod_LoadMarksurfaces (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	out = Hunk_Alloc ( count*sizeof(*out));
+	out = Hunk_Alloc(count*sizeof(*out));
 
 	loadmodel->marksurfaces = out;
 	loadmodel->nummarksurfaces = count;
@@ -824,7 +820,7 @@ Mod_LoadSurfedges (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	out = Hunk_Alloc ( (count+24)*sizeof(*out));	// extra for skybox
+	out = Hunk_Alloc((count+24)*sizeof(*out));	// extra for skybox
 
 	loadmodel->surfedges = out;
 	loadmodel->numsurfedges = count;
@@ -850,7 +846,7 @@ Mod_LoadPlanes (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	out = Hunk_Alloc ( (count+6)*sizeof(*out));		// extra for skybox
+	out = Hunk_Alloc((count+6)*sizeof(*out));		// extra for skybox
 
 	loadmodel->planes = out;
 	loadmodel->numplanes = count;
@@ -880,11 +876,15 @@ Mod_LoadBrushModel
 =================
 */
 static void
-Mod_LoadBrushModel (model_t *mod, void *buffer)
+Mod_LoadBrushModel(model_t *mod, void *buffer, int modfilelen)
 {
-	int			i;
+	int		i;
 	dheader_t	*header;
 	dmodel_t 	*bm;
+
+	// map use short indexes that we convert to pointers
+	// pointer size / 2 bytes
+	loadmodel->extradata = Hunk_Begin(modfilelen * sizeof(void*) / 2);
 
 	loadmodel->type = mod_brush;
 	if (loadmodel != mod_known)
@@ -960,14 +960,15 @@ Mod_LoadAliasModel
 =================
 */
 static void
-Mod_LoadAliasModel (model_t *mod, void *buffer)
+Mod_LoadAliasModel(model_t *mod, void *buffer, int modfilelen)
 {
-	int					i, j;
-	dmdl_t				*pinmodel, *pheader;
-	dstvert_t			*pinst, *poutst;
-	dtriangle_t			*pintri, *pouttri;
-	int					*pincmd, *poutcmd;
-	int					version;
+	int		i, j;
+	dmdl_t		*pinmodel, *pheader;
+	dstvert_t	*pinst, *poutst;
+	dtriangle_t	*pintri, *pouttri;
+	int		*pincmd, *poutcmd;
+	int		version;
+	int		ofs_end;
 
 	pinmodel = (dmdl_t *)buffer;
 
@@ -976,7 +977,13 @@ Mod_LoadAliasModel (model_t *mod, void *buffer)
 		ri.Sys_Error (ERR_DROP, "%s has wrong version number (%i should be %i)",
 				 mod->name, version, ALIAS_VERSION);
 
-	pheader = Hunk_Alloc (LittleLong(pinmodel->ofs_end));
+	ofs_end = LittleLong(pinmodel->ofs_end);
+	if (ofs_end < 0 || ofs_end > modfilelen)
+		ri.Sys_Error (ERR_DROP, "model %s file size(%d) too small, should be %d", mod->name,
+				   modfilelen, ofs_end);
+
+	mod->extradata = Hunk_Begin(modfilelen);
+	pheader = Hunk_Alloc(ofs_end);
 
 	// byte swap the header fields and sanity check
 	for (i=0 ; i<sizeof(dmdl_t)/4 ; i++)
@@ -1086,13 +1093,14 @@ Mod_LoadSpriteModel
 =================
 */
 static void
-Mod_LoadSpriteModel (model_t *mod, void *buffer)
+Mod_LoadSpriteModel(model_t *mod, void *buffer, int modfilelen)
 {
 	dsprite_t	*sprin, *sprout;
 	int			i;
 
 	sprin = (dsprite_t *)buffer;
-	sprout = Hunk_Alloc (modfilelen);
+	mod->extradata = Hunk_Begin(modfilelen);
+	sprout = Hunk_Alloc(modfilelen);
 
 	sprout->ident = LittleLong (sprin->ident);
 	sprout->version = LittleLong (sprin->version);

--- a/src/client/refresh/soft/sw_model.c
+++ b/src/client/refresh/soft/sw_model.c
@@ -172,7 +172,7 @@ Mod_ForName (char *name, qboolean crash)
 		break;
 
 	case IDBSPHEADER:
-		loadmodel->extradata = Hunk_Begin (0x1000000);
+		loadmodel->extradata = Hunk_Begin (0x2000000);
 		Mod_LoadBrushModel (mod, buf);
 		break;
 
@@ -753,6 +753,8 @@ Mod_LoadLeafs (lump_t *l)
 
 	for ( i=0 ; i<count ; i++, in++, out++)
 	{
+		unsigned firstleafface;
+
 		for (j=0 ; j<3 ; j++)
 		{
 			out->minmaxs[j] = LittleShort (in->mins[j]);
@@ -763,9 +765,15 @@ Mod_LoadLeafs (lump_t *l)
 		out->cluster = LittleShort(in->cluster);
 		out->area = LittleShort(in->area);
 
-		out->firstmarksurface = loadmodel->marksurfaces +
-			LittleShort(in->firstleafface);
-		out->nummarksurfaces = LittleShort(in->numleaffaces);
+		// make unsigned long from signed short
+		firstleafface = LittleShort(in->firstleafface) & 0xFFFF;
+		out->nummarksurfaces = LittleShort(in->numleaffaces) & 0xFFFF;
+
+		out->firstmarksurface = loadmodel->marksurfaces + firstleafface;
+		if ((firstleafface + out->nummarksurfaces) > loadmodel->nummarksurfaces)
+		{
+			ri.Sys_Error (ERR_DROP,"MOD_LoadBmodel: wrong marksurfaces position in %s",loadmodel->name);
+		}
 	}
 }
 

--- a/src/client/refresh/soft/sw_poly.c
+++ b/src/client/refresh/soft/sw_poly.c
@@ -1026,9 +1026,9 @@ R_ClipAndDrawPoly ( float alpha, int isturbulent, qboolean textured )
 ** R_BuildPolygonFromSurface
 */
 static void
-R_BuildPolygonFromSurface(const entity_t *currententity, msurface_t *fa)
+R_BuildPolygonFromSurface(const entity_t *currententity, const model_t *currentmodel, msurface_t *fa)
 {
-	int			i, lnumverts;
+	int		i, lnumverts;
 	medge_t		*pedges, *r_pedge;
 	float		*vec;
 	vec5_t     *pverts;
@@ -1213,8 +1213,7 @@ void
 R_DrawAlphaSurfaces(const entity_t *currententity)
 {
 	msurface_t *s = r_alpha_surfaces;
-
-	currentmodel = r_worldmodel;
+	const model_t *currentmodel = r_worldmodel;
 
 	modelorg[0] = -r_origin[0];
 	modelorg[1] = -r_origin[1];
@@ -1222,7 +1221,7 @@ R_DrawAlphaSurfaces(const entity_t *currententity)
 
 	while ( s )
 	{
-		R_BuildPolygonFromSurface(currententity, s);
+		R_BuildPolygonFromSurface(currententity, currentmodel, s);
 
 		//=======
 		//PGM

--- a/src/client/refresh/soft/sw_poly.c
+++ b/src/client/refresh/soft/sw_poly.c
@@ -1026,7 +1026,7 @@ R_ClipAndDrawPoly ( float alpha, int isturbulent, qboolean textured )
 ** R_BuildPolygonFromSurface
 */
 static void
-R_BuildPolygonFromSurface(msurface_t *fa)
+R_BuildPolygonFromSurface(const entity_t *currententity, msurface_t *fa)
 {
 	int			i, lnumverts;
 	medge_t		*pedges, *r_pedge;
@@ -1084,7 +1084,7 @@ R_BuildPolygonFromSurface(msurface_t *fa)
 	{
 		surfcache_t *scache;
 
-		scache = D_CacheSurface( fa, 0 );
+		scache = D_CacheSurface(currententity, fa, 0);
 
 		r_polydesc.pixels       = scache->data;
 		r_polydesc.pixel_width  = scache->width;
@@ -1210,7 +1210,7 @@ R_DrawPoly(int iswater)
 ** R_DrawAlphaSurfaces
 */
 void
-R_DrawAlphaSurfaces(void)
+R_DrawAlphaSurfaces(const entity_t *currententity)
 {
 	msurface_t *s = r_alpha_surfaces;
 
@@ -1222,7 +1222,7 @@ R_DrawAlphaSurfaces(void)
 
 	while ( s )
 	{
-		R_BuildPolygonFromSurface( s );
+		R_BuildPolygonFromSurface(currententity, s);
 
 		//=======
 		//PGM

--- a/src/client/refresh/soft/sw_polyse.c
+++ b/src/client/refresh/soft/sw_polyse.c
@@ -94,15 +94,15 @@ static byte	*skintable[MAX_LBM_HEIGHT];
 int		skinwidth;
 static byte	*skinstart;
 
-void	(*d_pdrawspans)(spanpackage_t *pspanpackage);
+void	(*d_pdrawspans)(const entity_t *currententity, spanpackage_t *pspanpackage);
 
-void R_PolysetDrawSpans8_33 (spanpackage_t *pspanpackage);
-void R_PolysetDrawSpans8_66 (spanpackage_t *pspanpackage);
-void R_PolysetDrawSpans8_Opaque (spanpackage_t *pspanpackage);
+void R_PolysetDrawSpans8_33 (const entity_t *currententity, spanpackage_t *pspanpackage);
+void R_PolysetDrawSpans8_66 (const entity_t *currententity, spanpackage_t *pspanpackage);
+void R_PolysetDrawSpans8_Opaque (const entity_t *currententity, spanpackage_t *pspanpackage);
 
 static void R_PolysetCalcGradients (int skinwidth);
 static void R_PolysetSetEdgeTable (void);
-static void R_RasterizeAliasPolySmooth (void);
+static void R_RasterizeAliasPolySmooth(const entity_t *currententity);
 static void R_PolysetScanLeftEdge_C(int height);
 
 // ======================
@@ -181,7 +181,7 @@ R_DrawTriangle
 ================
 */
 void
-R_DrawTriangle(const finalvert_t *a, const finalvert_t *b, const finalvert_t *c)
+R_DrawTriangle(const entity_t *currententity, const finalvert_t *a, const finalvert_t *b, const finalvert_t *c)
 {
 	int dv1_ab, dv0_ac;
 	int dv0_ab, dv1_ac;
@@ -229,7 +229,7 @@ R_DrawTriangle(const finalvert_t *a, const finalvert_t *b, const finalvert_t *c)
 		r_p2[5] = c->zi;
 
 		R_PolysetSetEdgeTable ();
-		R_RasterizeAliasPolySmooth ();
+		R_RasterizeAliasPolySmooth(currententity);
 	}
 }
 
@@ -462,7 +462,7 @@ R_PolysetDrawSpans8
 ================
 */
 void
-R_PolysetDrawSpans8_33( spanpackage_t *pspanpackage)
+R_PolysetDrawSpans8_33(const entity_t *currententity, spanpackage_t *pspanpackage)
 {
 	byte		*lpdest;
 	byte		*lptex;
@@ -528,7 +528,7 @@ R_PolysetDrawSpans8_33( spanpackage_t *pspanpackage)
 }
 
 void
-R_PolysetDrawSpansConstant8_33( spanpackage_t *pspanpackage)
+R_PolysetDrawSpansConstant8_33(const entity_t *currententity, spanpackage_t *pspanpackage)
 {
 	pixel_t		*lpdest;
 	int		lzi;
@@ -574,7 +574,7 @@ R_PolysetDrawSpansConstant8_33( spanpackage_t *pspanpackage)
 }
 
 void
-R_PolysetDrawSpans8_66(spanpackage_t *pspanpackage)
+R_PolysetDrawSpans8_66(const entity_t *currententity, spanpackage_t *pspanpackage)
 {
 	pixel_t		*lpdest;
 	pixel_t		*lptex;
@@ -641,7 +641,7 @@ R_PolysetDrawSpans8_66(spanpackage_t *pspanpackage)
 }
 
 void
-R_PolysetDrawSpansConstant8_66( spanpackage_t *pspanpackage)
+R_PolysetDrawSpansConstant8_66(const entity_t *currententity, spanpackage_t *pspanpackage)
 {
 	pixel_t		*lpdest;
 	zvalue_t	lzi;
@@ -687,7 +687,7 @@ R_PolysetDrawSpansConstant8_66( spanpackage_t *pspanpackage)
 }
 
 void
-R_PolysetDrawSpans8_Opaque (spanpackage_t *pspanpackage)
+R_PolysetDrawSpans8_Opaque (const entity_t *currententity, spanpackage_t *pspanpackage)
 {
 	do
 	{
@@ -762,7 +762,7 @@ R_RasterizeAliasPolySmooth
 ================
 */
 static void
-R_RasterizeAliasPolySmooth (void)
+R_RasterizeAliasPolySmooth(const entity_t *currententity)
 {
 	int	initialleftheight, initialrightheight;
 	int	*plefttop, *prighttop, *pleftbottom, *prightbottom;
@@ -949,7 +949,7 @@ R_RasterizeAliasPolySmooth (void)
 	}
 	originalcount = triangle_spans[initialrightheight].count;
 	triangle_spans[initialrightheight].count = -999999; // mark end of the spanpackages
-	(*d_pdrawspans) (triangle_spans);
+	(*d_pdrawspans) (currententity, triangle_spans);
 
 	// scan out the bottom part of the right edge, if it exists
 	if (pedgetable->numrightedges == 2)
@@ -979,7 +979,7 @@ R_RasterizeAliasPolySmooth (void)
 			return;
 		}
 		triangle_spans[initialrightheight + height].count = -999999; // mark end of the spanpackages
-		(*d_pdrawspans) (pstart);
+		(*d_pdrawspans) (currententity, pstart);
 	}
 }
 

--- a/src/client/refresh/soft/sw_polyse.c
+++ b/src/client/refresh/soft/sw_polyse.c
@@ -63,23 +63,19 @@ static edgetable edgetables[12] = {
 static int	a_sstepxfrac, a_tstepxfrac, r_lstepx, a_ststepxwhole;
 static int	r_sstepx, r_tstepx, r_lstepy, r_sstepy, r_tstepy;
 static zvalue_t	r_zistepx, r_zistepy;
-static int	d_aspancount, d_countextrastep;
+static int	d_aspancount;
 
 static spanpackage_t	*d_pedgespanpackage;
 
 spanpackage_t	*triangle_spans, *triangles_max;
 
-static int	ystart;
-static pixel_t	*d_pdest, *d_ptex;
-static zvalue_t	*d_pz;
 static int	d_sfrac, d_tfrac, d_light;
 static zvalue_t	d_zi;
 static int	d_ptexextrastep, d_sfracextrastep;
-static int	d_tfracextrastep, d_lightextrastep, d_pdestextrastep;
-static int	d_lightbasestep, d_pdestbasestep, d_ptexbasestep;
+static int	d_tfracextrastep, d_lightextrastep;
+static int	d_lightbasestep, d_ptexbasestep;
 static int	d_sfracbasestep, d_tfracbasestep;
 static zvalue_t	d_ziextrastep, d_zibasestep;
-static zvalue_t	d_pzextrastep, d_pzbasestep;
 
 typedef struct {
 	int		quotient;
@@ -96,14 +92,8 @@ static byte	*skinstart;
 
 void	(*d_pdrawspans)(const entity_t *currententity, spanpackage_t *pspanpackage);
 
-void R_PolysetDrawSpans8_33 (const entity_t *currententity, spanpackage_t *pspanpackage);
-void R_PolysetDrawSpans8_66 (const entity_t *currententity, spanpackage_t *pspanpackage);
-void R_PolysetDrawSpans8_Opaque (const entity_t *currententity, spanpackage_t *pspanpackage);
-
-static void R_PolysetCalcGradients (int skinwidth);
-static void R_PolysetSetEdgeTable (void);
+static void R_PolysetSetEdgeTable(void);
 static void R_RasterizeAliasPolySmooth(const entity_t *currententity);
-static void R_PolysetScanLeftEdge_C(int height);
 
 // ======================
 // PGM
@@ -234,7 +224,8 @@ R_DrawTriangle(const entity_t *currententity, const finalvert_t *a, const finalv
 }
 
 static void
-R_PushEdgesSpan()
+R_PushEdgesSpan(int u, int v, int count,
+		pixel_t* d_ptex, int d_sfrac, int d_tfrac, int d_light, zvalue_t d_zi)
 {
 	if (d_pedgespanpackage >= triangles_max)
 	{
@@ -243,9 +234,9 @@ R_PushEdgesSpan()
 		return;
 	}
 
-	d_pedgespanpackage->pdest = d_pdest;
-	d_pedgespanpackage->pz = d_pz;
-	d_pedgespanpackage->count = d_aspancount;
+	d_pedgespanpackage->u = u;
+	d_pedgespanpackage->v = v;
+	d_pedgespanpackage->count = count;
 	d_pedgespanpackage->ptex = d_ptex;
 
 	d_pedgespanpackage->sfrac = d_sfrac;
@@ -264,18 +255,24 @@ R_PolysetScanLeftEdge_C
 ====================
 */
 static void
-R_PolysetScanLeftEdge_C(int height)
+R_PolysetScanLeftEdge_C(int height, pixel_t *d_ptex, int u, int v)
 {
 	do
 	{
-		R_PushEdgesSpan();
+		R_PushEdgesSpan(u, v, d_aspancount,
+				d_ptex, d_sfrac, d_tfrac, d_light, d_zi);
+
+		v ++;
+		u += ubasestep;
+		d_aspancount += ubasestep;
 
 		errorterm += erroradjustup;
 		if (errorterm >= 0)
 		{
-			d_pdest += d_pdestextrastep;
-			d_pz += d_pzextrastep;
-			d_aspancount += d_countextrastep;
+			// addtional step for compensate error
+			u ++;
+			d_aspancount ++;
+
 			d_ptex += d_ptexextrastep;
 			d_sfrac += d_sfracextrastep;
 			d_ptex += d_sfrac >> SHIFT16XYZ;
@@ -293,9 +290,6 @@ R_PolysetScanLeftEdge_C(int height)
 		}
 		else
 		{
-			d_pdest += d_pdestbasestep;
-			d_pz += d_pzbasestep;
-			d_aspancount += ubasestep;
 			d_ptex += d_ptexbasestep;
 			d_sfrac += d_sfracbasestep;
 			d_ptex += d_sfrac >> SHIFT16XYZ;
@@ -478,21 +472,22 @@ R_PolysetDrawSpans8_33(const entity_t *currententity, spanpackage_t *pspanpackag
 		lcount = d_aspancount - pspanpackage->count;
 
 		errorterm += erroradjustup;
+		d_aspancount += ubasestep;
+
 		if (errorterm >= 0)
 		{
-			d_aspancount += d_countextrastep;
+			// addtional step for compensate error
+			d_aspancount ++;
 			errorterm -= erroradjustdown;
-		}
-		else
-		{
-			d_aspancount += ubasestep;
 		}
 
 		if (lcount)
 		{
-			lpdest = pspanpackage->pdest;
+			int	pos_shift = (pspanpackage->v * vid.width) + pspanpackage->u;
+
+			lpdest = d_viewbuffer + pos_shift;
+			lpz = d_pzbuffer + pos_shift;
 			lptex = pspanpackage->ptex;
-			lpz = pspanpackage->pz;
 			lsfrac = pspanpackage->sfrac;
 			ltfrac = pspanpackage->tfrac;
 			llight = pspanpackage->light;
@@ -541,20 +536,21 @@ R_PolysetDrawSpansConstant8_33(const entity_t *currententity, spanpackage_t *psp
 		lcount = d_aspancount - pspanpackage->count;
 
 		errorterm += erroradjustup;
+		d_aspancount += ubasestep;
+
 		if (errorterm >= 0)
 		{
-			d_aspancount += d_countextrastep;
+			// addtional step for compensate error
+			d_aspancount ++;
 			errorterm -= erroradjustdown;
-		}
-		else
-		{
-			d_aspancount += ubasestep;
 		}
 
 		if (lcount)
 		{
-			lpdest = pspanpackage->pdest;
-			lpz = pspanpackage->pz;
+			int	pos_shift = (pspanpackage->v * vid.width) + pspanpackage->u;
+
+			lpdest = d_viewbuffer + pos_shift;
+			lpz = d_pzbuffer + pos_shift;
 			lzi = pspanpackage->zi;
 
 			do
@@ -590,21 +586,22 @@ R_PolysetDrawSpans8_66(const entity_t *currententity, spanpackage_t *pspanpackag
 		lcount = d_aspancount - pspanpackage->count;
 
 		errorterm += erroradjustup;
+		d_aspancount += ubasestep;
+
 		if (errorterm >= 0)
 		{
-			d_aspancount += d_countextrastep;
+			// addtional step for compensate error
+			d_aspancount ++;
 			errorterm -= erroradjustdown;
-		}
-		else
-		{
-			d_aspancount += ubasestep;
 		}
 
 		if (lcount)
 		{
-			lpdest = pspanpackage->pdest;
+			int	pos_shift = (pspanpackage->v * vid.width) + pspanpackage->u;
+
+			lpdest = d_viewbuffer + pos_shift;
+			lpz = d_pzbuffer + pos_shift;
 			lptex = pspanpackage->ptex;
-			lpz = pspanpackage->pz;
 			lsfrac = pspanpackage->sfrac;
 			ltfrac = pspanpackage->tfrac;
 			llight = pspanpackage->light;
@@ -654,20 +651,21 @@ R_PolysetDrawSpansConstant8_66(const entity_t *currententity, spanpackage_t *psp
 		lcount = d_aspancount - pspanpackage->count;
 
 		errorterm += erroradjustup;
+		d_aspancount += ubasestep;
+
 		if (errorterm >= 0)
 		{
-			d_aspancount += d_countextrastep;
+			// addtional step for compensate error
+			d_aspancount ++;
 			errorterm -= erroradjustdown;
-		}
-		else
-		{
-			d_aspancount += ubasestep;
 		}
 
 		if (lcount)
 		{
-			lpdest = pspanpackage->pdest;
-			lpz = pspanpackage->pz;
+			int	pos_shift = (pspanpackage->v * vid.width) + pspanpackage->u;
+
+			lpdest = d_viewbuffer + pos_shift;
+			lpz = d_pzbuffer + pos_shift;
 			lzi = pspanpackage->zi;
 
 			do
@@ -695,14 +693,13 @@ R_PolysetDrawSpans8_Opaque (const entity_t *currententity, spanpackage_t *pspanp
 
 		lcount = d_aspancount - pspanpackage->count;
 		errorterm += erroradjustup;
+		d_aspancount += ubasestep;
+
 		if (errorterm >= 0)
 		{
-			d_aspancount += d_countextrastep;
+			// addtional step for compensate error
+			d_aspancount ++;
 			errorterm -= erroradjustdown;
-		}
-		else
-		{
-			d_aspancount += ubasestep;
 		}
 
 		if (lcount)
@@ -713,10 +710,12 @@ R_PolysetDrawSpans8_Opaque (const entity_t *currententity, spanpackage_t *pspanp
 			int		llight;
 			zvalue_t	lzi;
 			zvalue_t	*lpz;
+			int		pos_shift = (pspanpackage->v * vid.width) + pspanpackage->u;
 
-			lpdest = pspanpackage->pdest;
+			lpdest = d_viewbuffer + pos_shift;
+			lpz = d_pzbuffer + pos_shift;
+
 			lptex = pspanpackage->ptex;
-			lpz = pspanpackage->pz;
 			lsfrac = pspanpackage->sfrac;
 			ltfrac = pspanpackage->tfrac;
 			llight = pspanpackage->light;
@@ -767,6 +766,8 @@ R_RasterizeAliasPolySmooth(const entity_t *currententity)
 	int	initialleftheight, initialrightheight;
 	int	*plefttop, *prighttop, *pleftbottom, *prightbottom;
 	int	working_lstepx, originalcount;
+	int	u, v;
+	pixel_t	*d_ptex;
 
 	plefttop = pedgetable->pleftedgevert0;
 	prighttop = pedgetable->prightedgevert0;
@@ -791,7 +792,8 @@ R_RasterizeAliasPolySmooth(const entity_t *currententity)
 	//
 	d_pedgespanpackage = triangle_spans;
 
-	ystart = plefttop[1];
+	u = plefttop[0];
+	v = plefttop[1];
 	d_aspancount = plefttop[0] - prighttop[0];
 
 	d_ptex = (byte *)r_affinetridesc.pskin + (plefttop[2] >> SHIFT16XYZ) +
@@ -803,24 +805,15 @@ R_RasterizeAliasPolySmooth(const entity_t *currententity)
 	d_light = plefttop[4];
 	d_zi = plefttop[5];
 
-	d_pdest = d_viewbuffer + ystart * vid.width + plefttop[0];
-	d_pz = d_pzbuffer + ystart * vid.width + plefttop[0];
-
 	if (initialleftheight == 1)
 	{
-		R_PushEdgesSpan();
+		R_PushEdgesSpan(u, v, d_aspancount,
+				d_ptex, d_sfrac, d_tfrac, d_light, d_zi);
 	}
 	else
 	{
 		R_PolysetSetUpForLineScan(plefttop[0], plefttop[1],
 					  pleftbottom[0], pleftbottom[1]);
-		{
-			d_pzbasestep = vid.width + ubasestep;
-			d_pzextrastep = d_pzbasestep + 1;
-		}
-
-		d_pdestbasestep = vid.width + ubasestep;
-		d_pdestextrastep = d_pdestbasestep + 1;
 
 		// TODO: can reuse partial expressions here
 
@@ -832,30 +825,27 @@ R_RasterizeAliasPolySmooth(const entity_t *currententity)
 		else
 			working_lstepx = r_lstepx;
 
-		d_countextrastep = ubasestep + 1;
 		d_ptexbasestep = ((r_sstepy + r_sstepx * ubasestep) >> SHIFT16XYZ) +
 				((r_tstepy + r_tstepx * ubasestep) >> SHIFT16XYZ) *
 				r_affinetridesc.skinwidth;
-		{
-			d_sfracbasestep = (r_sstepy + r_sstepx * ubasestep) & 0xFFFF;
-			d_tfracbasestep = (r_tstepy + r_tstepx * ubasestep) & 0xFFFF;
-		}
+
+		d_sfracbasestep = (r_sstepy + r_sstepx * ubasestep) & 0xFFFF;
+		d_tfracbasestep = (r_tstepy + r_tstepx * ubasestep) & 0xFFFF;
+
 		d_lightbasestep = r_lstepy + working_lstepx * ubasestep;
 		d_zibasestep = r_zistepy + r_zistepx * ubasestep;
 
-		d_ptexextrastep = ((r_sstepy + r_sstepx * d_countextrastep) >> SHIFT16XYZ) +
-				((r_tstepy + r_tstepx * d_countextrastep) >> SHIFT16XYZ) *
+		d_ptexextrastep = ((r_sstepy + r_sstepx * (ubasestep + 1)) >> SHIFT16XYZ) +
+				((r_tstepy + r_tstepx * (ubasestep + 1)) >> SHIFT16XYZ) *
 				r_affinetridesc.skinwidth;
-		{
-			d_sfracextrastep = (r_sstepy + r_sstepx*d_countextrastep) & 0xFFFF;
-			d_tfracextrastep = (r_tstepy + r_tstepx*d_countextrastep) & 0xFFFF;
-		}
+
+		d_sfracextrastep = (r_sstepy + r_sstepx*(ubasestep + 1)) & 0xFFFF;
+		d_tfracextrastep = (r_tstepy + r_tstepx*(ubasestep + 1)) & 0xFFFF;
+
 		d_lightextrastep = d_lightbasestep + working_lstepx;
 		d_ziextrastep = d_zibasestep + r_zistepx;
 
-		{
-			R_PolysetScanLeftEdge_C(initialleftheight);
-		}
+		R_PolysetScanLeftEdge_C(initialleftheight, d_ptex, u, v);
 	}
 
 	//
@@ -871,8 +861,8 @@ R_RasterizeAliasPolySmooth(const entity_t *currententity)
 		height = pleftbottom[1] - plefttop[1];
 
 		// TODO: make this a function; modularize this function in general
-
-		ystart = plefttop[1];
+		u = plefttop[0];
+		v = plefttop[1];
 		d_aspancount = plefttop[0] - prighttop[0];
 		d_ptex = (byte *)r_affinetridesc.pskin + (plefttop[2] >> SHIFT16XYZ) +
 				(plefttop[3] >> SHIFT16XYZ) * r_affinetridesc.skinwidth;
@@ -881,66 +871,50 @@ R_RasterizeAliasPolySmooth(const entity_t *currententity)
 		d_light = plefttop[4];
 		d_zi = plefttop[5];
 
-		d_pdest = d_viewbuffer + ystart * vid.width + plefttop[0];
-		d_pz = d_pzbuffer + ystart * vid.width + plefttop[0];
-
 		if (height == 1)
 		{
-			R_PushEdgesSpan();
+			R_PushEdgesSpan(u, v, d_aspancount,
+					d_ptex, d_sfrac, d_tfrac, d_light, d_zi);
 		}
 		else
 		{
 			R_PolysetSetUpForLineScan(plefttop[0], plefttop[1],
 								  pleftbottom[0], pleftbottom[1]);
 
-			d_pdestbasestep = vid.width + ubasestep;
-			d_pdestextrastep = d_pdestbasestep + 1;
-
-			{
-				d_pzbasestep = vid.width + ubasestep;
-				d_pzextrastep = d_pzbasestep + 1;
-			}
-
 			if (ubasestep < 0)
 				working_lstepx = r_lstepx - 1;
 			else
 				working_lstepx = r_lstepx;
 
-			d_countextrastep = ubasestep + 1;
 			d_ptexbasestep = ((r_sstepy + r_sstepx * ubasestep) >> SHIFT16XYZ) +
 					((r_tstepy + r_tstepx * ubasestep) >> SHIFT16XYZ) *
 					r_affinetridesc.skinwidth;
-			{
-				d_sfracbasestep = (r_sstepy + r_sstepx * ubasestep) & 0xFFFF;
-				d_tfracbasestep = (r_tstepy + r_tstepx * ubasestep) & 0xFFFF;
-			}
+
+			d_sfracbasestep = (r_sstepy + r_sstepx * ubasestep) & 0xFFFF;
+			d_tfracbasestep = (r_tstepy + r_tstepx * ubasestep) & 0xFFFF;
+
 			d_lightbasestep = r_lstepy + working_lstepx * ubasestep;
 			d_zibasestep = r_zistepy + r_zistepx * ubasestep;
 
-			d_ptexextrastep = ((r_sstepy + r_sstepx * d_countextrastep) >> SHIFT16XYZ) +
-					((r_tstepy + r_tstepx * d_countextrastep) >> SHIFT16XYZ) *
+			d_ptexextrastep = ((r_sstepy + r_sstepx * (ubasestep + 1)) >> SHIFT16XYZ) +
+					((r_tstepy + r_tstepx * (ubasestep + 1)) >> SHIFT16XYZ) *
 					r_affinetridesc.skinwidth;
-			{
-				d_sfracextrastep = (r_sstepy+r_sstepx*d_countextrastep) & 0xFFFF;
-				d_tfracextrastep = (r_tstepy+r_tstepx*d_countextrastep) & 0xFFFF;
-			}
+
+			d_sfracextrastep = (r_sstepy+r_sstepx*(ubasestep + 1)) & 0xFFFF;
+			d_tfracextrastep = (r_tstepy+r_tstepx*(ubasestep + 1)) & 0xFFFF;
+
 			d_lightextrastep = d_lightbasestep + working_lstepx;
 			d_ziextrastep = d_zibasestep + r_zistepx;
 
-			{
-				R_PolysetScanLeftEdge_C(height);
-			}
+			R_PolysetScanLeftEdge_C(height, d_ptex, u, v);
 		}
 	}
 
 	// scan out the top (and possibly only) part of the right edge, updating the
 	// count field
-	d_pedgespanpackage = triangle_spans;
-
 	R_PolysetSetUpForLineScan(prighttop[0], prighttop[1],
 						  prightbottom[0], prightbottom[1]);
 	d_aspancount = 0;
-	d_countextrastep = ubasestep + 1;
 	if ((triangle_spans + initialrightheight) >= triangles_max)
 	{
 		// we dont have enough triangles for save full height
@@ -969,8 +943,6 @@ R_RasterizeAliasPolySmooth(const entity_t *currententity)
 
 		R_PolysetSetUpForLineScan(prighttop[0], prighttop[1],
 							  prightbottom[0], prightbottom[1]);
-
-		d_countextrastep = ubasestep + 1;
 
 		if ((triangle_spans + initialrightheight + height) >= triangles_max)
 		{

--- a/src/client/refresh/soft/sw_rast.c
+++ b/src/client/refresh/soft/sw_rast.c
@@ -163,7 +163,7 @@ R_EmitSkyBox
 ================
 */
 static void
-R_EmitSkyBox (void)
+R_EmitSkyBox(entity_t *currententity)
 {
 	int		i, j;
 	int		oldkey;
@@ -199,7 +199,7 @@ R_EmitSkyBox (void)
 	r_currentkey = 0x7ffffff0;
  	for (i=0 ; i<6 ; i++)
 	{
-		R_RenderFace (r_skyfaces + i, ALIAS_XY_CLIP_MASK);
+		R_RenderFace(currententity, r_skyfaces + i, ALIAS_XY_CLIP_MASK);
 	}
 	r_currentkey = oldkey;	// bsp sorting order
 }
@@ -354,9 +354,13 @@ R_EmitEdge (mvertex_t *pv0, mvertex_t *pv1)
 	// the edge of the screen
 	// FIXME: is this actually needed?
 	if (edge->u < r_refdef.vrect_x_adj_shift20)
+	{
 		edge->u = r_refdef.vrect_x_adj_shift20;
-	if (edge->u > r_refdef.vrectright_adj_shift20)
+	}
+	else if (edge->u > r_refdef.vrectright_adj_shift20)
+	{
 		edge->u = r_refdef.vrectright_adj_shift20;
+	}
 
 	//
 	// sort the edge in normally
@@ -515,7 +519,7 @@ R_RenderFace
 ================
 */
 void
-R_RenderFace (msurface_t *fa, int clipflags)
+R_RenderFace (entity_t *currententity, msurface_t *fa, int clipflags)
 {
 	int		i;
 	unsigned	mask;
@@ -537,7 +541,7 @@ R_RenderFace (msurface_t *fa, int clipflags)
 	// environment box surfaces to be emited
 	if ( fa->texinfo->flags & SURF_SKY )
 	{
-		R_EmitSkyBox ();
+		R_EmitSkyBox (currententity);
 		return;
 	}
 
@@ -731,7 +735,7 @@ R_RenderBmodelFace
 ================
 */
 void
-R_RenderBmodelFace (bedge_t *pedges, msurface_t *psurf)
+R_RenderBmodelFace(entity_t *currententity, bedge_t *pedges, msurface_t *psurf)
 {
 	int			i;
 	unsigned	mask;

--- a/src/client/refresh/soft/sw_rast.c
+++ b/src/client/refresh/soft/sw_rast.c
@@ -163,7 +163,7 @@ R_EmitSkyBox
 ================
 */
 static void
-R_EmitSkyBox(entity_t *currententity)
+R_EmitSkyBox(entity_t *currententity, const model_t *currentmodel)
 {
 	int		i, j;
 	int		oldkey;
@@ -199,7 +199,7 @@ R_EmitSkyBox(entity_t *currententity)
 	r_currentkey = 0x7ffffff0;
  	for (i=0 ; i<6 ; i++)
 	{
-		R_RenderFace(currententity, r_skyfaces + i, ALIAS_XY_CLIP_MASK);
+		R_RenderFace(currententity, currentmodel, r_skyfaces + i, ALIAS_XY_CLIP_MASK);
 	}
 	r_currentkey = oldkey;	// bsp sorting order
 }
@@ -519,7 +519,7 @@ R_RenderFace
 ================
 */
 void
-R_RenderFace (entity_t *currententity, msurface_t *fa, int clipflags)
+R_RenderFace (entity_t *currententity, const model_t *currentmodel, msurface_t *fa, int clipflags)
 {
 	int		i;
 	unsigned	mask;
@@ -541,7 +541,7 @@ R_RenderFace (entity_t *currententity, msurface_t *fa, int clipflags)
 	// environment box surfaces to be emited
 	if ( fa->texinfo->flags & SURF_SKY )
 	{
-		R_EmitSkyBox (currententity);
+		R_EmitSkyBox (currententity, currentmodel);
 		return;
 	}
 

--- a/src/client/refresh/soft/sw_sprite.c
+++ b/src/client/refresh/soft/sw_sprite.c
@@ -33,7 +33,7 @@ extern void	R_ClipAndDrawPoly( float alpha, qboolean isturbulent, qboolean textu
 ** mapped polygon
 */
 void
-R_DrawSprite (void)
+R_DrawSprite(entity_t *currententity)
 {
 	vec5_t		*pverts;
 	vec3_t		left, up, right, down;

--- a/src/client/refresh/soft/sw_sprite.c
+++ b/src/client/refresh/soft/sw_sprite.c
@@ -24,7 +24,7 @@ extern polydesc_t r_polydesc;
 
 extern vec5_t	r_clip_verts[2][MAXWORKINGVERTS+2];
 
-extern void	R_ClipAndDrawPoly( float alpha, qboolean isturbulent, qboolean textured );
+extern void R_ClipAndDrawPoly(float alpha, qboolean isturbulent, qboolean textured);
 
 /*
 ** R_DrawSprite
@@ -33,7 +33,7 @@ extern void	R_ClipAndDrawPoly( float alpha, qboolean isturbulent, qboolean textu
 ** mapped polygon
 */
 void
-R_DrawSprite(entity_t *currententity)
+R_DrawSprite(entity_t *currententity, const model_t *currentmodel)
 {
 	vec5_t		*pverts;
 	vec3_t		left, up, right, down;

--- a/src/client/refresh/soft/sw_surf.c
+++ b/src/client/refresh/soft/sw_surf.c
@@ -50,7 +50,7 @@ Returns the proper texture for a given time and base texture
 ===============
 */
 static image_t *
-R_TextureAnimation (mtexinfo_t *tex)
+R_TextureAnimation (const entity_t *currententity, mtexinfo_t *tex)
 {
 	int c;
 
@@ -344,14 +344,14 @@ D_CacheSurface
 ================
 */
 surfcache_t *
-D_CacheSurface (msurface_t *surface, int miplevel)
+D_CacheSurface (const entity_t *currententity, msurface_t *surface, int miplevel)
 {
 	surfcache_t	*cache;
 
 	//
 	// if the surface is animating or flashing, flush the cache
 	//
-	r_drawsurf.image = R_TextureAnimation (surface->texinfo);
+	r_drawsurf.image = R_TextureAnimation (currententity, surface->texinfo);
 	r_drawsurf.lightadj[0] = r_newrefdef.lightstyles[surface->styles[0]].white*128;
 	r_drawsurf.lightadj[1] = r_newrefdef.lightstyles[surface->styles[1]].white*128;
 	r_drawsurf.lightadj[2] = r_newrefdef.lightstyles[surface->styles[2]].white*128;

--- a/src/client/refresh/soft/sw_surf.c
+++ b/src/client/refresh/soft/sw_surf.c
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "header/local.h"
 
-static int		lightleft, blocksize, sourcetstep;
+static int		lightleft, sourcetstep;
 static int		lightright, lightleftstep, lightrightstep, blockdivshift;
 static void		*prowdestbase;
 static unsigned char	*pbasesource;
@@ -30,8 +30,6 @@ static int		r_lightwidth;
 static int		r_numhblocks, r_numvblocks;
 static unsigned char	*r_source, *r_sourcemax;
 static unsigned		*r_lightptr;
-
-static void R_DrawSurfaceBlock8_anymip (int level, int surfrowbytes);
 
 void R_BuildLightMap (drawsurf_t *drawsurf);
 extern	unsigned	blocklights[1024];	// allow some very large lightmaps
@@ -67,82 +65,6 @@ R_TextureAnimation (const entity_t *currententity, mtexinfo_t *tex)
 	return tex->image;
 }
 
-
-/*
-===============
-R_DrawSurface
-===============
-*/
-static void
-R_DrawSurface (drawsurf_t *drawsurf)
-{
-	unsigned char	*basetptr;
-	int		smax, tmax, twidth;
-	int		u;
-	int		soffset, basetoffset, texwidth;
-	unsigned char	*pcolumndest;
-	image_t		*mt;
-
-	mt = drawsurf->image;
-
-	r_source = mt->pixels[drawsurf->surfmip];
-
-	// the fractional light values should range from 0 to (VID_GRADES - 1) << 16
-	// from a source range of 0 - 255
-
-	texwidth = mt->width >> drawsurf->surfmip;
-
-	blocksize = 16 >> drawsurf->surfmip;
-	blockdivshift = NUM_MIPS - drawsurf->surfmip;
-
-	r_lightwidth = (drawsurf->surf->extents[0]>>4)+1;
-
-	r_numhblocks = drawsurf->surfwidth >> blockdivshift;
-	r_numvblocks = drawsurf->surfheight >> blockdivshift;
-
-	//==============================
-
-	// TODO: only needs to be set when there is a display settings change
-	// blocksize = blocksize;
-
-	smax = mt->width >> drawsurf->surfmip;
-	twidth = texwidth;
-	tmax = mt->height >> drawsurf->surfmip;
-	sourcetstep = texwidth;
-	r_stepback = tmax * twidth;
-
-	r_sourcemax = r_source + (tmax * smax);
-
-	soffset = drawsurf->surf->texturemins[0];
-	basetoffset = drawsurf->surf->texturemins[1];
-
-	// << 16 components are to guarantee positive values for %
-	soffset = ((soffset >> drawsurf->surfmip) + (smax << SHIFT16XYZ)) % smax;
-	basetptr = &r_source[((((basetoffset >> drawsurf->surfmip)
-		+ (tmax << SHIFT16XYZ)) % tmax) * twidth)];
-
-	pcolumndest = drawsurf->surfdat;
-
-	for (u=0 ; u<r_numhblocks; u++)
-	{
-		r_lightptr = blocklights + u;
-
-		prowdestbase = pcolumndest;
-
-		pbasesource = basetptr + soffset;
-
-		R_DrawSurfaceBlock8_anymip(NUM_MIPS - drawsurf->surfmip, drawsurf->rowbytes);
-
-		soffset = soffset + blocksize;
-		if (soffset >= smax)
-			soffset = 0;
-
-		pcolumndest += blocksize;
-	}
-}
-
-
-//=============================================================================
 
 /*
 ================
@@ -195,8 +117,80 @@ R_DrawSurfaceBlock8_anymip (int level, int surfrowbytes)
 	}
 }
 
-//============================================================================
 
+/*
+===============
+R_DrawSurface
+===============
+*/
+static void
+R_DrawSurface (drawsurf_t *drawsurf)
+{
+	unsigned char	*basetptr;
+	int		smax, tmax, twidth;
+	int		u;
+	int		soffset, basetoffset, texwidth;
+	int		blocksize;
+	unsigned char	*pcolumndest;
+	image_t		*mt;
+
+	mt = drawsurf->image;
+
+	r_source = mt->pixels[drawsurf->surfmip];
+
+	// the fractional light values should range from 0 to (VID_GRADES - 1) << 16
+	// from a source range of 0 - 255
+
+	texwidth = mt->width >> drawsurf->surfmip;
+
+	blocksize = 16 >> drawsurf->surfmip;
+	blockdivshift = NUM_MIPS - drawsurf->surfmip;
+
+	r_lightwidth = (drawsurf->surf->extents[0]>>4)+1;
+
+	r_numhblocks = drawsurf->surfwidth >> blockdivshift;
+	r_numvblocks = drawsurf->surfheight >> blockdivshift;
+
+	//==============================
+
+	smax = mt->width >> drawsurf->surfmip;
+	twidth = texwidth;
+	tmax = mt->height >> drawsurf->surfmip;
+	sourcetstep = texwidth;
+	r_stepback = tmax * twidth;
+
+	r_sourcemax = r_source + (tmax * smax);
+
+	soffset = drawsurf->surf->texturemins[0];
+	basetoffset = drawsurf->surf->texturemins[1];
+
+	// << 16 components are to guarantee positive values for %
+	soffset = ((soffset >> drawsurf->surfmip) + (smax << SHIFT16XYZ)) % smax;
+	basetptr = &r_source[((((basetoffset >> drawsurf->surfmip)
+		+ (tmax << SHIFT16XYZ)) % tmax) * twidth)];
+
+	pcolumndest = drawsurf->surfdat;
+
+	for (u=0 ; u<r_numhblocks; u++)
+	{
+		r_lightptr = blocklights + u;
+
+		prowdestbase = pcolumndest;
+
+		pbasesource = basetptr + soffset;
+
+		R_DrawSurfaceBlock8_anymip(NUM_MIPS - drawsurf->surfmip, drawsurf->rowbytes);
+
+		soffset = soffset + blocksize;
+		if (soffset >= smax)
+			soffset = 0;
+
+		pcolumndest += blocksize;
+	}
+}
+
+
+//=============================================================================
 
 /*
 ================


### PR DESCRIPTION
* Cleanup soft render little more
* Support for big bsp with 32k+ marksurfaces.
* allocate hunks with relation to original file size.
* save hunk size to size_t typed variable for unix systems.