### PR TITLE
Enable rpath with Mac OS linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,7 @@ config:
 	@echo "WITH_OPENAL = $(WITH_OPENAL)"
 	@echo "WITH_SYSTEMWIDE = $(WITH_SYSTEMWIDE)"
 	@echo "WITH_SYSTEMDIR = $(WITH_SYSTEMDIR)"
+	@echo "WITH_RPATH = $(WITH_RPATH)"
 	@echo "============================"
 	@echo ""
 
@@ -427,7 +428,7 @@ endif
 
 ifeq ($(WITH_RPATH),yes)
 ifeq ($(YQ2_OSTYPE), Darwin)
-release/quake2 : LDFLAGS += -Wl,-rpath,'$$ORIGIN/lib'
+release/quake2 : LDFLAGS += -Wl,-rpath,'@executable_path/lib'
 else
 release/quake2 : LDFLAGS += -Wl,-z,origin,-rpath='$$ORIGIN/lib'
 endif

--- a/Makefile
+++ b/Makefile
@@ -426,7 +426,11 @@ release/quake2 : LDFLAGS += -lexecinfo
 endif
 
 ifeq ($(WITH_RPATH),yes)
+ifeq ($(YQ2_OSTYPE), Darwin)
+release/quake2 : LDFLAGS += -Wl,-rpath,'$$ORIGIN/lib'
+else
 release/quake2 : LDFLAGS += -Wl,-z,origin,-rpath='$$ORIGIN/lib'
+endif
 endif
 endif
 


### PR DESCRIPTION
It looks like when you made RPATH optional here: https://github.com/yquake2/yquake2/commit/b48cc4746551061a4135b848fe0679c468442614, the build will try to call the linker with arguments that Mac OS's linker doesn't like. Here is a working fix, I've only tested on Mac OS 10.15.4 though.

I've also added WITH_RPATH to the config info that gets printed when building.

Here's some info about Mac OS's linker, but I'm certainly no expert in it either: https://jorgen.tjer.no/post/2014/05/20/dt-rpath-ld-and-at-rpath-dyld/

Edit: I should include the original failure here as well. This is what happens on master right now when building on Mac OS:
```
===> LD release/quake2
ld: unknown option: -z
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [release/quake2] Error 1
make: *** [client] Error 2
```