### PR TITLE
map name autocompletion

### DIFF
--- a/src/client/cl_keyboard.c
+++ b/src/client/cl_keyboard.c
@@ -325,8 +325,48 @@ CompleteCommand(void)
 		{
 			key_lines[edit_line][key_linepos] = 0;
 		}
+	}
 
-		return;
+	return;
+}
+
+void
+CompleteMapNameCommand(void)
+{
+	int i;
+	char *s, *t, *cmdArg;
+	const char *mapCmdString = "map ";
+
+	s = key_lines[edit_line] + 1;
+
+	if ((*s == '\\') || (*s == '/'))
+	{
+		s++;
+	}
+
+	t = s;
+
+	for (i = 0; i < strlen(mapCmdString); i++)
+	{
+		if (t[i] == mapCmdString[i])
+		{
+			s++;
+		}
+		else
+		{
+			return;
+		}
+	}
+
+	cmdArg = Cmd_CompleteMapCommand(s);
+
+	if (cmdArg)
+	{
+		key_lines[edit_line][1] = '/';
+		strcpy(key_lines[edit_line] + 2, mapCmdString);
+		key_linepos = strlen(key_lines[edit_line]);
+		strcpy(key_lines[edit_line] + key_linepos, cmdArg);
+		key_linepos = key_linepos + strlen(cmdArg);
 	}
 }
 
@@ -407,6 +447,8 @@ Key_Console(int key)
 	{
 		/* command completion */
 		CompleteCommand();
+		CompleteMapNameCommand();
+
 		return;
 	}
 

--- a/src/common/cmdparser.c
+++ b/src/common/cmdparser.c
@@ -888,6 +888,89 @@ Cmd_CompleteCommand(char *partial)
 	return NULL;
 }
 
+char *
+Cmd_CompleteMapCommand(char *partial)
+{
+	char **mapNames;
+	int i, j, k, nbMatches, len, nMaps;
+	char *mapName;
+	char *pmatch[1024];
+	qboolean partialFillContinue = true;
+
+	if ((mapNames = FS_ListFiles2("maps/*.bsp", &nMaps, 0, 0)) != 0)
+	{
+		len = strlen(partial);
+		nbMatches = 0;
+		memset(retval, 0, strlen(retval));
+
+		for (i = 0; i < nMaps - 1; i++)
+		{
+			if (strrchr(mapNames[i], '/'))
+			{
+				mapName = strrchr(mapNames[i], '/') + 1;
+			}
+			else
+			{
+				mapName = mapNames[i];
+			}
+
+			mapName = strtok(mapName, ".");
+
+			/* check for exact match */
+			if (!strcmp(partial, mapName))
+			{
+				strcpy(retval, partial);
+			}
+			/* check for partial match */
+			else if (!strncmp(partial, mapName, len))
+			{
+				pmatch[nbMatches] = mapName;
+				nbMatches++;
+			}
+		}
+
+		if (nbMatches == 1)
+		{
+			strcpy(retval, pmatch[0]);
+		}
+		else if (nbMatches > 1)
+		{
+			Com_Printf("\n=================\n\n");
+
+			for (j = 0; j < nbMatches; j++)
+			{
+				Com_Printf("%s\n", pmatch[j]);
+			}
+
+			//partial complete
+			for (j = 0; j < strlen(pmatch[0]); j++)
+			{
+				for (k = 1; k < nbMatches; k++)
+				{
+					if (j >= strlen(pmatch[k]) || pmatch[0][j] != pmatch[k][j])
+					{
+						partialFillContinue = false;
+						break;
+					}
+				}
+
+				if (partialFillContinue)
+				{
+					retval[j] = pmatch[0][j];
+				}
+				else
+				{
+					break;
+				}
+			}
+		}
+
+		FS_FreeList(mapNames, nMaps);
+	}
+
+	return retval;
+}
+
 qboolean
 Cmd_IsComplete(char *command)
 {

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -371,6 +371,8 @@ qboolean Cmd_Exists(char *cmd_name);
 
 char *Cmd_CompleteCommand(char *partial);
 
+char *Cmd_CompleteMapCommand(char *partial);
+
 /* attempts to match a partial command for automatic command line completion */
 /* returns NULL if nothing fits */
 


### PR DESCRIPTION
When using the command to load a map "map x", if one character from the map name is provided, it will try to autocomplete it.

There are 3 possible scenarios I anticipated:

1) The name is an exact match. In this case we do nothing.
2) The name is partially filled out and only 1 match was found. In this case we fill out the rest.
3) The name has many matches. In this case we complete the map name with the characters from the matches until one differs. We also provide the list of the current matches.