### PR TITLE
Add ioquake3 vstr/nextdemo support

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -129,6 +129,11 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   spawned in maps (in fact, some official Ground Zero maps contain
   these entities). This cvar is set to 0 by default.
 
+* **nextdemo**: Defines the next command to run after maps from the
+  `nextserver` list. By default this is set to the empty string.
+
+* **nextserver**: Used for looping the introduction demos.
+
 ## Audio
 
 * **al_device**: OpenAL device to use. In most cases there's no need to

--- a/doc/050_commands.md
+++ b/doc/050_commands.md
@@ -21,3 +21,5 @@ original clients (Vanilla Quake II) commands are still in place.
 * **listmaps**: Lists available maps for the player to load. Maps from
   loaded pak files will be listed first followed by maps placed in 
   the current game's maps folder.
+
+* **vstr**: Inserts the current value of a variable as command text.

--- a/src/common/cmdparser.c
+++ b/src/common/cmdparser.c
@@ -366,6 +366,9 @@ Cbuf_AddLateCommands(void)
 	return ret;
 }
 
+/*
+ * Execute a script file
+ */
 void
 Cmd_Exec_f(void)
 {
@@ -399,6 +402,21 @@ Cmd_Exec_f(void)
 
 	Z_Free(f2);
 	FS_FreeFile(f);
+}
+
+/*
+ * Inserts the current value of a variable as command text
+ */
+void Cmd_Vstr_f( void ) {
+	const char	*v;
+
+	if (Cmd_Argc() != 2) {
+		Com_Printf("vstr <variablename> : execute a variable command\n");
+		return;
+	}
+
+	v = Cvar_VariableString(Cmd_Argv(1));
+	Cbuf_InsertText(va("%s\n", v));
 }
 
 /*
@@ -1111,6 +1129,7 @@ Cmd_Init(void)
 	/* register our commands */
 	Cmd_AddCommand("cmdlist", Cmd_List_f);
 	Cmd_AddCommand("exec", Cmd_Exec_f);
+	Cmd_AddCommand("vstr", Cmd_Vstr_f);
 	Cmd_AddCommand("echo", Cmd_Echo_f);
 	Cmd_AddCommand("alias", Cmd_Alias_f);
 	Cmd_AddCommand("wait", Cmd_Wait_f);

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -440,7 +440,10 @@ SV_Map(qboolean attractloop, char *levelstring, qboolean loadgame)
 	}
 	else
 	{
-		Cvar_Set("nextserver", "");
+		// use next demo command if list of map commands as empty
+		Cvar_Set("nextserver", (char*)Cvar_VariableString("nextdemo"));
+		// and cleanup nextdemo
+		Cvar_Set("nextdemo", "");
 	}
 
 	/* hack for end game screen in coop mode */


### PR DESCRIPTION
Add `vstr` command and `nextdemo` variable for support ioquake3 style benchmark commands like:
```
unbindall

timedemo 1
set nextdemo quit
set demoloop "demomap q2demo1.dm2"
vstr demoloop
```
With run by
```shell
./quake2 +exec pts.cfg +set r_mode 5 +set r_fullscreen 0 +set com_speeds 1
``` 

based on [Phoronix Test Suite::OpenArena](https://openbenchmarking.org/innhold/a702bd92a52f8f6d944b7e55ddb6447ee500352b)