### PR TITLE
Allow scrolling with mouse in console

### DIFF
--- a/src/client/cl_keyboard.c
+++ b/src/client/cl_keyboard.c
@@ -1016,6 +1016,10 @@ Key_Init(void)
 	consolekeys[K_KP_PLUS] = true;
 	consolekeys[K_KP_MINUS] = true;
 	consolekeys[K_KP_5] = true;
+	consolekeys[K_MWHEELUP] = true;
+	consolekeys[K_MWHEELDOWN] = true;
+	consolekeys[K_MOUSE4] = true;
+	consolekeys[K_MOUSE5] = true;
 
 	consolekeys['`'] = false;
 	consolekeys['~'] = false;
@@ -1160,7 +1164,8 @@ Key_Event(int key, qboolean down, qboolean special)
 	}
 
 	/* Key is unbound */
-	if ((key >= K_MOUSE1 && key != K_JOY_BACK) && !keybindings[key] && (cls.key_dest != key_console))
+	if ((key >= K_MOUSE1 && key != K_JOY_BACK) && !keybindings[key] && (cls.key_dest != key_console) &&
+		(cls.state == ca_active))
 	{
 		Com_Printf("%s is unbound, hit F4 to set.\n", Key_KeynumToString(key));
 	}


### PR DESCRIPTION
Scroll functionality for both the mouse wheel and buttons 4 & 5 was already implemented in `Key_Console()`. However, those keycodes never reached that function as they were not declared in `consolekeys`.

Once that issue was fixed another appeared. If those keycodes were unbound, warning messages would then appear in instances where the console was technically open but `cls.key_dest` was not set to `key_console` (e.g. fullscreen console).

In order to fix this unbound key warnings now only print when in-game. This is the only time when the warnings are actually useful as `Con_DrawNotify()` is only called during gameplay.
