### PR TITLE
fix march armv8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ if ("${ARCH}" STREQUAL "arm")
     if (CMAKE_SIZEOF_VOID_P EQUAL 4)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv6k")
     else()
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8.0-a")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a")
     endif()
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ CFLAGS += -march=armv6k
 endif
 
 ifeq ($(YQ2_ARCH), aarch64)
-CFLAGS += -march=armv8.0-a
+CFLAGS += -march=armv8-a
 endif
 
 # ----------


### PR DESCRIPTION
Gcc does not support "armv8.0-a", correct value for gcc should be [armv8.0-a](https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/AArch64-Options.html).

```
Error: unrecognized option -march=armv8.0-a
cc1: error: unknown value ‘armv8.0-a’ for ‘-march’
cc1: note: valid arguments are: armv8-a armv8.1-a armv8.2-a armv8.3-a armv8.4-a armv8.5-a native; did you mean ‘armv8.1-a’?
```