### PR TITLE
Make gl3 fast with AMDs Windows drivers

### DIFF
--- a/doc/04_cvarlist.md
+++ b/doc/04_cvarlist.md
@@ -177,6 +177,12 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   and `16`. Anisotropic filtering gives a huge improvement to texture
   quality by a negligible performance impact.
 
+* **gl_fixsurfsky**: Some maps misuse sky surfaces for interior
+  lightning. The original renderer had a bug that made such surfaces
+  mess up the lightning of entities near them. If set to `0` (the
+  default) the bug is there and maps look like their developers
+  intended. If set to `1` the bug is fixed and the lightning correct.
+
 * **gl_msaa_samples**: Full scene anti aliasing samples. The number of
   samples depends on the GPU driver, most drivers support at least `2`,
   `4` and `8` samples. If an invalid value is set, the value is reverted

--- a/src/client/refresh/gl1/gl1_model.c
+++ b/src/client/refresh/gl1/gl1_model.c
@@ -577,6 +577,8 @@ Mod_LoadFaces(lump_t *l)
 	int planenum, side;
 	int ti;
 
+	cvar_t* gl_fixsurfsky = ri.Cvar_Get("gl_fixsurfsky", "0", CVAR_ARCHIVE);
+
 	in = (void *)(mod_base + l->fileofs);
 
 	if (l->filelen % sizeof(*in))
@@ -655,9 +657,12 @@ Mod_LoadFaces(lump_t *l)
 			R_SubdivideSurface(out); /* cut up polygon for warps */
 		}
 
-		if (out->texinfo->flags & SURF_SKY)
+		if (gl_fixsurfsky->value)
 		{
-			out->flags |= SURF_DRAWSKY;
+			if (out->texinfo->flags & SURF_SKY)
+			{
+				out->flags |= SURF_DRAWSKY;
+			}
 		}
 
 		/* create lightmaps and polygons */

--- a/src/client/refresh/gl1/gl1_model.c
+++ b/src/client/refresh/gl1/gl1_model.c
@@ -655,9 +655,13 @@ Mod_LoadFaces(lump_t *l)
 			R_SubdivideSurface(out); /* cut up polygon for warps */
 		}
 
+		if (out->texinfo->flags & SURF_SKY)
+		{
+			out->flags |= SURF_DRAWSKY;
+		}
+
 		/* create lightmaps and polygons */
-		if (!(out->texinfo->flags &
-			  (SURF_SKY | SURF_TRANS33 | SURF_TRANS66 | SURF_WARP)))
+		if (!(out->texinfo->flags & (SURF_SKY | SURF_TRANS33 | SURF_TRANS66 | SURF_WARP)))
 		{
 			LM_CreateSurfaceLightmap(out);
 		}

--- a/src/client/refresh/gl3/gl3_light.c
+++ b/src/client/refresh/gl3/gl3_light.c
@@ -233,10 +233,10 @@ RecursiveLightPoint(mnode_t *node, vec3_t start, vec3_t end)
 			for (maps = 0; maps < MAX_LIGHTMAPS_PER_SURFACE && surf->styles[maps] != 255;
 				 maps++)
 			{
-				for (i = 0; i < 3; i++)
+				for (int j = 0; j < 3; j++)
 				{
-					scale[i] = r_modulate->value *
-							   gl3_newrefdef.lightstyles[surf->styles[maps]].rgb[i];
+					scale[j] = r_modulate->value *
+							   gl3_newrefdef.lightstyles[surf->styles[maps]].rgb[j];
 				}
 
 				pointcolor[0] += lightmap[0] * scale[0] * (1.0 / 255);

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -583,6 +583,18 @@ GL3_Shutdown(void)
 	GL3_ShutdownContext();
 }
 
