### PR TITLE
Enable automatic Windows builds with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yamagi Quake II
+# Yamagi Quake II  [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/yquake2/yquake2?branch=master&svg=true)](https://ci.appveyor.com/project/yquake2/yquake2)
 
 This is the Yamagi Quake II Client, an enhanced version of id Software's Quake
 II with focus on offline and coop gameplay. Both the gameplay and the graphics

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ install:
   - mkdir cmake_build
   - cd cmake_build
   - cmake --version
+  - find_package(SDL2 REQUIRED)
+  - include_directories(${SDL2_INCLUDE_DIR})
   - cmake c:\projects\yquake2
 
 build_script: msbuild "C:\projects\yquake2\cmake_build\yquake2.sln"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+image: Visual Studio 2017
+configuration: Release
+
+before_build:
+- cmd: |-
+    cd %APPVEYOR_BUILD_FOLDER%
+    mkdir cmake_build
+    cd cmake_build
+    cmake --version
+
+build_script: cmake c:\projects\yquake2
+
+artifacts:
+ - path: cmake_build\Release\**\*.*
+ - path: cmake_build\Release\*.*
+ - path: cmake_build\**\*.exe
+ - path: cmake_build\**\*.lib
+ 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   - cmake --version
   - cmake c:\projects\yquake2
 
-build_script: msbuild "C:\projects\mozjpeg\cmake_build\yquake2.sln"
+build_script: msbuild "C:\projects\yquake2\cmake_build\yquake2.sln"
 
 artifacts:
  - path: cmake_build\Release\**\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,15 @@
 image: Visual Studio 2017
 configuration: Release
 
-before_build:
-- cmd: |-
-    cd %APPVEYOR_BUILD_FOLDER%
-    mkdir cmake_build
-    cd cmake_build
-    cmake --version
+install:
+  ## Prepare .sln with cmake
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - mkdir cmake_build
+  - cd cmake_build
+  - cmake --version
+  - cmake c:\projects\yquake2
 
-build_script: cmake c:\projects\yquake2
+build_script: msbuild "C:\projects\mozjpeg\cmake_build\yquake2.sln"
 
 artifacts:
  - path: cmake_build\Release\**\*.*
- - path: cmake_build\Release\*.*
- - path: cmake_build\**\*.exe
- - path: cmake_build\**\*.lib
- 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ install:
   - cd cmake_build
   - cmake --version
   - find_package(SDL2 REQUIRED)
-  - include_directories(${SDL2_INCLUDE_DIR})
+  - include_directories(%SDL2_INCLUDE_DIR%)
   - cmake c:\projects\yquake2
 
 build_script: msbuild "C:\projects\yquake2\cmake_build\yquake2.sln"


### PR DESCRIPTION
Add continuous integration with AppVeyor, which enables automatic builds of yquake2 for x86-64 Windows. Example can be found [here](https://ci.appveyor.com/project/EwoutH/yquake2/history).

AppVeyor only needs to be [enabled](https://github.com/marketplace/appveyor) on the GitHub Marketplace.

At the moment it produces this error, is this expected?
```
CMake Error at C:/Program Files (x86)/CMake/share/cmake-3.12/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find SDL2 (missing: SDL2_LIBRARY SDL2_INCLUDE_DIR)
Call Stack (most recent call first):
  C:/Program Files (x86)/CMake/share/cmake-3.12/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
  stuff/cmake/modules/FindSDL2.cmake:173 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:96 (find_package)
```
