### PR TITLE
Minor bug-fixes: Case-insensitive file loading & Rogue dmflags display

### DIFF
--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -3397,7 +3397,7 @@ DMOptions_MenuInit(void)
     Menu_AddItem(&s_dmoptions_menu, &s_quad_drop_box);
     Menu_AddItem(&s_dmoptions_menu, &s_friendlyfire_box);
 
-    if (M_IsGame("rogueg"))
+    if (M_IsGame("rogue"))
     {
         Menu_AddItem(&s_dmoptions_menu, &s_no_mines_box);
         Menu_AddItem(&s_dmoptions_menu, &s_no_nukes_box);

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -367,7 +367,7 @@ FS_FCloseFile(fileHandle_t f)
 int
 FS_FOpenFile(const char *name, fileHandle_t *f, qboolean gamedir_only)
 {
-	char path[MAX_OSPATH];
+	char path[MAX_OSPATH], lwrName[MAX_OSPATH];
 	fsHandle_t *handle;
 	fsPack_t *pack;
 	fsSearchPath_t *search;
@@ -463,7 +463,9 @@ FS_FOpenFile(const char *name, fileHandle_t *f, qboolean gamedir_only)
 
 			if (!handle->file)
 			{
-				Q_strlwr(path);
+				Com_sprintf(lwrName, sizeof(lwrName), "%s", handle->name);
+				Q_strlwr(lwrName);
+				Com_sprintf(path, sizeof(path), "%s/%s", search->path, lwrName);
 				handle->file = Q_fopen(path, "rb");
 			}
 


### PR DESCRIPTION
I noticed these issues while making some changes for CTF in the "Start Server" menu for myself:

1. Case-insensitivity isn't working for directly loading files when YQ2 is located in a directory tree with capitalization (when it is also executed from a different directory than where it resides).
2. It looks like there's a typo in the code that would prevent the Rogue dmflags from displaying in the menu.  (I don't have the mission pack to verify that, though.)

Also, let me know if you'd be interested in adding the CTF-specific game options to the "Start Server" menu and "dmflags" menu, and I'll send those through.