### PR TITLE
Multi-Monitor Management

### DIFF
--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -32,6 +32,7 @@
 extern void M_ForceMenuOff(void);
 
 static cvar_t *r_mode;
+static cvar_t *vid_displayindex;
 static cvar_t *r_hudscale;
 static cvar_t *r_consolescale;
 static cvar_t *r_menuscale;
@@ -49,6 +50,7 @@ static menuframework_s s_opengl_menu;
 
 static menulist_s s_renderer_list;
 static menulist_s s_mode_list;
+static menulist_s s_display_list;
 static menulist_s s_uiscale_list;
 static menuslider_s s_brightness_slider;
 static menuslider_s s_fov_slider;
@@ -188,6 +190,12 @@ ApplyChanges(void *unused)
 	{
 		/* Restarts automatically */
 		Cvar_SetValue("r_mode", s_mode_list.curvalue);
+	}
+
+	if (s_display_list.curvalue != GLimp_GetWindowDisplayIndex() )
+	{
+		Cvar_SetValue( "vid_displayindex", s_display_list.curvalue );
+		restart = true;
 	}
 
 	/* UI scaling */
@@ -333,6 +341,11 @@ VID_MenuInit(void)
 		r_mode = Cvar_Get("r_mode", "4", 0);
 	}
 
+	if (!vid_displayindex)
+	{
+		vid_displayindex = Cvar_Get("vid_displayindex", "0", CVAR_ARCHIVE);
+	}
+
 	if (!r_hudscale)
 	{
 		r_hudscale = Cvar_Get("r_hudscale", "-1", CVAR_ARCHIVE);
@@ -413,6 +426,13 @@ VID_MenuInit(void)
 		// 'custom'
 		s_mode_list.curvalue = GetCustomValue(&s_mode_list);
 	}
+
+	s_display_list.generic.type = MTYPE_SPINCONTROL;
+	s_display_list.generic.name = "display index";
+	s_display_list.generic.x = 0;
+	s_display_list.generic.y = (y += 10);
+	s_display_list.itemnames = GLimp_GetDisplayIndices();
+	s_display_list.curvalue = GLimp_GetWindowDisplayIndex();
 
 	s_brightness_slider.generic.type = MTYPE_SLIDER;
 	s_brightness_slider.generic.name = "brightness";
@@ -519,6 +539,7 @@ VID_MenuInit(void)
 
 	Menu_AddItem(&s_opengl_menu, (void *)&s_renderer_list);
 	Menu_AddItem(&s_opengl_menu, (void *)&s_mode_list);
+	Menu_AddItem(&s_opengl_menu, (void *)&s_display_list);
 	Menu_AddItem(&s_opengl_menu, (void *)&s_brightness_slider);
 	Menu_AddItem(&s_opengl_menu, (void *)&s_fov_slider);
 	Menu_AddItem(&s_opengl_menu, (void *)&s_uiscale_list);

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -427,12 +427,15 @@ VID_MenuInit(void)
 		s_mode_list.curvalue = GetCustomValue(&s_mode_list);
 	}
 
-	s_display_list.generic.type = MTYPE_SPINCONTROL;
-	s_display_list.generic.name = "display index";
-	s_display_list.generic.x = 0;
-	s_display_list.generic.y = (y += 10);
-	s_display_list.itemnames = GLimp_GetDisplayIndices();
-	s_display_list.curvalue = GLimp_GetWindowDisplayIndex();
+	if (GLimp_GetNumVideoDisplays() > 1)
+	{
+		s_display_list.generic.type = MTYPE_SPINCONTROL;
+		s_display_list.generic.name = "display index";
+		s_display_list.generic.x = 0;
+		s_display_list.generic.y = (y += 10);
+		s_display_list.itemnames = GLimp_GetDisplayIndices();
+		s_display_list.curvalue = GLimp_GetWindowDisplayIndex();
+	}
 
 	s_brightness_slider.generic.type = MTYPE_SLIDER;
 	s_brightness_slider.generic.name = "brightness";
@@ -539,7 +542,13 @@ VID_MenuInit(void)
 
 	Menu_AddItem(&s_opengl_menu, (void *)&s_renderer_list);
 	Menu_AddItem(&s_opengl_menu, (void *)&s_mode_list);
-	Menu_AddItem(&s_opengl_menu, (void *)&s_display_list);
+
+	// only show this option if we have multiple displays
+	if (GLimp_GetNumVideoDisplays() > 1)
+	{
+		Menu_AddItem(&s_opengl_menu, (void *)&s_display_list);
+	}
+
 	Menu_AddItem(&s_opengl_menu, (void *)&s_brightness_slider);
 	Menu_AddItem(&s_opengl_menu, (void *)&s_fov_slider);
 	Menu_AddItem(&s_opengl_menu, (void *)&s_uiscale_list);

--- a/src/client/vid/glimp_sdl.c
+++ b/src/client/vid/glimp_sdl.c
@@ -219,7 +219,7 @@ ShutdownGraphics(void)
 			last_display = vid_displayindex->value;
 		}
 		else {
-		SDL_GetWindowPosition(window,
+			SDL_GetWindowPosition(window,
 				      &last_position_x, &last_position_y);
 		}
 

--- a/src/client/vid/glimp_sdl.c
+++ b/src/client/vid/glimp_sdl.c
@@ -99,7 +99,6 @@ InitDisplayIndices(qboolean ClearExisting)
 static qboolean
 CreateSDLWindow(int flags, int w, int h)
 {
-	num_displays = SDL_GetNumVideoDisplays();
 	int displayindex = 0;
 
 	if ( vid_displayindex->value < 0 || vid_displayindex->value >= num_displays)
@@ -256,6 +255,8 @@ GLimp_Init(void)
 		SDL_GetVersion(&version);
 		Com_Printf("SDL version is: %i.%i.%i\n", (int)version.major, (int)version.minor, (int)version.patch);
 		Com_Printf("SDL video driver is \"%s\".\n", SDL_GetCurrentVideoDriver());
+
+		num_displays = SDL_GetNumVideoDisplays();
 	}
 
 	return true;

--- a/src/client/vid/header/vid.h
+++ b/src/client/vid/header/vid.h
@@ -55,6 +55,9 @@ const char *VID_MenuKey(int);
 // Stuff provided by platform backend.
 extern int glimp_refreshRate;
 
+const char **GLimp_GetDisplayIndices(void);
+int GLimp_GetWindowDisplayIndex(void);
+int GLimp_GetNumVideoDisplays(void);
 qboolean GLimp_Init(void);
 void GLimp_Shutdown(void);
 qboolean GLimp_InitGraphics(int fullscreen, int *pwidth, int *pheight);


### PR DESCRIPTION
This pull request adds an option to the "VIDEO" menu that allows you to specify which display/monitor you want the game to run on, and can be seen in the screenshot.

![20190616043855_1](https://user-images.githubusercontent.com/8671884/59561714-5a83fb00-8ff1-11e9-8bab-2a487458cda5.jpg)

If this option is not desired, please feel free to disregard this pull request.

This adds a new archived Cvar "vid_displayindex" which the video menu sets and signals a restart with the "restart" qboolean in ApplyChanges()

Extra Notes:

The last_position_x and last_position_y variables don't actually seem to be used, though the window position is still stored in them.

I have a habit of adding extra spaces around parenthesis, and I notice I still accidentally did that, but if you prefer I conform to the no-spaces coding style, I can throw that in an extra commit.

If you have any other questions/comments/concerns, please let me know.