### PR TITLE
Fix for insane marines not always playing pain sounds

### DIFF
--- a/src/game/monster/insane/insane.c
+++ b/src/game/monster/insane/insane.c
@@ -27,6 +27,8 @@
 #include "../../header/local.h"
 #include "insane.h"
 
+#define SPAWNFLAG_CRUSIFIED		8
+
 static int sound_fist;
 static int sound_shake;
 static int sound_moan;
@@ -62,6 +64,12 @@ insane_moan(edict_t *self)
 		return;
 	}
 
+	/* suppress screaming so pain sound can play */
+	if (self->delay > level.time)
+	{
+		return;
+	}
+
 	gi.sound(self, CHAN_VOICE, sound_moan, 1, ATTN_IDLE, 0);
 }
 
@@ -69,6 +77,12 @@ void
 insane_scream(edict_t *self)
 {
 	if (!self)
+	{
+		return;
+	}
+
+	/* suppress screaming so pain sound can play */
+	if (self->delay > level.time)
 	{
 		return;
 	}
@@ -682,13 +696,16 @@ insane_pain(edict_t *self, edict_t *other /* unused */,
 	gi.sound(self, CHAN_VOICE, gi.soundindex(va("player/male/pain%i_%i.wav",
 							l, r)), 1, ATTN_IDLE, 0);
 
+	/* suppress screaming and moaning for 1 second so pain sound plays */
+	self->delay = level.time + 1;
+
 	if (skill->value == 3)
 	{
 		return; /* no pain anims in nightmare */
 	}
 
 	/* Don't go into pain frames if crucified. */
-	if (self->spawnflags & 8)
+	if (self->spawnflags & SPAWNFLAG_CRUSIFIED)
 	{
 		self->monsterinfo.currentmove = &insane_move_struggle_cross;
 		return;
@@ -772,7 +789,7 @@ insane_stand(edict_t *self)
 		return;
 	}
 
-	if (self->spawnflags & 8) /* If crucified */
+	if (self->spawnflags & SPAWNFLAG_CRUSIFIED) /* If crucified */
 	{
 		self->monsterinfo.currentmove = &insane_move_cross;
 		self->monsterinfo.aiflags |= AI_STAND_GROUND;
@@ -801,7 +818,7 @@ insane_dead(edict_t *self)
 		return;
 	}
 
-	if (self->spawnflags & 8)
+	if (self->spawnflags & SPAWNFLAG_CRUSIFIED)
 	{
 		self->flags |= FL_FLY;
 	}
@@ -862,7 +879,7 @@ insane_die(edict_t *self, edict_t *inflictor /* unused */,
 	self->deadflag = DEAD_DEAD;
 	self->takedamage = DAMAGE_YES;
 
-	if (self->spawnflags & 8)
+	if (self->spawnflags & SPAWNFLAG_CRUSIFIED)
 	{
 		insane_dead(self);
 	}
@@ -945,7 +962,7 @@ SP_misc_insane(edict_t *self)
 
 	self->monsterinfo.scale = MODEL_SCALE;
 
-	if (self->spawnflags & 8) /* Crucified ? */
+	if (self->spawnflags & SPAWNFLAG_CRUSIFIED) /* Crucified ? */
 	{
 		VectorSet(self->mins, -16, 0, 0);
 		VectorSet(self->maxs, 16, 8, 32);


### PR DESCRIPTION
This was a little thing partially caused by the change in sound prioritization. Insane marines will no longer scream or moan for 1 second after taking damage. To my knowledge the insane marines are the only enemy type in the game who need this special handling of sound priority. This also fixes the sound issue on nightmare difficulty, since they don't go into pain frames they constantly moan and scream which frequently would cut off the pain sound. I will also add pull requests for xatrix and rogue to address this there.