### PR TITLE
Restore memory allocation flags from vkquake2

### DIFF
--- a/src/client/refresh/vk/header/util.h
+++ b/src/client/refresh/vk/header/util.h
@@ -64,6 +64,7 @@ VkResult image_create(ImageResource_t *img,
 VkResult image_destroy(ImageResource_t *img);
 
 void vulkan_memory_init(void);
+void vulkan_memory_types_show(void);
 void vulkan_memory_free_unused(void);
 void vulkan_memory_delete(void);
 

--- a/src/client/refresh/vk/vk_buffer.c
+++ b/src/client/refresh/vk/vk_buffer.c
@@ -132,6 +132,8 @@ QVk_CreateStagingBuffer(VkDeviceSize size, qvkstagingbuffer_t *dstBuffer,
 		.pQueueFamilyIndices = NULL,
 	};
 
+	reqMemFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+
 	dstBuffer->currentOffset = 0;
 	return buffer_create(&dstBuffer->resource, bcInfo, reqMemFlags,
 						 prefMemFlags);
@@ -147,6 +149,13 @@ QVk_CreateUniformBuffer(VkDeviceSize size, qvkbuffer_t *dstBuffer,
 		.reqMemFlags = reqMemFlags,
 		.prefMemFlags = prefMemFlags,
 	};
+
+	dstOpts.reqMemFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+
+	if((dstOpts.prefMemFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
+	{
+		dstOpts.prefMemFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+	}
 
 	return QVk_CreateBuffer(size, dstBuffer, dstOpts);
 }
@@ -164,6 +173,11 @@ QVk_CreateVertexBuffer(const void *data, VkDeviceSize size,
 		.prefMemFlags = prefMemFlags,
 	};
 
+	if ((dstOpts.prefMemFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
+	{
+		dstOpts.prefMemFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+	}
+
 	createStagedBuffer(data, size, dstBuffer, dstOpts);
 }
 
@@ -178,6 +192,11 @@ QVk_CreateIndexBuffer(const void *data, VkDeviceSize size,
 		.reqMemFlags = reqMemFlags,
 		.prefMemFlags = prefMemFlags,
 	};
+
+	if ((dstOpts.prefMemFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
+	{
+		dstOpts.prefMemFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+	}
 
 	createStagedBuffer(data, size, dstBuffer, dstOpts);
 }

--- a/src/client/refresh/vk/vk_buffer.c
+++ b/src/client/refresh/vk/vk_buffer.c
@@ -152,7 +152,8 @@ QVk_CreateUniformBuffer(VkDeviceSize size, qvkbuffer_t *dstBuffer,
 
 	dstOpts.reqMemFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
 
-	if((dstOpts.prefMemFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
+	if((vk_device.properties.deviceType != VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU) ||
+	   (dstOpts.prefMemFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
 	{
 		dstOpts.prefMemFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 	}
@@ -173,7 +174,8 @@ QVk_CreateVertexBuffer(const void *data, VkDeviceSize size,
 		.prefMemFlags = prefMemFlags,
 	};
 
-	if ((dstOpts.prefMemFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
+	if((vk_device.properties.deviceType != VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU) ||
+	   (dstOpts.prefMemFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
 	{
 		dstOpts.prefMemFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 	}
@@ -193,7 +195,8 @@ QVk_CreateIndexBuffer(const void *data, VkDeviceSize size,
 		.prefMemFlags = prefMemFlags,
 	};
 
-	if ((dstOpts.prefMemFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
+	if((vk_device.properties.deviceType != VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU) ||
+	   (dstOpts.prefMemFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
 	{
 		dstOpts.prefMemFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 	}

--- a/src/client/refresh/vk/vk_common.c
+++ b/src/client/refresh/vk/vk_common.c
@@ -1751,6 +1751,9 @@ qboolean QVk_Init(SDL_Window *window)
 	}
 	QVk_DebugSetObjectName((uintptr_t)vk_device.physical, VK_OBJECT_TYPE_PHYSICAL_DEVICE, va("Physical Device: %s", vk_config.vendor_name));
 
+	if (vk_validation->value)
+		vulkan_memory_types_show();
+
 	// setup swapchain
 	res = QVk_CreateSwapchain();
 	if (res != VK_SUCCESS)

--- a/src/client/refresh/vk/vk_image.c
+++ b/src/client/refresh/vk/vk_image.c
@@ -339,7 +339,10 @@ VkResult QVk_CreateImage(uint32_t width, uint32_t height, VkFormat format, VkIma
 	}
 
 	texture->sharingMode = imageInfo.sharingMode;
-	return image_create(&texture->resource, imageInfo, /*mem_properties*/ 0, /*mem_preferences*/ 0);
+	return image_create(
+		&texture->resource, imageInfo,
+		/*mem_properties*/ 0,
+		/*mem_preferences*/ VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 }
 
 void QVk_CreateDepthBuffer(VkSampleCountFlagBits sampleCount, qvktexture_t *depthBuffer)

--- a/src/client/refresh/vk/vk_swapchain.c
+++ b/src/client/refresh/vk/vk_swapchain.c
@@ -64,6 +64,7 @@ static VkSurfaceFormatKHR getSwapSurfaceFormat(const VkSurfaceFormatKHR *surface
 }
 
 // internal helper
+// look to https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentModeKHR.html for more information
 static VkPresentModeKHR getSwapPresentMode(const VkPresentModeKHR *presentModes, uint32_t presentModesCount, VkPresentModeKHR desiredMode)
 {
 	// PRESENT_MODE_FIFO_KHR is guaranteed to exist due to spec requirements
@@ -89,12 +90,13 @@ static VkPresentModeKHR getSwapPresentMode(const VkPresentModeKHR *presentModes,
 	// preferred present mode not found - choose the next best thing
 	for (uint32_t i = 0; i < presentModesCount; ++i)
 	{
-		// always prefer mailbox for triple buffering
+		// always prefer mailbox for triple buffering with whole image replace
 		if (presentModes[i] == VK_PRESENT_MODE_MAILBOX_KHR)
 		{
 			usedPresentMode = presentModes[i];
 			break;
 		}
+		// prefer immediate update with tearing
 		else if (presentModes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR)
 		{
 			usedPresentMode = presentModes[i];
@@ -169,7 +171,7 @@ VkResult QVk_CreateSwapchain()
 
 	// request at least 2 images - this fixes fullscreen crashes on AMD when launching the game in fullscreen
 	uint32_t imageCount = max(2, surfaceCaps.minImageCount);
-	if (swapPresentMode == VK_PRESENT_MODE_MAILBOX_KHR)
+	if (swapPresentMode != VK_PRESENT_MODE_FIFO_KHR)
 		imageCount = max(3, surfaceCaps.minImageCount);
 
 	if (surfaceCaps.maxImageCount > 0)

--- a/src/client/refresh/vk/vk_util.c
+++ b/src/client/refresh/vk/vk_util.c
@@ -67,6 +67,34 @@ vulkan_memory_init(void)
 	memset(used_memory, 0, used_memory_size * sizeof(MemoryResource_t));
 }
 
+void
+vulkan_memory_types_show(void)
+{
+#define MPSTR(r, i) \
+	if((vk_device.mem_properties.memoryTypes[i].propertyFlags & VK_ ##r) != 0) \
+		{ R_Printf(PRINT_ALL, " %s", "VK_"#r); };
+
+	R_Printf(PRINT_ALL, "\nMemory blocks:\n");
+
+	for(uint32_t i = 0; i < VK_MAX_MEMORY_TYPES; i++)
+	{
+		if (vk_device.mem_properties.memoryTypes[i].propertyFlags)
+		{
+			R_Printf(PRINT_ALL, "\n#%d:", i);
+			MPSTR(MEMORY_PROPERTY_DEVICE_LOCAL_BIT, i);
+			MPSTR(MEMORY_PROPERTY_HOST_VISIBLE_BIT, i);
+			MPSTR(MEMORY_PROPERTY_HOST_COHERENT_BIT, i);
+			MPSTR(MEMORY_PROPERTY_HOST_CACHED_BIT, i);
+			MPSTR(MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT, i);
+			MPSTR(MEMORY_PROPERTY_PROTECTED_BIT, i);
+			MPSTR(MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD, i);
+			MPSTR(MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD, i);
+		}
+	}
+	R_Printf(PRINT_ALL, "\n");
+#undef PMSTR
+}
+
 static VkBool32
 vulkan_memory_is_used(int start_pos, int end_pos, VkDeviceMemory memory)
 {
@@ -357,11 +385,13 @@ memory_create_by_property(VkMemoryRequirements* mem_reqs,
 
 	memory_index = get_memory_type(mem_reqs->memoryTypeBits,
 		mem_properties | mem_preferences);
+	// prefered memory allocation
 	if (memory_index == -1)
 	{
 		memory_index = get_memory_type(mem_reqs->memoryTypeBits,
 			mem_properties);
 	}
+	// strictly required
 	if (memory_index == -1)
 	{
 		R_Printf(PRINT_ALL, "%s:%d: Have not found required memory type.\n",

--- a/src/client/refresh/vk/vk_util.c
+++ b/src/client/refresh/vk/vk_util.c
@@ -67,32 +67,39 @@ vulkan_memory_init(void)
 	memset(used_memory, 0, used_memory_size * sizeof(MemoryResource_t));
 }
 
+static void
+memory_type_print(VkMemoryPropertyFlags mem_prop)
+{
+#define MPSTR(r, prop) \
+	if((prop & VK_ ##r) != 0) \
+		{ R_Printf(PRINT_ALL, " %s", "VK_"#r); };
+
+	MPSTR(MEMORY_PROPERTY_DEVICE_LOCAL_BIT, mem_prop);
+	MPSTR(MEMORY_PROPERTY_HOST_VISIBLE_BIT, mem_prop);
+	MPSTR(MEMORY_PROPERTY_HOST_COHERENT_BIT, mem_prop);
+	MPSTR(MEMORY_PROPERTY_HOST_CACHED_BIT, mem_prop);
+	MPSTR(MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT, mem_prop);
+	MPSTR(MEMORY_PROPERTY_PROTECTED_BIT, mem_prop);
+	MPSTR(MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD, mem_prop);
+	MPSTR(MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD, mem_prop);
+
+#undef PMSTR
+}
+
 void
 vulkan_memory_types_show(void)
 {
-#define MPSTR(r, i) \
-	if((vk_device.mem_properties.memoryTypes[i].propertyFlags & VK_ ##r) != 0) \
-		{ R_Printf(PRINT_ALL, " %s", "VK_"#r); };
-
-	R_Printf(PRINT_ALL, "\nMemory blocks:\n");
+	R_Printf(PRINT_ALL, "\nMemory blocks:");
 
 	for(uint32_t i = 0; i < VK_MAX_MEMORY_TYPES; i++)
 	{
 		if (vk_device.mem_properties.memoryTypes[i].propertyFlags)
 		{
-			R_Printf(PRINT_ALL, "\n#%d:", i);
-			MPSTR(MEMORY_PROPERTY_DEVICE_LOCAL_BIT, i);
-			MPSTR(MEMORY_PROPERTY_HOST_VISIBLE_BIT, i);
-			MPSTR(MEMORY_PROPERTY_HOST_COHERENT_BIT, i);
-			MPSTR(MEMORY_PROPERTY_HOST_CACHED_BIT, i);
-			MPSTR(MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT, i);
-			MPSTR(MEMORY_PROPERTY_PROTECTED_BIT, i);
-			MPSTR(MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD, i);
-			MPSTR(MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD, i);
+			R_Printf(PRINT_ALL, "\n   #%d:", i);
+			memory_type_print(vk_device.mem_properties.memoryTypes[i].propertyFlags);
 		}
 	}
 	R_Printf(PRINT_ALL, "\n");
-#undef PMSTR
 }
 
 static VkBool32


### PR DESCRIPTION
* Restore memory allocate flags based on GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator 
* Mark non VK_PRESENT_MODE_FIFO_KHR as triple buffered