### PR TITLE
Start Server Menu: reload "maps.lst" after "game" dir is changed

### DIFF
--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2836,8 +2836,8 @@ M_Menu_JoinServer_f(void)
  */
 
 static menuframework_s s_startserver_menu;
-static char **mapnames = NULL;
-static int nummaps = 0;
+char **mapnames = NULL;
+static int nummaps;
 
 static menuaction_s s_startserver_start_action;
 static menuaction_s s_startserver_dmoptions_action;
@@ -2997,10 +2997,13 @@ StartServer_MenuInit(void)
     char *s;
     float scale = SCR_GetMenuScale();
 
-    /* initialize list of maps once, reuse it afterwards (=> it isn't freed) */
+    /* initialize list of maps once, reuse it afterwards (=> it isn't freed unless the game dir is changed) */
     if (mapnames == NULL)
     {
         int i, length;
+
+        nummaps = 0;
+        s_startmap_list.curvalue = 0;
 
         /* load the list of map names */
         if ((length = FS_LoadFile("maps.lst", (void **)&buffer)) == -1)

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -1672,6 +1672,10 @@ FS_BuildGameSpecificSearchPath(char *dir)
 	// list of music tracks needs to be loaded again (=> tracks
 	// are possibly from the new mod dir)
 	OGG_InitTrackList();
+
+    // ...and the current list of maps in the "start network server" menu is
+    // cleared so that it will be re-initialized when the menu is accessed
+    mapnames = NULL;
 #endif
 }
 

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -754,6 +754,7 @@ extern char cfgdir[MAX_OSPATH];
 
 /* Hack for working 'game' cmd */
 extern char userGivenGame[MAX_QPATH];
+extern char **mapnames;
 
 extern FILE *log_stats_file;
 


### PR DESCRIPTION
The data read from "maps.lst" is only ever read once currently, but this change implemented in "FS_BuildGameSpecificSearchPath" causes it to be read again if the "game" cvar/directory is updated.  NOTE: I made this change on an older branch (I'm no longer able to compile locally from about 7.40 onward) but it looks like it shouldn't be impacted by intervening updates.