### PR TITLE
Fix case error for linux -> win32 cross compile

### DIFF
--- a/src/backends/windows/main.c
+++ b/src/backends/windows/main.c
@@ -27,7 +27,7 @@
 
 #include <windows.h>
 #include <SDL2/SDL.h>
-#include <SDL2/SDL_Main.h>
+#include <SDL2/SDL_main.h>
 
 #include "../../common/header/common.h"
 


### PR DESCRIPTION
When cross compiling for Windows on a Linux environment case sensitivity matters for file names.