### PR TITLE
Fix for some items playing wrong sound when instantly used

### DIFF
--- a/src/game/g_items.c
+++ b/src/game/g_items.c
@@ -215,20 +215,6 @@ Pickup_Powerup(edict_t *ent, edict_t *other)
 		{
 			SetRespawn(ent, ent->item->quantity);
 		}
-
-		if (((int)dmflags->value & DF_INSTANT_ITEMS) ||
-			((ent->item->use == Use_Quad) &&
-			 (ent->spawnflags & DROPPED_PLAYER_ITEM)))
-		{
-			if ((ent->item->use == Use_Quad) &&
-				(ent->spawnflags & DROPPED_PLAYER_ITEM))
-			{
-				quad_drop_timeout_hack =
-					(ent->nextthink - level.time) / FRAMETIME;
-			}
-
-			ent->item->use(other, ent->item);
-		}
 	}
 
 	return true;
@@ -1214,6 +1200,29 @@ Touch_Item(edict_t *ent, edict_t *other, cplane_t *plane /* unused */, csurface_
 			gi.sound(other, CHAN_ITEM, gi.soundindex(
 							ent->item->pickup_sound), 1, ATTN_NORM, 0);
 		}
+
+		/* activate item instantly if appropriate */
+		/* moved down here so activation sounds override the pickup sound */
+		if (deathmatch->value)
+		{
+			if ((((int)dmflags->value & DF_INSTANT_ITEMS) &&
+				 (ent->item->flags & IT_INSTANT_USE)) ||
+				((ent->item->use == Use_Quad) &&
+				 (ent->spawnflags & DROPPED_PLAYER_ITEM)))
+			{
+				if ((ent->item->use == Use_Quad) &&
+					(ent->spawnflags & DROPPED_PLAYER_ITEM))
+				{
+					quad_drop_timeout_hack =
+						(ent->nextthink - level.time) / FRAMETIME;
+				}
+
+				if (ent->item->use)
+				{
+					ent->item->use(other, ent->item);
+				}
+			}
+		}
 	}
 
 	if (!(ent->spawnflags & ITEM_TARGETS_USED))
@@ -2160,7 +2169,7 @@ static const gitem_t gameitemlist[] = {
 		2,
 		60,
 		NULL,
-		IT_POWERUP,
+		IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,
@@ -2182,7 +2191,7 @@ static const gitem_t gameitemlist[] = {
 		2,
 		300,
 		NULL,
-		IT_POWERUP,
+		IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,
@@ -2204,7 +2213,7 @@ static const gitem_t gameitemlist[] = {
 		2,
 		60,
 		NULL,
-		IT_POWERUP,
+		IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,
@@ -2226,7 +2235,7 @@ static const gitem_t gameitemlist[] = {
 		2,
 		60,
 		NULL,
-		IT_STAY_COOP | IT_POWERUP,
+		IT_STAY_COOP | IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,
@@ -2248,7 +2257,7 @@ static const gitem_t gameitemlist[] = {
 		2,
 		60,
 		NULL,
-		IT_STAY_COOP | IT_POWERUP,
+		IT_STAY_COOP | IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -215,6 +215,7 @@ typedef struct
 #define IT_STAY_COOP 8
 #define IT_KEY 16
 #define IT_POWERUP 32
+#define IT_INSTANT_USE 64 /* item is insta-used on pickup if dmflag is set */
 
 /* gitem_t->weapmodel for weapons indicates model index */
 #define WEAP_BLASTER 1


### PR DESCRIPTION
Fix for bug https://github.com/yquake2/yquake2/issues/547.

I defined a new item flag, IT_INSTANT_USE, that tags items that will be instantly used when picked up in instant-use deathmatch games (deathmatch 1 and dmflags & 16), and I moved the instant use code out of Pickup_Powerup/Pickup_Sphere and into Touch_Item so that the use action overrides the generic pickup sound event, making sure original sound prioritization is maintained.

In my testing I did not discover any unwanted side-effects and the bug is fixed, but I definitely invite others to try this out if they can.