### PR TITLE
Fix for insane marines not firing deathtarget right away

### DIFF
--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -1015,7 +1015,7 @@ struct edict_s
 	float touch_debounce_time;
 	float pain_debounce_time;
 	float damage_debounce_time;
-	float fly_sound_debounce_time;
+	float fly_sound_debounce_time;	/* now also used by insane marines to store pain sound timeout */
 	float last_move_time;
 
 	int health;

--- a/src/game/monster/insane/insane.c
+++ b/src/game/monster/insane/insane.c
@@ -65,7 +65,7 @@ insane_moan(edict_t *self)
 	}
 
 	/* suppress screaming so pain sound can play */
-	if (self->delay > level.time)
+	if (self->fly_sound_debounce_time > level.time)
 	{
 		return;
 	}
@@ -82,7 +82,7 @@ insane_scream(edict_t *self)
 	}
 
 	/* suppress screaming so pain sound can play */
-	if (self->delay > level.time)
+	if (self->fly_sound_debounce_time > level.time)
 	{
 		return;
 	}
@@ -697,7 +697,7 @@ insane_pain(edict_t *self, edict_t *other /* unused */,
 							l, r)), 1, ATTN_IDLE, 0);
 
 	/* suppress screaming and moaning for 1 second so pain sound plays */
-	self->delay = level.time + 1;
+	self->fly_sound_debounce_time = level.time + 1;
 
 	if (skill->value == 3)
 	{


### PR DESCRIPTION
Fixes bug https://github.com/yquake2/yquake2/issues/495. As detailed in the comments, this was caused by using the delay struct member for storing data specific to the insane-marines, when in fact it is a generally used value by G_UseTargets.

I fixed it by using a different struct member, fly_sound_debounce_time, this time making absolutely sure there won't be any interference. This struct member is only stored and referenced in one place in the code and only by clients, so interference by the insane marines code is impossible. I added a comment in local.h to explicitly state this new use case for the struct member.