### PR TITLE
Triggered spawned monsters use path_corner correctly

### DIFF
--- a/src/game/g_monster.c
+++ b/src/game/g_monster.c
@@ -958,11 +958,13 @@ walkmonster_start_go(edict_t *self)
 		self->viewheight = 25;
 	}
 
-	monster_start_go(self);
-
 	if (self->spawnflags & 2)
 	{
 		monster_triggered_start(self);
+	}
+	else
+	{
+		monster_start_go(self);
 	}
 }
 
@@ -1001,11 +1003,13 @@ flymonster_start_go(edict_t *self)
 		self->viewheight = 25;
 	}
 
-	monster_start_go(self);
-
 	if (self->spawnflags & 2)
 	{
 		monster_triggered_start(self);
+	}
+	else
+	{
+		monster_start_go(self);
 	}
 }
 
@@ -1040,11 +1044,13 @@ swimmonster_start_go(edict_t *self)
 		self->viewheight = 10;
 	}
 
-	monster_start_go(self);
-
 	if (self->spawnflags & 2)
 	{
 		monster_triggered_start(self);
+	}
+	else
+	{
+		monster_start_go(self);
 	}
 }
 


### PR DESCRIPTION
This pull request addresses issue https://github.com/yquake2/yquake2/issues/458.

Long story short, it was caused by triggered spawn monsters calling monster_start_go() twice. First during initial spawn and then again when they are spawned by being triggered. The first call works correctly but the second call actually clears the target and sets the monster to stand still.

I fixed this by making triggered spawn monsters only call monster_start_go() once - when they get triggered.

You can use the security.ent test file from the bug report to see that when you pick up the shotgun, the triggered guard moves to his marker like the other guard does.