### PR TITLE
Fix monsters being disoriented after ducking

### DIFF
--- a/src/game/monster/brain/brain.c
+++ b/src/game/monster/brain/brain.c
@@ -383,6 +383,7 @@ brain_dodge(edict_t *self, edict_t *attacker, float eta)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	self->monsterinfo.pausetime = level.time + eta + 0.5;

--- a/src/game/monster/chick/chick.c
+++ b/src/game/monster/chick/chick.c
@@ -618,6 +618,7 @@ chick_dodge(edict_t *self, edict_t *attacker, float eta /* unused */)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	self->monsterinfo.currentmove = &chick_move_duck;

--- a/src/game/monster/gunner/gunner.c
+++ b/src/game/monster/gunner/gunner.c
@@ -609,6 +609,7 @@ gunner_dodge(edict_t *self, edict_t *attacker, float eta /* unused */)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	self->monsterinfo.currentmove = &gunner_move_duck;

--- a/src/game/monster/infantry/infantry.c
+++ b/src/game/monster/infantry/infantry.c
@@ -637,6 +637,7 @@ infantry_dodge(edict_t *self, edict_t *attacker, float eta /* unused */)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	self->monsterinfo.currentmove = &infantry_move_duck;

--- a/src/game/monster/medic/medic.c
+++ b/src/game/monster/medic/medic.c
@@ -681,6 +681,11 @@ mmove_t medic_move_duck =
 void
 medic_dodge(edict_t *self, edict_t *attacker, float eta)
 {
+	if (!self || !attacker)
+	{
+		return;
+	}
+
 	if (random() > 0.25)
 	{
 		return;
@@ -689,6 +694,7 @@ medic_dodge(edict_t *self, edict_t *attacker, float eta)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	self->monsterinfo.currentmove = &medic_move_duck;

--- a/src/game/monster/soldier/soldier.c
+++ b/src/game/monster/soldier/soldier.c
@@ -1092,6 +1092,7 @@ soldier_dodge(edict_t *self, edict_t *attacker, float eta)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	if (skill->value == 0)


### PR DESCRIPTION
This pull request fixes bug https://github.com/yquake2/yquake2/issues/456 by adding a call to FoundTarget() after assigning the enemy in the dodge functions.