### PR TITLE
Cast arguments to ctype functions to unsigned char

### DIFF
--- a/src/client/curl/download.c
+++ b/src/client/curl/download.c
@@ -127,7 +127,7 @@ static void CL_EscapeHTTPPath(const char *filePath, char *escaped)
 
 	for (int i = 0; i < len; i++)
 	{
-		if (!isalnum(filePath[i]) && filePath[i] != ';' && filePath[i] != '/' &&
+		if (!isalnum((unsigned char)filePath[i]) && filePath[i] != ';' && filePath[i] != '/' &&
 			filePath[i] != '?' && filePath[i] != ':' && filePath[i] != '@' && filePath[i] != '&' &&
 			filePath[i] != '=' && filePath[i] != '+' && filePath[i] != '$' && filePath[i] != ',' &&
 			filePath[i] != '[' && filePath[i] != ']' && filePath[i] != '-' && filePath[i] != '_' &&

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -3206,7 +3206,7 @@ StartServer_MenuInit(void)
 
             for (j = 0; j < l; j++)
             {
-                shortname[j] = toupper(shortname[j]);
+                shortname[j] = toupper((unsigned char)shortname[j]);
             }
 
             strcpy(longname, COM_Parse(&s));

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -969,7 +969,7 @@ R_RenderView(refdef_t *fd)
 						// Decode the colour name from its character.
 						for (eye = 0; eye < 2; ++eye) {
 							colour = 0;
-							switch (toupper(gl1_stereo_anaglyph_colors->string[eye])) {
+							switch (toupper((unsigned char)gl1_stereo_anaglyph_colors->string[eye])) {
 								case 'B': ++colour; // 001 Blue
 								case 'G': ++colour; // 010 Green
 								case 'C': ++colour; // 011 Cyan

--- a/src/common/cmdparser.c
+++ b/src/common/cmdparser.c
@@ -971,7 +971,7 @@ Cmd_CompleteMapCommand(char *partial)
 			{
 				for (k = 1; k < nbMatches; k++)
 				{
-					if (j >= strlen(pmatch[k]) || tolower(pmatch[0][j]) != tolower(pmatch[k][j]))
+					if (j >= strlen(pmatch[k]) || tolower((unsigned char)pmatch[0][j]) != tolower((unsigned char)pmatch[k][j]))
 					{
 						partialFillContinue = false;
 						break;

--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -1104,7 +1104,7 @@ Q_strlwr ( char *s )
 
 	while ( *s )
 	{
-		*s = tolower( *s );
+		*s = tolower( (unsigned char)*s );
 		s++;
 	}
 


### PR DESCRIPTION
According to the C standard, arguments to the ctype functions must fit into unsigned char (presumably so they can be implemented with simple array access). This causes a build time warning on NetBSD, and may function incorrectly if any UTF-8 strings are used.