### PR TITLE
Full bugfix for monsters not fighting parasites

### DIFF
--- a/src/game/g_monster.c
+++ b/src/game/g_monster.c
@@ -996,7 +996,10 @@ flymonster_start_go(edict_t *self)
 		self->yaw_speed = 10;
 	}
 
-	self->viewheight = 25;
+	if (!self->viewheight)
+	{
+		self->viewheight = 25;
+	}
 
 	monster_start_go(self);
 
@@ -1032,7 +1035,10 @@ swimmonster_start_go(edict_t *self)
 		self->yaw_speed = 10;
 	}
 
-	self->viewheight = 10;
+	if (!self->viewheight)
+	{
+		self->viewheight = 10;
+	}
 
 	monster_start_go(self);
 

--- a/src/game/monster/parasite/parasite.c
+++ b/src/game/monster/parasite/parasite.c
@@ -764,6 +764,7 @@ SP_monster_parasite(edict_t *self)
 	self->health = 175;
 	self->gib_health = -50;
 	self->mass = 250;
+	self->viewheight = 16;
 
 	self->pain = parasite_pain;
 	self->die = parasite_die;


### PR DESCRIPTION
I noticed the bugfix to asdress https://github.com/yquake2/yquake2/issues/440 was incomplete. This pull request completes it by setting the parasite's viewheight to 16, ensuring traces don't shoot over its bbox. I also added if (!self->viewheight) checks to swimmonster and flymonster as well for consistency with walkmonster.