+// assumes gl3state.v[ab]o3D are bound
+// buffers and draws gl3_3D_vtx_t vertices
+// drawMode is something like GL_TRIANGLE_STRIP or GL_TRIANGLE_FAN or whatever
+void
+GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode)
+{
+	// TODO: do something more efficient, maybe with glMapBufferRange() + GL_MAP_UNSYNCHRONIZED_BIT
+	//       and glBindBufferRange()
+	glBufferData( GL_ARRAY_BUFFER, sizeof(gl3_3D_vtx_t)*numVerts, verts, GL_STREAM_DRAW );
+	glDrawArrays( drawMode, 0, numVerts );
+}
+
 static void
 GL3_DrawBeam(entity_t *e)
 {
@@ -658,8 +670,7 @@ GL3_DrawBeam(entity_t *e)
 	GL3_BindVAO(gl3state.vao3D);
 	GL3_BindVBO(gl3state.vbo3D);
 
-	glBufferData(GL_ARRAY_BUFFER, sizeof(verts), verts, GL_STREAM_DRAW);
-	glDrawArrays( GL_TRIANGLE_STRIP, 0, NUM_BEAM_SEGS*4 );
+	GL3_BufferAndDraw3D(verts, NUM_BEAM_SEGS*4, GL_TRIANGLE_STRIP);
 
 	glDisable(GL_BLEND);
 	glDepthMask(GL_TRUE);
@@ -734,8 +745,7 @@ GL3_DrawSpriteModel(entity_t *e)
 	GL3_BindVAO(gl3state.vao3D);
 	GL3_BindVBO(gl3state.vbo3D);
 
-	glBufferData(GL_ARRAY_BUFFER, 4*sizeof(gl3_3D_vtx_t), verts, GL_STREAM_DRAW);
-	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+	GL3_BufferAndDraw3D(verts, 4, GL_TRIANGLE_FAN);
 
 	if (alpha != 1.0F)
 	{
@@ -779,16 +789,14 @@ GL3_DrawNullModel(void)
 		{{16 * cos( 4 * M_PI / 2 ), 16 * sin( 4 * M_PI / 2 ), 0}, {0,0}, {0,0}}
 	};
 
-	glBufferData(GL_ARRAY_BUFFER, sizeof(vtxA), vtxA, GL_STREAM_DRAW);
-	glDrawArrays(GL_TRIANGLE_FAN, 0, 6);
+	GL3_BufferAndDraw3D(vtxA, 6, GL_TRIANGLE_FAN);
 
 	gl3_3D_vtx_t vtxB[6] = {
 		{{0, 0, 16}, {0,0}, {0,0}},
 		vtxA[5], vtxA[4], vtxA[3], vtxA[2], vtxA[1]
 	};
 
-	glBufferData(GL_ARRAY_BUFFER, sizeof(vtxB), vtxB, GL_STREAM_DRAW);
-	glDrawArrays(GL_TRIANGLE_FAN, 0, 6);
+	GL3_BufferAndDraw3D(vtxB, 6, GL_TRIANGLE_FAN);
 
 	gl3state.uni3DData.transModelMat4 = origModelMat;
 	GL3_UpdateUBO3D();

--- a/src/client/refresh/gl3/gl3_model.c
+++ b/src/client/refresh/gl3/gl3_model.c
@@ -541,6 +541,11 @@ Mod_LoadFaces(lump_t *l)
 			GL3_SubdivideSurface(out, loadmodel); /* cut up polygon for warps */
 		}
 
+		if (out->texinfo->flags & SURF_SKY)
+		{
+			out->flags |= SURF_DRAWSKY;
+		}
+
 		/* create lightmaps and polygons */
 		if (!(out->texinfo->flags & (SURF_SKY | SURF_TRANS33 | SURF_TRANS66 | SURF_WARP)))
 		{

--- a/src/client/refresh/gl3/gl3_model.c
+++ b/src/client/refresh/gl3/gl3_model.c
@@ -463,6 +463,8 @@ Mod_LoadFaces(lump_t *l)
 	int planenum, side;
 	int ti;
 
+	cvar_t* gl_fixsurfsky = ri.Cvar_Get("gl_fixsurfsky", "0", CVAR_ARCHIVE);
+
 	in = (void *)(mod_base + l->fileofs);
 
 	if (l->filelen % sizeof(*in))
@@ -541,9 +543,12 @@ Mod_LoadFaces(lump_t *l)
 			GL3_SubdivideSurface(out, loadmodel); /* cut up polygon for warps */
 		}
 
-		if (out->texinfo->flags & SURF_SKY)
+		if (gl_fixsurfsky->value)
 		{
-			out->flags |= SURF_DRAWSKY;
+			if (out->texinfo->flags & SURF_SKY)
+			{
+				out->flags |= SURF_DRAWSKY;
+			}
 		}
 
 		/* create lightmaps and polygons */

