### PR TITLE
Make build system more distro-friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ WITH_SYSTEMWIDE:=no
 # MUST NOT be surrounded by quotation marks!
 WITH_SYSTEMDIR:=""
 
+# If yes, set build options so that the executable will find libraries
+# in non-standard locations. Distributions that control the linker path
+# might want to turn this off.
+WITH_RPATH:=yes
+
 # This will set the architectures of the OSX-binaries.
 # You have to make sure your libs/frameworks supports
 # these architectures! To build an universal ppc-compatible
@@ -410,6 +415,7 @@ ifeq ($(YQ2_OSTYPE), FreeBSD)
 release/quake2 : YQ2_LDFLAGS += -lexecinfo
 endif
 
+ifeq ($(WITH_RPATH),yes)
 ifeq ($(YQ2_OSTYPE), FreeBSD)
 release/quake2 : YQ2_LDFLAGS += -Wl,-z,origin,-rpath='$$ORIGIN/lib' -lexecinfo
 else ifeq ($(YQ2_OSTYPE), Linux)
@@ -431,7 +437,8 @@ release/quake2 : YQ2_LDFLAGS += -Wl,-z,origin,-rpath='/usr/share/games/quake2/li
 endif
 endif
 endif
-endif
+endif # WITH_RPATH
+endif # not Windows
 
 # ----------
 


### PR DESCRIPTION
* build: Let users pass in their own CFLAGS, CPPFLAGS, LDFLAGS
    
    There is a widely-used convention that CFLAGS, CPPFLAGS and LDFLAGS are
    set by the user (or packaging system) when building software,
    defaulting to empty: in Autotools terminology they are said to be
    "reserved for the user". Linux distributions use this to provide
    globally-used compiler flags, for example enabling enabling various
    hardening features.
    
    These are conventionally placed on the compiler command-line *after* the
    build system's choice of CFLAGS and LDFLAGS, so that they can override
    the build system's defaults. For example, when the Debian packaging
    toolchain is told to build a package without optimization for debugging,
    it includes -O0 in CFLAGS. This would not be effective in previous
    versions of yquake2, which hard-code -O2.
    
    Loosely based on a patch by Fabian Greffrath, which we have been applying
    in Debian for several years.

* build: Add an option to turn off RPATHs
    
    When distributions like Debian build binaries that are going to use the
    standard system-wide libraries in directories that are searched by
    default, it's undesired to have a RPATH that makes the library search
    behaviour less predictable. Continue to set the RPATH by default, for
    use in portable binaries, but provide an off-switch.
    
    Based on a patch by Fabian Greffrath, which we have been applying in
    Debian for several years.