### PR TITLE
Add a separate noreturn macro for function pointers

### DIFF
--- a/src/client/vid/header/ref.h
+++ b/src/client/vid/header/ref.h
@@ -198,7 +198,7 @@ typedef struct
 
 typedef struct
 {
-	YQ2_ATTR_NORETURN void	(IMPORT *Sys_Error) (int err_level, char *str, ...) __attribute__ ((format (printf, 2, 3)));
+	YQ2_ATTR_NORETURN_FUNCPTR void	(IMPORT *Sys_Error) (int err_level, char *str, ...) __attribute__ ((format (printf, 2, 3)));
 
 	void	(IMPORT *Cmd_AddCommand) (char *name, void(*cmd)(void));
 	void	(IMPORT *Cmd_RemoveCommand) (char *name);

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -75,6 +75,16 @@ typedef unsigned char byte;
 	#define YQ2_ATTR_NORETURN
 #endif
 
+#if defined(__GNUC__)
+	/* ISO C11 _Noreturn can't be attached to function pointers, so
+	 * use the gcc/clang-specific version for function pointers, even
+	 * in C11 mode. MSVC __declspec(noreturn) seems to have the same
+	 * restriction as _Noreturn so can't be used here either. */
+	#define YQ2_ATTR_NORETURN_FUNCPTR  __attribute__ ((noreturn))
+#else
+	#define YQ2_ATTR_NORETURN_FUNCPTR  /* nothing */
+#endif
+
 /* angle indexes */
 #define PITCH 0                     /* up / down */
 #define YAW 1                       /* left / right */

--- a/src/game/header/game.h
+++ b/src/game/header/game.h
@@ -120,7 +120,7 @@ typedef struct
 	   they connect, and changes are sent to all connected clients. */
 	void (*configstring)(int num, char *string);
 
-	YQ2_ATTR_NORETURN void (*error)(char *fmt, ...);
+	YQ2_ATTR_NORETURN_FUNCPTR void (*error)(char *fmt, ...);
 
 	/* the *index functions create configstrings
 	   and some internal server state */


### PR DESCRIPTION
C11 _Noreturn is only accepted on function declarations, not on function
pointers, so we can't use it on callbacks like game_import_t.error and
refimport_t.Sys_Error. Use a separate macro for those.

The problematic situation doesn't currently happen because the Makefile
hard-codes -std=gnu99, which disables C11 features; but removing
-std=gnu99 (resulting in the compiler's default, currently gnu11) causes
compilation failures with at least gcc 9.x.

---

As discussed briefly on #523, this isn't a practical problem right now, but will become a practical problem if porting to C11 compilers in future.