--- a/src/client/refresh/gl3/gl3_sdl.c
+++ b/src/client/refresh/gl3/gl3_sdl.c
@@ -98,6 +98,15 @@ DebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei le
  */
 void GL3_EndFrame(void)
 {
+	if(gl3config.useBigVBO)
+	{
+		// I think this is a good point to orphan the VBO and get a fresh one
+		GL3_BindVAO(gl3state.vao3D);
+		GL3_BindVBO(gl3state.vbo3D);
+		glBufferData(GL_ARRAY_BUFFER, gl3state.vbo3Dsize, NULL, GL_STREAM_DRAW);
+		gl3state.vbo3DcurOffset = 0;
+	}
+
 	SDL_GL_SwapWindow(window);
 }
 

--- a/src/client/refresh/gl3/gl3_shaders.c
+++ b/src/client/refresh/gl3/gl3_shaders.c
@@ -626,7 +626,7 @@ static const char* fragmentSrcAlias = MULTILINE_STRING(
 			// apply gamma correction and intensity
 			texel.rgb *= intensity;
 			texel.a *= alpha; // is alpha even used here?
-			texel *= min(vec4(3.0), passColor);
+			texel *= min(vec4(1.5), passColor);
 
 			outColor.rgb = pow(texel.rgb, vec3(gamma));
 			outColor.a = texel.a; // I think alpha shouldn't be modified by gamma and intensity

--- a/src/client/refresh/gl3/gl3_surf.c
+++ b/src/client/refresh/gl3/gl3_surf.c
@@ -44,7 +44,7 @@ extern int numgl3textures;
 void GL3_SurfInit(void)
 {
 	// init the VAO and VBO for the standard vertexdata: 10 floats and 1 uint
-	// (X, Y, Z), (S, T), (LMS, LMT), (normX, normY, normZ) - last two groups for lightmap/dynlights
+	// (X, Y, Z), (S, T), (LMS, LMT), (normX, normY, normZ) ; lightFlags - last two groups for lightmap/dynlights
 
 	glGenVertexArrays(1, &gl3state.vao3D);
 	GL3_BindVAO(gl3state.vao3D);
@@ -212,9 +212,8 @@ GL3_DrawGLPoly(msurface_t *fa)
 
 	GL3_BindVAO(gl3state.vao3D);
 	GL3_BindVBO(gl3state.vbo3D);
-	glBufferData(GL_ARRAY_BUFFER, sizeof(gl3_3D_vtx_t)*p->numverts, p->vertices, GL_STREAM_DRAW);
 
-	glDrawArrays(GL_TRIANGLE_FAN, 0, p->numverts);
+	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN);
 }
 
 void
@@ -241,8 +240,7 @@ GL3_DrawGLFlowingPoly(msurface_t *fa)
 	GL3_BindVAO(gl3state.vao3D);
 	GL3_BindVBO(gl3state.vbo3D);
 
-	glBufferData(GL_ARRAY_BUFFER, sizeof(gl3_3D_vtx_t)*p->numverts, p->vertices, GL_STREAM_DRAW);
-	glDrawArrays(GL_TRIANGLE_FAN, 0, p->numverts);
+	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN);
 }
 
 static void

--- a/src/client/refresh/gl3/gl3_surf.c
+++ b/src/client/refresh/gl3/gl3_surf.c
@@ -52,6 +52,13 @@ void GL3_SurfInit(void)
 	glGenBuffers(1, &gl3state.vbo3D);
 	GL3_BindVBO(gl3state.vbo3D);
 
+	if(gl3config.useBigVBO)
+	{
+		gl3state.vbo3Dsize = 5*1024*1024; // a 5MB buffer seems to work well?
+		gl3state.vbo3DcurOffset = 0;
+		glBufferData(GL_ARRAY_BUFFER, gl3state.vbo3Dsize, NULL, GL_STREAM_DRAW); // allocate/reserve that data
+	}
+
 	glEnableVertexAttribArray(GL3_ATTRIB_POSITION);
 	qglVertexAttribPointer(GL3_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, sizeof(gl3_3D_vtx_t), 0);
 

