### PR TITLE
Fix the pending sound list sorting

### DIFF
--- a/src/client/sound/sound.c
+++ b/src/client/sound/sound.c
@@ -724,7 +724,7 @@ S_StartSound(vec3_t origin, int entnum, int entchannel, sfx_t *sfx,
 
 	/* sort into the pending sound list */
 	for (sort = s_pendingplays.next;
-		 sort != &s_pendingplays && sort->begin < ps->begin;
+		 sort != &s_pendingplays && sort->begin <= ps->begin;
 		 sort = sort->next)
 	{
 	}


### PR DESCRIPTION
S_StartSound inserts sounds with same mix time after the first inserted such sound, instead of after the last one.

#448 