### PR TITLE
Added parenesis for REGEX REPLACE command to fix this error:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,9 +72,9 @@ add_definitions(-DYQ2OSTYPE="${YQ2OSTYPE}")
 
 # Architecture string.
 set(YQ2ARCH "${CMAKE_SYSTEM_PROCESSOR}" CACHE STRING "Override CPU architecture")
-string(REGEX REPLACE "amd64" "x86_64" ARCH ${YQ2ARCH})
-string(REGEX REPLACE "i.86" "i386" ARCH ${ARCH})
-string(REGEX REPLACE "^arm.*" "arm" ARCH ${ARCH})
+string(REGEX REPLACE "amd64" "x86_64" ARCH "${YQ2ARCH}")
+string(REGEX REPLACE "i.86" "i386" ARCH "${ARCH}")
+string(REGEX REPLACE "^arm.*" "arm" ARCH "${ARCH}")
 add_definitions(-DYQ2ARCH="${ARCH}")
 
 # Systemwide installation of game assets.
@@ -561,7 +561,7 @@ else()
 			RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/release
 			)
 	target_link_libraries(quake2 ${yquake2LinkerFlags} ${yquake2ClientLinkerFlags}
-			${yquake2SDLLinkerFlags} ${yquake2ZLibLinkerFlags})
+			${yquake2SDLLinkerFlags} ${yquake2ZLibLinkerFlags} rt)
 endif()
 
 # Quake 2 Dedicated Server
@@ -574,7 +574,7 @@ set_target_properties(q2ded PROPERTIES
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 	target_link_libraries(q2ded ${yquake2LinkerFlags} ${yquake2ZLibLinkerFlags} ws2_32 winmm)
 else()
-	target_link_libraries(q2ded ${yquake2LinkerFlags} ${yquake2ServerLinkerFlags} ${yquake2ZLibLinkerFlags})
+	target_link_libraries(q2ded ${yquake2LinkerFlags} ${yquake2ServerLinkerFlags} ${yquake2ZLibLinkerFlags} rt)
 endif()
 
 # Build the game dynamic library


### PR DESCRIPTION
CMake Error at CMakeLists.txt:25 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.

Added librt to link list (was required during cross compile)