### PR TITLE
coop_baseq2 documentation added under General section in cvar docs

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -16,10 +16,10 @@ have been renamed. The prefixes are:
 * `sw_`: Software renderer.
 * `vid_`: Video backend.
 
-All cvars may be given at command line trough `+set cvar value` or typed
+All cvars may be given at command line through `+set cvar value` or typed
 into the console. The console can be opended with *Left Shift + Esc*.
 
-Keep in mind that some cvar need quotation marks around the arguments.
+Keep in mind that some cvars need quotation marks around the arguments.
 When giving such cvars at the command line the argument string must be
 surrounded by ticks. For example `+set sv_maplist '"q2dm1 q2dm2"'`.
 
@@ -83,6 +83,19 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   during gameplay and released otherwise (in menu, videos, console or if
   game is paused).
 
+* **coop_baseq2 (Ground Zero only)**: In Ground Zero, entity spawnflags
+  (which difficulty modes / game modes level entities spawn in) are
+  interpeted a bit differently. In original Quake 2, if an entity is
+  set to not spawn on any difficulty, it is treated as deathmatch-only,
+  however, in Ground Zero this same condition is treated as coop-only.
+  This causes maps made for original Quake 2, including the entire
+  Quake 2 campaign, to not work correctly when played in Ground Zero
+  in co-op mode. This cvar, when set to 1, restores the original
+  interpretation and enables you to play original Quake 2 maps in
+  Ground Zero co-op. Though keep in mind that Ground Zero maps will
+  not work correctly when this cvar is enabled so remember to
+  disable it again before playing Ground Zero maps in co-op. By
+  default this cvar is disabled (set to 0).
 
 ## Audio
 


### PR DESCRIPTION
Added documentation for coop_baseq2 cvar. I wasn't sure where to put it so I put it under the General section of the cvar docs. If you want it somewhere else then let me know and I'll move it.