### PR TITLE
Weapon selector mechanism for controllers

### DIFF
--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -60,6 +60,7 @@ kbutton_t in_left, in_right, in_forward, in_back;
 kbutton_t in_lookup, in_lookdown, in_moveleft, in_moveright;
 kbutton_t in_strafe, in_speed, in_use, in_attack;
 kbutton_t in_up, in_down;
+kbutton_t in_weaponselector;
 
 int in_impulse;
 
@@ -192,6 +193,18 @@ IN_KLookDown(void)
 
 void
 IN_KLookUp(void)
+{
+	KeyUp(&in_klook);
+}
+
+void
+IN_WeaponSelectorDown(void)
+{
+	KeyDown(&in_weaponselector);
+}
+
+void
+IN_WeaponSelectoUp(void)
 {
 	KeyUp(&in_klook);
 }
@@ -627,6 +640,8 @@ CL_InitInput(void)
 	Cmd_AddCommand("impulse", IN_Impulse);
 	Cmd_AddCommand("+klook", IN_KLookDown);
 	Cmd_AddCommand("-klook", IN_KLookUp);
+	Cmd_AddCommand("+weaponselector", IN_WeaponSelectorDown);
+	Cmd_AddCommand("-weaponselector", IN_WeaponSelectoUp);
 
 	cl_nodelta = Cvar_Get("cl_nodelta", "0", 0);
 }

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -198,15 +198,9 @@ IN_KLookUp(void)
 }
 
 void
-IN_WeaponSelectorDown(void)
+IN_WeaponSelector(void)
 {
-	KeyDown(&in_weaponselector);
-}
-
-void
-IN_WeaponSelectoUp(void)
-{
-	KeyUp(&in_klook);
+	
 }
 
 void
@@ -608,6 +602,7 @@ CL_InitInput(void)
 {
 	Cmd_AddCommand("centerview", IN_CenterView);
 	Cmd_AddCommand("force_centerview", IN_ForceCenterView);
+	Cmd_AddCommand("weaponselector", IN_WeaponSelector);
 
 	Cmd_AddCommand("+moveup", IN_UpDown);
 	Cmd_AddCommand("-moveup", IN_UpUp);
@@ -640,8 +635,6 @@ CL_InitInput(void)
 	Cmd_AddCommand("impulse", IN_Impulse);
 	Cmd_AddCommand("+klook", IN_KLookDown);
 	Cmd_AddCommand("-klook", IN_KLookUp);
-	Cmd_AddCommand("+weaponselector", IN_WeaponSelectorDown);
-	Cmd_AddCommand("-weaponselector", IN_WeaponSelectoUp);
 
 	cl_nodelta = Cvar_Get("cl_nodelta", "0", 0);
 }

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -197,7 +197,7 @@ IN_KLookUp(void)
 }
 
 void
-IN_WeaponSelector(void)
+IN_AltSelector(void)
 {
 	
 }
@@ -601,7 +601,7 @@ CL_InitInput(void)
 {
 	Cmd_AddCommand("centerview", IN_CenterView);
 	Cmd_AddCommand("force_centerview", IN_ForceCenterView);
-	Cmd_AddCommand("weaponselector", IN_WeaponSelector);
+	Cmd_AddCommand("altselector", IN_AltSelector);
 
 	Cmd_AddCommand("+moveup", IN_UpDown);
 	Cmd_AddCommand("-moveup", IN_UpUp);

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -60,7 +60,6 @@ kbutton_t in_left, in_right, in_forward, in_back;
 kbutton_t in_lookup, in_lookdown, in_moveleft, in_moveright;
 kbutton_t in_strafe, in_speed, in_use, in_attack;
 kbutton_t in_up, in_down;
-kbutton_t in_weaponselector;
 
 int in_impulse;
 

--- a/src/client/cl_keyboard.c
+++ b/src/client/cl_keyboard.c
@@ -1104,8 +1104,27 @@ Key_Event(int key, qboolean down, qboolean special)
 	}
 
 	/* Special binding for walking through weapons using a controller */
