### PR TITLE
Implement accurate-aiming CVAR in baseq2 game code.

### DIFF
--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -80,6 +80,8 @@ cvar_t *sv_maplist;
 
 cvar_t *gib_on;
 
+cvar_t *aimfix;
+
 void SpawnEntities(char *mapname, char *entities, char *spawnpoint);
 void ClientThink(edict_t *ent, usercmd_t *cmd);
 qboolean ClientConnect(edict_t *ent, char *userinfo);

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -542,6 +542,8 @@ extern cvar_t *flood_waitdelay;
 
 extern cvar_t *sv_maplist;
 
+extern cvar_t *aimfix;
+
 #define world (&g_edicts[0])
 
 /* item spawnflags */

--- a/src/game/player/weapon.c
+++ b/src/game/player/weapon.c
@@ -41,10 +41,12 @@ static byte is_silenced;
 void weapon_grenade_fire(edict_t *ent, qboolean held);
 
 void
-P_ProjectSource(gclient_t *client, vec3_t point, vec3_t distance,
+P_ProjectSource(edict_t *ent, vec3_t distance,
 		vec3_t forward, vec3_t right, vec3_t result)
 {
-	vec3_t _distance;
+	gclient_t *client = ent->client;
+	float     *point  = ent->s.origin;
+	vec3_t     _distance;
 
 	if (!client)
 	{
@@ -63,6 +65,21 @@ P_ProjectSource(gclient_t *client, vec3_t point, vec3_t distance,
 	}
 
 	G_ProjectSource(point, _distance, forward, right, result);
+
+	// Berserker: fix - now the projectile hits exactly where the scope is pointing.
+	if (aimfix->value)
+	{
+		vec3_t start, end;
+		VectorSet(start, ent->s.origin[0], ent->s.origin[1], ent->s.origin[2] + ent->viewheight);
+		VectorMA(start, 8192, forward, end);
+
+		trace_t	tr = gi.trace(start, NULL, NULL, end, ent, MASK_SHOT);
+		if (tr.fraction < 1)
+		{
+			VectorSubtract(tr.endpos, result, forward);
+			VectorNormalize(forward);
+		}
+	}
 }
 
 /*
@@ -670,7 +687,7 @@ weapon_grenade_fire(edict_t *ent, qboolean held)
 
 	VectorSet(offset, 8, 8, ent->viewheight - 8);
 	AngleVectors(ent->client->v_angle, forward, right, NULL);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	timer = ent->client->grenade_time - level.time;
 	speed = GRENADE_MINSPEED + (GRENADE_TIMER - timer) *
@@ -870,7 +887,7 @@ weapon_grenadelauncher_fire(edict_t *ent)
 
 	VectorSet(offset, 8, 8, ent->viewheight - 8);
 	AngleVectors(ent->client->v_angle, forward, right, NULL);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	VectorScale(forward, -2, ent->client->kick_origin);
 	ent->client->kick_angles[0] = -1;
@@ -936,7 +953,7 @@ Weapon_RocketLauncher_Fire(edict_t *ent)
 	ent->client->kick_angles[0] = -1;
 
 	VectorSet(offset, 8, 8, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 	fire_rocket(ent, start, forward, damage, 650, damage_radius, radius_damage);
 
 	/* send muzzle flash */
@@ -990,7 +1007,7 @@ Blaster_Fire(edict_t *ent, vec3_t g_offset, int damage,
 	AngleVectors(ent->client->v_angle, forward, right, NULL);
 	VectorSet(offset, 24, 8, ent->viewheight - 8);
 	VectorAdd(offset, g_offset, offset);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	VectorScale(forward, -2, ent->client->kick_origin);
 	ent->client->kick_angles[0] = -1;
@@ -1245,7 +1262,7 @@ Machinegun_Fire(edict_t *ent)
 	VectorAdd(ent->client->v_angle, ent->client->kick_angles, angles);
 	AngleVectors(angles, forward, right, NULL);
 	VectorSet(offset, 0, 8, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 	fire_bullet(ent, start, forward, damage, kick, DEFAULT_BULLET_HSPREAD,
 			DEFAULT_BULLET_VSPREAD, MOD_MACHINEGUN);
 
@@ -1421,7 +1438,7 @@ Chaingun_Fire(edict_t *ent)
 		r = 7 + crandom() * 4;
 		u = crandom() * 4;
 		VectorSet(offset, 0, r, u + ent->viewheight - 8);
-		P_ProjectSource(ent->client, ent->s.origin, offset,
+		P_ProjectSource(ent, offset,
 				forward, right, start);
 
 		fire_bullet(ent, start, forward, damage, kick,
@@ -1487,7 +1504,7 @@ weapon_shotgun_fire(edict_t *ent)
 	ent->client->kick_angles[0] = -2;
 
 	VectorSet(offset, 0, 8, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	if (is_quad)
 	{
@@ -1559,7 +1576,7 @@ weapon_supershotgun_fire(edict_t *ent)
 	ent->client->kick_angles[0] = -2;
 
 	VectorSet(offset, 0, 8, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 
 	if (is_quad)
 	{
@@ -1652,7 +1669,7 @@ weapon_railgun_fire(edict_t *ent)
 	ent->client->kick_angles[0] = -3;
 
 	VectorSet(offset, 0, 7, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 	fire_rail(ent, start, forward, damage, kick);
 
 	/* send muzzle flash */
@@ -1748,7 +1765,7 @@ weapon_bfg_fire(edict_t *ent)
 	ent->client->v_dmg_time = level.time + DAMAGE_TIME;
 
 	VectorSet(offset, 8, 8, ent->viewheight - 8);
-	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource(ent, offset, forward, right, start);
 	fire_bfg(ent, start, forward, damage, 400, damage_radius);
 
 	ent->client->ps.gunframe++;

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -258,6 +258,9 @@ InitGame(void)
 	/* dm map list */
 	sv_maplist = gi.cvar("sv_maplist", "", 0);
 
+	/* others */
+	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
+
 	/* items */
 	InitItems();
 


### PR DESCRIPTION
Awhile ago, I raised issue #379 about whether there was anything that could be done to improve the aiming in-game.

Essentially, I've taken this implementation from Berserker@QuakeII v1.41 that provides the accurate aiming I've desired for so long and placed it behind a CVAR so that it's not enabled by default.

I hope with this change being optional, it can be considered for merging into the port. There are many forum posts online about Quake II and how to get accurate aiming, so I believe this would be desirable by many players.