--- a/src/client/refresh/gl3/gl3_warp.c
+++ b/src/client/refresh/gl3/gl3_warp.c
@@ -255,9 +255,7 @@ GL3_EmitWaterPolys(msurface_t *fa)
 
 	for (bp = fa->polys; bp != NULL; bp = bp->next)
 	{
-		int numverts = bp->numverts;
-		glBufferData(GL_ARRAY_BUFFER, sizeof(gl3_3D_vtx_t)*numverts, bp->vertices, GL_STREAM_DRAW);
-		glDrawArrays(GL_TRIANGLE_FAN, 0, numverts);
+		GL3_BufferAndDraw3D(bp->vertices, bp->numverts, GL_TRIANGLE_FAN);
 	}
 }
 
@@ -726,8 +724,7 @@ GL3_DrawSkyBox(void)
 		MakeSkyVec( skymaxs [ 0 ] [ i ], skymaxs [ 1 ] [ i ], i, &skyVertices[2] );
 		MakeSkyVec( skymaxs [ 0 ] [ i ], skymins [ 1 ] [ i ], i, &skyVertices[3] );
 
-		glBufferData(GL_ARRAY_BUFFER, sizeof(skyVertices), skyVertices, GL_STREAM_DRAW);
-		glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+		GL3_BufferAndDraw3D(skyVertices, 4, GL_TRIANGLE_FAN);
 	}
 
 	// glPopMatrix();

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -106,6 +106,8 @@ typedef struct
 	qboolean debug_output; // is GL_ARB_debug_output supported?
 	qboolean stencil; // Do we have a stencil buffer?
 
+	qboolean useBigVBO; // workaround for AMDs windows driver for fewer calls to glBufferData()
+
 	// ----
 
 	float max_anisotropy;
@@ -226,6 +228,11 @@ typedef struct
 	gl3ShaderInfo_t siParticle; // for particles. surprising, right?
 
 	GLuint vao3D, vbo3D; // for brushes etc, using 10 floats and one uint as vertex input (x,y,z, s,t, lms,lmt, normX,normY,normZ ; lightFlags)
+
+	// the next two are for gl3config.useBigVBO == true
+	int vbo3Dsize;
+	int vbo3DcurOffset;
+
 	GLuint vaoAlias, vboAlias, eboAlias; // for models, using 9 floats as (x,y,z, s,t, r,g,b,a)
 	GLuint vaoParticle, vboParticle; // for particles, using 9 floats (x,y,z, size,distance, r,g,b,a)
 

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -225,7 +225,7 @@ typedef struct
 	// NOTE: make sure siParticle is always the last shaderInfo (or adapt GL3_ShutdownShaders())
 	gl3ShaderInfo_t siParticle; // for particles. surprising, right?
 
-	GLuint vao3D, vbo3D; // for brushes etc, using 1 floats as vertex input (x,y,z, s,t, lms,lmt, normX,normY,normZ)
+	GLuint vao3D, vbo3D; // for brushes etc, using 10 floats and one uint as vertex input (x,y,z, s,t, lms,lmt, normX,normY,normZ ; lightFlags)
 	GLuint vaoAlias, vboAlias, eboAlias; // for models, using 9 floats as (x,y,z, s,t, r,g,b,a)
 	GLuint vaoParticle, vboParticle; // for particles, using 9 floats (x,y,z, size,distance, r,g,b,a)
 
@@ -349,6 +349,8 @@ GL3_BindEBO(GLuint ebo)
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
 	}
 }
+
+extern void GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode);
 
 extern qboolean GL3_CullBox(vec3_t mins, vec3_t maxs);
 extern void GL3_RotateForEntity(entity_t *e);


### PR DESCRIPTION
Seems like AMDs Windows driver doesn't like it when we call `glBufferData()` *a lot* (other drivers, incl. Intels and, IIRC, the AMD legacy driver used for the Radeon HD 6850 don't seem to care as much).
Even on an i7-4771 with a Radeon RX 580 I couldn't get stable 60fps on Windows without this workaround (the open source Linux driver is ok).

The be enabled/disabled with the gl3_usebigvbo CVar; by default it's -1 which means "enable if AMD driver is detected".

Enabling it when using a nvidia GPU with their proprietary drivers reduces the performance to 1/3 of the fps we get without it, so it indeed needs to be conditional...
So yeah, this is our first GPU-vendor specific workaround :-/


I'm not 100% sure about the code yet, I especially wonder if I should add some padding between the data in the VBO of consecutive calls to `GL3_BufferAndDraw3D()`..