### PR TITLE
Fixed the Jorg skin bug present since the original Quake 2 release.

### DIFF
--- a/src/game/monster/boss3/boss31.c
+++ b/src/game/monster/boss3/boss31.c
@@ -915,8 +915,8 @@ SP_monster_jorg(edict_t *self)
 
 	self->movetype = MOVETYPE_STEP;
 	self->solid = SOLID_BBOX;
-	self->s.modelindex = gi.modelindex("models/monsters/boss3/rider/tris.md2");
-	self->s.modelindex2 = gi.modelindex("models/monsters/boss3/jorg/tris.md2");
+	self->s.modelindex = gi.modelindex("models/monsters/boss3/jorg/tris.md2");
+	self->s.modelindex2 = gi.modelindex("models/monsters/boss3/rider/tris.md2");
 	VectorSet(self->mins, -80, -80, 0);
 	VectorSet(self->maxs, 80, 80, 140);
 


### PR DESCRIPTION
I fixed this in my own project and figured it might be worth to move it to Yamagi Quake 2, since it seems to still have that bug present.
Jorg and Makron models need to be swapped in order for the "hurt" skin to trigger correctly - right now, if Jorg has < 50% of health, it's the Makron's skin that's being replaced instead of the Jorg's. This fix has been tested in vkQuake2 but I see that multi-model entities (I think Jorg is the only one) are handled in the same manner here.