### PR TITLE
WIP: arm: Don't use yield if unsupported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,8 +168,6 @@ endif()
 if ("${ARCH}" STREQUAL "arm")
     if (CMAKE_SIZEOF_VOID_P EQUAL 4)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv6k")
-    else()
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a")
     endif()
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -192,10 +192,6 @@ ifeq ($(YQ2_ARCH), arm)
 CFLAGS += -march=armv6k
 endif
 
-ifeq ($(YQ2_ARCH), aarch64)
-CFLAGS += -march=armv8-a
-endif
-
 # ----------
 
 # Systemwide installation.

--- a/src/common/frame.c
+++ b/src/common/frame.c
@@ -146,7 +146,7 @@ Qcommon_Mainloop(void)
 				   a Kaby Lake laptop. */
 #if defined (__GNUC__) && (__i386 || __x86_64__)
 				asm("pause");
-#elif defined(__arm__) || defined(__aarch64__)
+#elif defined(__aarch64__) || (defined(__ARM_ARCH) && __ARM_ARCH >= 7) || defined(__ARM_ARCH_6K__)
 				asm("yield");
 #endif
 


### PR DESCRIPTION
(See below for updated description of branch)

~~Building with a -march= argument attempts to override the compiler's
configuration. In distributions that target a higher baseline CPU
than we specify, -march=armv6k will force the compiler to try to build
for ARMv6K specifically, rather than that higher baseline.~~

~~For example, in Debian's "armhf" port (like many 32-bit ARM ports), the
compiler targets ARMv7 with the VFPv3D16 floating-point extensions, and
the port explicitly does not support older CPUs. Asking it to build for
armv6k just fails, which appears to be because armv6k implies an older
VFP (floating point) ABI than anything this compiler supports. Even if
it succeeded, it would produce binaries that unnecessarily do not take
full advantage of the distribution's ARMv7 baseline.~~

~~Conversely, in distributions that target a *lower* baseline CPU than
we specify, building with an explicit -march= option will produce an
executable that cannot run successfully on the distribution's baseline
CPU. For example, Debian's "armel" port (ARMv5TE) and the baseline used in
Raspbian (ARMv6, with no K) are designed to be compatible with older ARM
CPUs, even if the CPU they are actually run on in practice might be newer,
such as the ARMv7 in the Raspberry Pi version 2. Individual packages in
these distributions are not generally allowed to override that baseline.~~

~~Instead, let the distribution or user set their target CPU (distributions
configure their gcc to default to a specified baseline, while users can
put -march=native or another suitable -march= option in their CFLAGS if
they want a binary suitable for their specific system), and conditionally
enable the yield instruction at compile-time if that target CPU has
it. As far as I can find out, yield was added in ARMv6K, a minor revision
of ARMv6, so it should be available in all ARMv7 or higher CPUs (which
includes anything 64-bit), plus ARMv6 CPUs *if* they are actually ARMv6K.~~

~~Using -march=armv8-a on 64-bit ARM (aarch64) was unnecessary in any
case, because it is the oldest form of aarch64: the only effect of that
option would be to disable newer functionality if the compiler defaults
to enabling it (which I suspect no distributions do yet, but they might
consider in a few years' time).~~

---

I believe this is correct, but it might be too conservative: adding `|| defined(__ARM_ARCH_6KZ__)` to the condition might also work (I'm unsure whether ARMv6KZ is strictly a superset of ARMv6K).

This has been successfully compiled (although not tested at runtime) on Debian armhf and armel, with some `#warning` to tell me which code path it's taking. It appears to enable the yield instruction on armhf (ARMv7) but not on armel (ARMv5), which is what should happen here.

cc @devnexen, @0lvin