### PR TITLE
Added gl1_particle_use_pointparams to avoid the point parameters rendering path

### DIFF
--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -88,6 +88,7 @@ cvar_t *gl1_particle_size;
 cvar_t *gl1_particle_att_a;
 cvar_t *gl1_particle_att_b;
 cvar_t *gl1_particle_att_c;
+cvar_t *gl1_particle_use_pointparams;
 
 cvar_t *gl1_palettedtexture;
 cvar_t *gl1_pointparameters;
@@ -517,6 +518,12 @@ R_DrawParticles(void)
 {
 	qboolean stereo_split_tb = ((gl_state.stereo_mode == STEREO_SPLIT_VERTICAL) && gl_state.camera_separation);
 	qboolean stereo_split_lr = ((gl_state.stereo_mode == STEREO_SPLIT_HORIZONTAL) && gl_state.camera_separation);
+
+	if (!gl1_particle_use_pointparams->value) {
+		R_DrawParticles2(r_newrefdef.num_particles,
+				r_newrefdef.particles, d_8to24table);
+		return;
+	}
 
 	if (gl_config.pointparameters && !(stereo_split_tb || stereo_split_lr))
 	{
@@ -1218,6 +1225,7 @@ R_Register(void)
 	gl1_particle_att_a = ri.Cvar_Get("gl1_particle_att_a", "0.01", CVAR_ARCHIVE);
 	gl1_particle_att_b = ri.Cvar_Get("gl1_particle_att_b", "0.0", CVAR_ARCHIVE);
 	gl1_particle_att_c = ri.Cvar_Get("gl1_particle_att_c", "0.01", CVAR_ARCHIVE);
+	gl1_particle_use_pointparams = ri.Cvar_Get("gl1_particle_use_pointparams", "1", CVAR_ARCHIVE);
 
 	r_modulate = ri.Cvar_Get("r_modulate", "1", CVAR_ARCHIVE);
 	r_mode = ri.Cvar_Get("r_mode", "4", CVAR_ARCHIVE);


### PR DESCRIPTION
ref_gl1 renders points weirdly on my machine. Way too big, and square.

After trying to work out why for an hour or so I just forced it to use R_DrawParticles2() regardless of point parameters support, which renders them correctly. I added gl1_particle_use_pointparms to make it slightly cleaner, but it's still quite hacky...

Someone with more experience can likely work out why R_DrawParticles() wasn't behaving, and point me to a real fix, which would be appreciated.