### PR TITLE
Fixed menu code to correctly parse maps.lst file.

### DIFF
--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2898,7 +2898,7 @@ StartServer_MenuInit(void)
 
         while (i < length)
         {
-            if (s[i] == '\r')
+            if (s[i] == '\n')
             {
                 nummaps++;
             }


### PR DESCRIPTION
While working on my personal project using your quake 2 fork I noticed issues parsing my `map.lst` file, I had to change the line terminator from `\r` to `\n`. Not sure if there are other types of `map.lst` files with a different format to them. Perhaps the better solution would be using `||` and testing for both conditions.

The original code gave me an `No maps in maps.lst` error.

My `maps.lst` file contents are the following:

```
q2dm1 "The Edge"
q2dm2 "Tokay's Towers" 
q2dm3 "The Frag Pipe" 
q2dm4 "Lost Hallways"
q2dm5 "The Pits"
q2dm6 "Lava Tomb"
q2dm7 "The Slimy Place"
q2dm8 "WareHouse"
``` 

_Thanks for the cleaned up Quake 2 code :+1: !_