-	if(down && keydown[K_JOY6])
+
+	// This is a bit ugly, but perhaps needed if we want to allow the key to be rebinded?
+	// we simply need to re-iterate the list and locate the key for +weaponselector
+	// Or is there some smarter way of doing this that I am missing?
+	int keyWeaponSelector = -1;	
+	for(int i = 0; i < K_LAST; i++)
 	{
+		if(keybindings[i] && Q_stricmp(keybindings[i], "+weaponselector") == 0)
+		{
+			keyWeaponSelector = i;
+		}
+	}
+	if(down && keyWeaponSelector > 0 && keydown[keyWeaponSelector])
+	{
+		// For testing, udalit pashalsta
+		if(key == 'm')
+		{
+			Cbuf_AddText("use Grenade Launcher\n");
+			return;
+		}
+
 		if(key == K_HAT_LEFT)
 		{
 			Cbuf_AddText("use Grenade Launcher\n");

--- a/src/client/cl_keyboard.c
+++ b/src/client/cl_keyboard.c
@@ -1103,6 +1103,31 @@ Key_Event(int key, qboolean down, qboolean special)
 		return;
 	}
 
+	/* Special binding for walking through weapons using a controller */
+	if(down && keydown[K_JOY6])
+	{
+		if(key == K_HAT_LEFT)
+		{
+			Cbuf_AddText("use Grenade Launcher\n");
+			return;
+		}
+		if(key == K_HAT_UP)
+		{
+			Cbuf_AddText("use Rocket Launcher\n");
+			return;
+		}
+		if(key == K_HAT_RIGHT)
+		{
+			Cbuf_AddText("use HyperBlaster\n");
+			return;
+		}
+		if(key == K_HAT_DOWN)
+		{
+			Cbuf_AddText("use Railgun\n");
+			return;
+		}
+	}	
+
 	/* Key is unbound */
 	if ((key >= K_MOUSE1 && key != K_JOY_BACK) && !keybindings[key] && (cls.key_dest != key_console))
 	{

--- a/src/client/cl_keyboard.c
+++ b/src/client/cl_keyboard.c
@@ -36,6 +36,12 @@ static cvar_t *weaponselector_2;
 static cvar_t *weaponselector_3;
 static cvar_t *weaponselector_4;
 
+static cvar_t *weaponselector_key_1;
+static cvar_t *weaponselector_key_2;
+static cvar_t *weaponselector_key_3;
+static cvar_t *weaponselector_key_4;
+
+
 /*
  * key up events are sent even if in console mode
  */
@@ -1020,6 +1026,11 @@ Key_Init(void)
 	weaponselector_2 = Cvar_Get("weaponselector_weapon2", "Rocket Launcher", CVAR_ARCHIVE);
 	weaponselector_3 = Cvar_Get("weaponselector_weapon3", "HyperBlaster", CVAR_ARCHIVE);
 	weaponselector_4 = Cvar_Get("weaponselector_weapon4", "Railgun", CVAR_ARCHIVE);
+
+	weaponselector_key_1 = Cvar_Get("weaponselector_key_1", "HAT_UP", CVAR_ARCHIVE);
+	weaponselector_key_2 = Cvar_Get("weaponselector_key_2", "HAT_UP", CVAR_ARCHIVE);
+	weaponselector_key_3 = Cvar_Get("weaponselector_key_3", "HAT_RIGHT", CVAR_ARCHIVE);
+	weaponselector_key_4 = Cvar_Get("weaponselector_key_4", "HAT_DOWN", CVAR_ARCHIVE);
 	
 	/* register our functions */
 	Cmd_AddCommand("bind", Key_Bind_f);
@@ -1152,6 +1163,26 @@ Key_Event(int key, qboolean down, qboolean special)
 	if(down && key_weaponselector > 0 && keydown[key_weaponselector])
 	{
 		cvar_t *weaponselector_current = NULL;
+		char* keyName = Key_KeynumToString(key);
+
+		if(strcmp(keyName, weaponselector_key_1->string) == 0)
+		{
+			weaponselector_current = weaponselector_1;
+		}
+		else if(strcmp(keyName, weaponselector_key_2->string) == 0)
+		{
+			weaponselector_current = weaponselector_2;
+		}
+		else if(strcmp(keyName, weaponselector_key_3->string) == 0)
+		{
+			weaponselector_current = weaponselector_3;
+		}
+		else if(strcmp(keyName, weaponselector_key_4->string) == 0)
+		{
+			weaponselector_current = weaponselector_4;
+		}
+
+		/*
 		switch(key)
 		{
 			case K_HAT_LEFT:
@@ -1174,6 +1205,7 @@ Key_Event(int key, qboolean down, qboolean special)
 				weaponselector_current = NULL;
 			break;		
 		}
+		*/
 
 		if(weaponselector_current)
 		{

--- a/src/client/header/client.h
+++ b/src/client/header/client.h
@@ -455,7 +455,6 @@ typedef struct
 extern	kbutton_t	in_mlook, in_klook;
 extern 	kbutton_t 	in_strafe;
 extern 	kbutton_t 	in_speed;
-extern	kbutton_t	in_weaponselector;
 
 void CL_InitInput (void);
 void CL_RefreshCmd(void);

--- a/src/client/header/client.h
+++ b/src/client/header/client.h
@@ -455,6 +455,7 @@ typedef struct
 extern	kbutton_t	in_mlook, in_klook;
 extern 	kbutton_t 	in_strafe;
 extern 	kbutton_t 	in_speed;
+extern	kbutton_t	in_weaponselector;
 
 void CL_InitInput (void);
 void CL_RefreshCmd(void);

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -824,7 +824,7 @@ char *bindnames[][2] =
     {"invprev", "prev item"},
     {"invnext", "next item"},    
     {"cmd help", "help computer"},
-    {"+weaponselector", "select weapon"},
+    {"weaponselector", "select weapon"},
 };
 #define NUM_BINDNAMES (sizeof bindnames / sizeof bindnames[0])
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -829,15 +829,6 @@ char *bindnames[][2] =
 };
 #define NUM_BINDNAMES (sizeof bindnames / sizeof bindnames[0])
 
-/*
-char *altKeyMenu[] =
-{
-    "weapon 1",
-    "weapon 2",
-    "weapon 3",
-    "weapon 4"
-};
-*/
 #define NUM_ALT_KEYS 7
 
 int keys_cursor;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -822,8 +822,9 @@ char *bindnames[][2] =
     {"invuse", "use item"},
     {"invdrop", "drop item"},
     {"invprev", "prev item"},
-    {"invnext", "next item"},
-    {"cmd help", "help computer"}
+    {"invnext", "next item"},    
+    {"cmd help", "help computer"},
+    {"+weaponselector", "select weapon"},
 };
 #define NUM_BINDNAMES (sizeof bindnames / sizeof bindnames[0])
 


### PR DESCRIPTION
In order to switch weapons in a convenient way on a controller one needs a better mechanism in Quake 2 to do so because of the limited number of buttons a controller.
This change consists of 2 changes:
1. Add a couple of bindings in the config.cfg (HAT_LEFT...HAT_DOWN for first 4 weapons to adress, one binding for the "selector key" (JOY6 on the PS4 controller on a retropie, the top right shoulder button).
2. Support in Quake 2 to let the user press "selector key" + HAT_LEFT...HAT_DOWN to reach 4 more weapons. The selector key should also be rebindable from the "control settings" in the GUI.

My solution now also introduces 4 new cvars, "weaponselector_weapon1"..."weaponselector_weapon4" for the weapons that can be reached through "selector key" + HAT_LEFT...HAT_DOWN. This will make it possible to use this for mods as well as the cvars could be setup in the config.cfg of the mod if you have weapons with new names. 