### PR TITLE
Create "mods" submenu to allow changing "game" cvar via UI

### DIFF
--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -33,6 +33,7 @@
 
 
 #define MAX_HANDLES 512
+#define MAX_MODS 32
 #define MAX_PAKS 100
 
 #ifdef SYSTEMWIDE
@@ -1673,9 +1674,18 @@ FS_BuildGameSpecificSearchPath(char *dir)
 	// are possibly from the new mod dir)
 	OGG_InitTrackList();
 
-    // ...and the current list of maps in the "start network server" menu is
-    // cleared so that it will be re-initialized when the menu is accessed
-    mapnames = NULL;
+	// ...and the current list of maps in the "start network server" menu is
+	// cleared so that it will be re-initialized when the menu is accessed
+	if (mapnames != NULL)
+	{
+		for (i = 0; i < nummaps; i++)
+		{
+			free(mapnames[i]);
+		}
+
+		free(mapnames);
+		mapnames = NULL;
+	}
 #endif
 }
 
@@ -1790,5 +1800,103 @@ FS_InitFilesystem(void)
 
 	// Debug output
 	Com_Printf("Using '%s' for writing.\n", fs_gamedir);
+}
+
+extern int qsort_strcomp(const void *s1, const void *s2);
+
+/*
+ * Combs all Raw search paths to find game dirs containing PAK/PK2/PK3 files.
+ * Returns an alphabetized array of unique relative dir names.
+ */
+char**
+FS_ListMods(int *nummods)
+{
+	int nmods = 0, numdirchildren, numpacksinchilddir, searchpathlength;
+	char findnamepattern[MAX_OSPATH], modname[MAX_QPATH], searchpath[MAX_OSPATH];
+	char **dirchildren, **packsinchilddir, **modnames;
+
+	modnames = malloc((MAX_QPATH + 1) * (MAX_MODS + 1));
+	memset(modnames, 0, (MAX_QPATH + 1) * (MAX_MODS + 1));
+
+	// iterate over all Raw paths
+	for (fsRawPath_t *search = fs_rawPath; search; search = search->next)
+	{
+		searchpathlength = strlen(search->path);
+		if(!searchpathlength)
+		{
+			continue;
+		}
+
+		// make sure this Raw path ends with a '/' otherwise FS_ListFiles will open its parent dir
+		if(search->path[searchpathlength - 1] != '/')
+		{
+			Com_sprintf(searchpath, sizeof(searchpath), "%s/", search->path);
+		}
+		else
+		{
+			strcpy(searchpath, search->path);
+		}
+
+		dirchildren = FS_ListFiles(searchpath, &numdirchildren, 0, 0);
+
+		// iterate over the children of this Raw path (unless we've already got enough mods)
+		for (int i = 0; i < numdirchildren && nmods < MAX_MODS; i++)
+		{
+			if(dirchildren[i] == NULL)
+			{
+				continue;
+			}
+
+			numpacksinchilddir = 0;
+
+			// iterate over supported pack types, but ignore ZIP files (they cause false positives)
+			for (int j = 0; j < sizeof(fs_packtypes) / sizeof(fs_packtypes[0]); j++)
+			{
+				if (strcmp("zip", fs_packtypes[j].suffix) != 0)
+				{
+					Com_sprintf(findnamepattern, sizeof(findnamepattern), "%s/*.%s", dirchildren[i], fs_packtypes[j].suffix);
+
+					packsinchilddir = FS_ListFiles(findnamepattern, &numpacksinchilddir, 0, 0);
+					FS_FreeList(packsinchilddir, numpacksinchilddir);
+
+					// if this dir has some pack files, add it if not already in the list
+					if (numpacksinchilddir > 0)
+					{
+						qboolean matchfound = false;
+
+						Com_sprintf(modname, sizeof(modname), "%s", strrchr(dirchildren[i], '/') + 1);
+
+						for (int k = 0; k < nmods; k++)
+						{
+							if (strcmp(modname, modnames[k]) == 0)
+							{
+								matchfound = true;
+								break;
+							}
+						}
+
+						if (!matchfound)
+						{
+							modnames[nmods] = malloc(strlen(modname) + 1);
+							strcpy(modnames[nmods], modname);
+
+							nmods++;
+						}
+
+						break;
+					}
+				}
+			}
+		}
+
+		FS_FreeList(dirchildren, numdirchildren);
+	}
+
+	modnames[nmods] = 0;
+
+	qsort(modnames, nmods, sizeof(modnames[0]), qsort_strcomp);
+
+	*nummods = nmods;
+	return modnames;
 }
 

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -682,6 +682,7 @@ int FS_LoadFile(char *path, void **buffer);
 qboolean FS_FileInGamedir(const char *file);
 qboolean FS_AddPAKFromGamedir(const char *pak);
 const char* FS_GetNextRawPath(const char* lastRawPath);
+char **FS_ListMods(int *nummods);
 
 /* a null buffer will just return the file length without loading */
 /* a -1 length is not present */
@@ -755,6 +756,7 @@ extern char cfgdir[MAX_OSPATH];
 /* Hack for working 'game' cmd */
 extern char userGivenGame[MAX_QPATH];
 extern char **mapnames;
+extern int nummaps;
 
 extern FILE *log_stats_file;
 


### PR DESCRIPTION
I tried opening the original PR back up, but since I also squashed my commits it was refused. Using Address Sanitizer was easier than I expected.  In addition to correcting my memory leaks, I've also added verification that any params the mod-finder passes to "FS_ListFiles" are formatted properly and any NULL data it returns gets ignored, so mods in "datadir" are located correctly.
I won't be so quick to close a PR next time.