### PR TITLE
Allow loading ZIP files with a `.pkz` extension

### DIFF
--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -103,6 +103,8 @@ fsPackTypes_t fs_packtypes[] = {
 	{"pak", PAK},
 	{"pk2", PK3},
 	{"pk3", PK3},
+	// For compatibility with Q2PRO, as PKZ is the only ZIP-like extension supported by that source port.
+	{"pkz", PK3},
 	{"zip", PK3}
 };
 
@@ -1772,4 +1774,3 @@ FS_InitFilesystem(void)
 	// Debug output
 	Com_Printf("Using '%s' for writing.\n", fs_gamedir);
 }
-


### PR DESCRIPTION
This makes it possible to distribute add-ons that are compatible with both Yamagi Quake 2 and Q2PRO. (Q2PRO only supports `.pkz` as a file extension for ZIP files.)

See https://github.com/Calinou/quake2-neural-upscale/issues/2 :slightly_smiling_face: