### PR TITLE
Typos in README: if => in, build => built

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 Yamagi Quake II is an enhanced client for id Software's Quake
 II with focus on offline and coop gameplay. Both the gameplay and the graphics
-are unchanged, but many bugs if the last official release were fixed and some
+are unchanged, but many bugs in the last official release were fixed and some
 nice to have features like widescreen support and a modern OpenGL 3.2 renderer
 were added. Unlike most other Quake II source ports Yamagi Quake II is fully 64-bit
 clean. It works perfectly on modern processors and operating systems. Yamagi
 Quake II runs on nearly all common platforms; including FreeBSD, Linux, OpenBSD,
 Windows and macOS (experimental).
 
-This code is build upon Icculus Quake II, which itself is based on Quake II
+This code is built upon Icculus Quake II, which itself is based on Quake II
 3.21. Yamagi Quake II is released under the terms of the GPL version 2. See the
 LICENSE file for further information.
 


### PR DESCRIPTION
if => in (in the last official release)
build => built (is built upon)