### PR TITLE
Allow second layer of keybindings for controllers, refs #387

### DIFF
--- a/src/client/cl_keyboard.c
+++ b/src/client/cl_keyboard.c
@@ -147,6 +147,49 @@ keyname_t keynames[] = {
 	{"TRIG_LEFT", K_TRIG_LEFT},
 	{"TRIG_RIGHT", K_TRIG_RIGHT},
 
+	// virtual keys you get by pressing the corresponding normal joy key
+	// and the altselector key
+	{"JOY1_ALT", K_JOY1_ALT},
+	{"JOY2_ALT", K_JOY2_ALT},
+	{"JOY3_ALT", K_JOY3_ALT},
+	{"JOY4_ALT", K_JOY4_ALT},
+	{"JOY5_ALT", K_JOY5_ALT},
+	{"JOY6_ALT", K_JOY6_ALT},
+	{"JOY7_ALT", K_JOY7_ALT},
+	{"JOY8_ALT", K_JOY8_ALT},
+	{"JOY9_ALT", K_JOY9_ALT},
+	{"JOY10_ALT", K_JOY10_ALT},
+	{"JOY11_ALT", K_JOY11_ALT},
+	{"JOY12_ALT", K_JOY12_ALT},
+	{"JOY13_ALT", K_JOY13_ALT},
+	{"JOY14_ALT", K_JOY14_ALT},
+	{"JOY15_ALT", K_JOY15_ALT},
+	{"JOY16_ALT", K_JOY16_ALT},
+	{"JOY17_ALT", K_JOY17_ALT},
+	{"JOY18_ALT", K_JOY18_ALT},
+	{"JOY19_ALT", K_JOY19_ALT},
+	{"JOY20_ALT", K_JOY20_ALT},
+	{"JOY21_ALT", K_JOY21_ALT},
+	{"JOY22_ALT", K_JOY22_ALT},
+	{"JOY23_ALT", K_JOY23_ALT},
+	{"JOY24_ALT", K_JOY24_ALT},
+	{"JOY25_ALT", K_JOY25_ALT},
+	{"JOY26_ALT", K_JOY26_ALT},
+	{"JOY27_ALT", K_JOY27_ALT},
+	{"JOY28_ALT", K_JOY28_ALT},
+	{"JOY29_ALT", K_JOY29_ALT},
+	{"JOY30_ALT", K_JOY30_ALT},
+	{"JOY31_ALT", K_JOY31_ALT},
+	{"JOY32_ALT", K_JOY32_ALT},
+
+	{"HAT_UP_ALT", K_HAT_UP_ALT},
+	{"HAT_RIGHT_ALT", K_HAT_RIGHT_ALT},
+	{"HAT_DOWN_ALT", K_HAT_DOWN_ALT},
+	{"HAT_LEFT_ALT", K_HAT_LEFT_ALT},
+
+	{"TRIG_LEFT", K_TRIG_LEFT_ALT},
+	{"TRIG_RIGHT", K_TRIG_RIGHT_ALT},
+
 	{"JOY_BACK", K_JOY_BACK},
 
 	{"AUX1", K_AUX1},
@@ -1053,7 +1096,20 @@ Key_Event(int key, qboolean down, qboolean special)
 	cvar_t *fullscreen;
 	unsigned int time = Sys_Milliseconds();
 
-    /* Track if key is down */
+	// evil hack for the joystick key altselector, which turns K_JOYx into K_JOYx_ALT
+	if(joy_altselector_pressed && key >= K_JOY1 && key <= K_JOY_LAST_REGULAR)
+	{
+		// make sure key is not the altselector itself (which we won't turn into *_ALT)
+		if(keybindings[key] == NULL || strcmp(keybindings[key], "+joyaltselector") != 0)
+		{
+			int altkey = key + (K_JOY1_ALT - K_JOY1);
+			// allow fallback to binding with non-alt key
+			if(keybindings[altkey] != NULL || keybindings[key] == NULL)
+				key = altkey;
+		}
+	}
+
+	/* Track if key is down */
 	keydown[key] = down;
 
 	/* Ignore most autorepeats */

--- a/src/client/header/keyboard.h
+++ b/src/client/header/keyboard.h
@@ -40,6 +40,12 @@
  * instead of % so -1 wraps to NUM_KEY_LINES-1 */
 #define NUM_KEY_LINES 32
 
+/*
+ * the joystick altselector key is pressed
+ * => K_JOYx turns into K_JOYx_ALT
+ */
+extern qboolean joy_altselector_pressed;
+
 /* these are the key numbers that should be passed to Key_Event
    they must be mached by the low level key event processing! */
 enum QKEYS {
@@ -155,8 +161,56 @@ enum QKEYS {
 	K_TRIG_LEFT,
 	K_TRIG_RIGHT,
 
-	/* Can't be mapped to any action */
+	// add other joystick/controller keys before this one
+	// and adjust it accordingly, also remember to add corresponding _ALT key below!
+	K_JOY_LAST_REGULAR = K_TRIG_RIGHT,
+
+	/* Can't be mapped to any action (=> not regular) */
 	K_JOY_BACK,
+
+	K_JOY1_ALT,
+	K_JOY2_ALT,
+	K_JOY3_ALT,
+	K_JOY4_ALT,
+	K_JOY5_ALT,
+	K_JOY6_ALT,
+	K_JOY7_ALT,
+	K_JOY8_ALT,
+	K_JOY9_ALT,
+	K_JOY10_ALT,
+	K_JOY11_ALT,
+	K_JOY12_ALT,
+	K_JOY13_ALT,
+	K_JOY14_ALT,
+	K_JOY15_ALT,
+	K_JOY16_ALT,
+	K_JOY17_ALT,
+	K_JOY18_ALT,
+	K_JOY19_ALT,
+	K_JOY20_ALT,
+	K_JOY21_ALT,
+	K_JOY22_ALT,
+	K_JOY23_ALT,
+	K_JOY24_ALT,
+	K_JOY25_ALT,
+	K_JOY26_ALT,
+	K_JOY27_ALT,
+	K_JOY28_ALT,
+	K_JOY29_ALT,
+	K_JOY30_ALT,
+	K_JOY31_ALT,
+	K_JOY32_ALT,
+
+	K_HAT_UP_ALT,
+	K_HAT_RIGHT_ALT,
+	K_HAT_DOWN_ALT,
+	K_HAT_LEFT_ALT,
+
+	K_TRIG_LEFT_ALT,
+	K_TRIG_RIGHT_ALT,
+
+	// add other joystick/controller keys before this one and adjust it accordingly
+	K_JOY_LAST_REGULAR_ALT = K_TRIG_RIGHT_ALT,
 
 	K_AUX1,
 	K_AUX2,

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -57,6 +57,10 @@ static qboolean mlooking;
 // Used throughout the client.
 int sys_frame_time;
 
+// the joystick altselector that turns K_JOYX into K_JOYX_ALT
+// is pressed
+qboolean joy_altselector_pressed = false;
+
 // Console Variables
 cvar_t *vid_fullscreen;
 cvar_t *freelook;
@@ -844,6 +848,18 @@ IN_MLookUp(void)
 	IN_CenterView();
 }
 
+static void
+IN_JoyAltSelectorDown(void)
+{
+	joy_altselector_pressed = true;
+}
+
+static void
+IN_JoyAltSelectorUp(void)
+{
+	joy_altselector_pressed = false;
+}
+
 /* ------------------------------------------------------------------ */
 
 static void IN_Haptic_Shutdown(void);
@@ -1235,6 +1251,9 @@ IN_Init(void)
 
 	Cmd_AddCommand("+mlook", IN_MLookDown);
 	Cmd_AddCommand("-mlook", IN_MLookUp);
+
+	Cmd_AddCommand("+joyaltselector", IN_JoyAltSelectorDown);
+	Cmd_AddCommand("-joyaltselector", IN_JoyAltSelectorUp);
 
 	SDL_StartTextInput();
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -823,7 +823,8 @@ char *bindnames[][2] =
     {"invdrop", "drop item"},
     {"invprev", "prev item"},
     {"invnext", "next item"},
-    {"cmd help", "help computer"}
+    {"cmd help", "help computer"},
+    {"+joyaltselector", "enable alt joy keys"}
 };
 #define NUM_BINDNAMES (sizeof bindnames / sizeof bindnames[0])
 


### PR DESCRIPTION
There's an "enable alt joy keys" command now. If a key is bound to that
command, all joystick buttons (incl. hat and triggers) are turned from
K_JOYx into K_JOYx_ALT, which allows two keybindings on the same key,
one with the altselector pressed and one without.
If there's no keybinding for K_JOYx_ALT, it will use the binding for
just K_JOYx as a fallback (if it exists).

This is especially handy to create direct bindings for all the weapons
on the (limited amount of) Joystick buttons.

This is inspired by #387 / #388