### PR TITLE
Silence deprecation warning with OpenGL.

### DIFF
--- a/src/client/refresh/gl1/header/qgl.h
+++ b/src/client/refresh/gl1/header/qgl.h
@@ -34,6 +34,7 @@
 #endif
 
 #if defined(__APPLE__)
+#define GL_SILENCE_DEPRECATION
 #include <OpenGL/gl.h>
 #else
 #include <GL/gl.h>


### PR DESCRIPTION
on Darwin, Mojave has deprecated it in favor of Metal,
here we silent the lengthy build warning.