### PR TITLE
Use gl_texturemode for UI and skies as well, fixes #489 and #491

### DIFF
--- a/src/client/refresh/gl1/gl1_draw.c
+++ b/src/client/refresh/gl1/gl1_draw.c
@@ -501,8 +501,10 @@ RDraw_StretchRaw(int x, int y, int w, int h, int cols, int rows, byte *data)
 				0, GL_COLOR_INDEX, GL_UNSIGNED_BYTE, image8);
 	}
 
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	// Note: gl_filter_min could be GL_*_MIPMAP_* so we can't use it for min filter here (=> no mipmaps)
+	//       but gl_filter_max (either GL_LINEAR or GL_NEAREST) should do the trick.
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, gl_filter_max);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, gl_filter_max);
 
 	glEnableClientState( GL_VERTEX_ARRAY );
 	glEnableClientState( GL_TEXTURE_COORD_ARRAY );

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -378,8 +378,10 @@ GL3_Draw_StretchRaw(int x, int y, int w, int h, int cols, int rows, byte *data)
 		free(img);
 	}
 
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	// Note: gl_filter_min could be GL_*_MIPMAP_* so we can't use it for min filter here (=> no mipmaps)
+	//       but gl_filter_max (either GL_LINEAR or GL_NEAREST) should do the trick.
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, gl_filter_max);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, gl_filter_max);
 
 	drawTexturedRectangle(x, y, w, h, 0.0f, 0.0f, 1.0f, 1.0f);
 

--- a/src/client/refresh/gl3/gl3_misc.c
+++ b/src/client/refresh/gl3/gl3_misc.c
@@ -43,8 +43,8 @@ GL3_SetDefaultState(void)
 
 	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
-	// TODO: gl_texturemode, gl1_texturealphamode?
-	//GL3_TextureMode(gl_texturemode->string);
+	// TODO: gl1_texturealphamode?
+	GL3_TextureMode(gl_texturemode->string);
 	//R_TextureAlphaMode(gl1_texturealphamode->string);
 	//R_TextureSolidMode(gl1_texturesolidmode->string);
 

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -508,6 +508,7 @@ extern cvar_t *vid_gamma;
 extern cvar_t *gl3_intensity;
 extern cvar_t *gl3_intensity_2D;
 extern cvar_t *gl_anisotropic;
+extern cvar_t *gl_texturemode;
 
 extern cvar_t *r_lightlevel;
 extern cvar_t *gl3_overbrightbits;


### PR DESCRIPTION
and make sure that after vid_restart (or starting the game) it's used
correctly in GL3.

While at it, made sure that it's *not* applied to textures from
gl_nolerp_list, because they're supposed to always use GL_NEAREST
independent of this setting (used so console font and crosshairs don't
look blurry)