### PR TITLE
signalhandler: Fix a typo

### DIFF
--- a/src/backends/unix/signalhandler.c
+++ b/src/backends/unix/signalhandler.c
@@ -72,7 +72,7 @@ printBacktrace(int sig)
 	printf("Compiler:     %s\n", __VERSION__);
 	printf("Signal:       %i\n", sig);
 	printf("\nBacktrace:\n");
-	printf("  Not available on this plattform.\n\n");
+	printf("  Not available on this platform.\n\n");
 }
 
 #endif


### PR DESCRIPTION
Detected by Lintian, a QA tool used in Debian.