### PR TITLE
Cleanup vulkan code

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -334,6 +334,13 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   * `1` - only errors and warnings
   * `2` - best-practices validation
 
+* **vk_retexturing**: Apply retexturing:
+  * `0` - dont use retexturing logic and dont load the high resolution
+          textures,
+  * `1` - load the high resolution textures if pack is installed.
+  * `2` - try to load the pack or scale up all 8bit textures if pack is
+          not installed.
+
 * **vk_strings**: Print some basic Vulkan/GPU information.
 
 * **vk_mem**: Print dynamic vertex/index/uniform/triangle fan buffer

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -341,6 +341,11 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   * `2` - try to load the pack or scale up all 8bit textures if pack is
           not installed.
 
+* **vk_nolerp_list**: list separate by spaces of textures omitted from
+  bilinear filtering. Used by default to exclude the console and HUD
+  fonts.  Make sure to include the default values when extending the
+  list.
+
 * **vk_strings**: Print some basic Vulkan/GPU information.
 
 * **vk_mem**: Print dynamic vertex/index/uniform/triangle fan buffer

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -393,8 +393,6 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
 
 * **vk_picmip**: Shrink factor for the textures. (default: `0`)
 
-* **vk_round_down**: Toggle the rounding of texture sizes. (default: `1`)
-
 * **vk_dynamic**: Use dynamic lighting. (default: `1`)
 
 * **vk_showtris**: Display mesh triangles. (default: `0`)

--- a/src/client/refresh/vk/header/local.h
+++ b/src/client/refresh/vk/header/local.h
@@ -162,6 +162,7 @@ extern	cvar_t	*vk_aniso;
 extern	cvar_t	*vk_sampleshading;
 extern	cvar_t	*vk_device_idx;
 extern	cvar_t	*vk_retexturing;
+extern	cvar_t	*vk_nolerp_list;
 
 extern	cvar_t	*vid_fullscreen;
 extern	cvar_t	*vid_gamma;
@@ -225,8 +226,8 @@ struct image_s *RE_RegisterSkin (char *name);
 void LoadPCX (char *filename, byte **pic, byte **palette, int *width, int *height);
 image_t *Vk_LoadPic(char *name, byte *pic, int width, int realwidth,
 		    int height, int realheight, imagetype_t type,
-		    int bits, qvksampler_t *samplerType);
-image_t	*Vk_FindImage (char *name, imagetype_t type, qvksampler_t *samplerType);
+		    int bits);
+image_t	*Vk_FindImage (char *name, imagetype_t type);
 void	Vk_TextureMode( char *string );
 void	Vk_LmapTextureMode( char *string );
 void	Vk_ImageList_f (void);

--- a/src/client/refresh/vk/header/local.h
+++ b/src/client/refresh/vk/header/local.h
@@ -141,7 +141,6 @@ extern	cvar_t	*vk_validation;
 extern	cvar_t	*vk_bitdepth;
 extern	cvar_t	*vk_picmip;
 extern	cvar_t	*vk_skymip;
-extern	cvar_t	*vk_round_down;
 extern	cvar_t	*vk_flashblend;
 extern	cvar_t	*vk_finish;
 extern	cvar_t	*vk_polyblend;

--- a/src/client/refresh/vk/header/local.h
+++ b/src/client/refresh/vk/header/local.h
@@ -68,9 +68,6 @@ typedef struct image_s
 	int		registration_sequence;		// 0 = free
 	struct msurface_s	*texturechain;	// for sort-by-texture world drawing
 	qvktexture_t vk_texture;			// Vulkan texture handle
-	float	sl, tl, sh, th;				// 0,0 - 1,1 unless part of the scrap
-	qboolean	scrap;
-
 } image_t;
 
 #define		MAX_VKTEXTURES	1024

--- a/src/client/refresh/vk/vk_draw.c
+++ b/src/client/refresh/vk/vk_draw.c
@@ -31,9 +31,7 @@ Draw_InitLocal
 */
 void Draw_InitLocal (void)
 {
-	// load console characters (don't bilerp characters)
-	qvksampler_t samplerType = S_NEAREST;
-	draw_chars = Vk_FindImage("pics/conchars.pcx", it_pic, &samplerType);
+	draw_chars = Vk_FindImage("pics/conchars.pcx", it_pic);
 	if (!draw_chars)
 	{
 		ri.Sys_Error(ERR_FATAL, "%s: Couldn't load pics/conchars.pcx", __func__);
@@ -91,10 +89,10 @@ image_t	*RE_Draw_FindPic (char *name)
 		char	fullname[MAX_QPATH];
 
 		Com_sprintf(fullname, sizeof(fullname), "pics/%s.pcx", name);
-		vk = Vk_FindImage(fullname, it_pic, NULL);
+		vk = Vk_FindImage(fullname, it_pic);
 	}
 	else
-		vk = Vk_FindImage(name + 1, it_pic, NULL);
+		vk = Vk_FindImage(name + 1, it_pic);
 
 	return vk;
 }

--- a/src/client/refresh/vk/vk_draw.c
+++ b/src/client/refresh/vk/vk_draw.c
@@ -137,8 +137,7 @@ void RE_Draw_StretchPic (int x, int y, int w, int h, char *name)
 
 	float imgTransform[] = { (float)x / vid.width, (float)y / vid.height,
 							 (float)w / vid.width, (float)h / vid.height,
-							  vk->sl,				vk->tl,
-							  vk->sh - vk->sl,		vk->th - vk->tl };
+							  0, 0, 1, 1 };
 	QVk_DrawTexRect(imgTransform, sizeof(imgTransform), &vk->vk_texture);
 }
 

--- a/src/client/refresh/vk/vk_image.c
+++ b/src/client/refresh/vk/vk_image.c
@@ -916,6 +916,11 @@ static uint32_t Vk_Upload8 (byte *data, int width, int height, imagetype_t type,
 		}
 	}
 
+	if (vk_retexturing->value)
+	{
+		SmoothColorImage(trans, s, s >> 7);
+	}
+
 	miplevel = Vk_Upload32((byte *)trans, width, height, type, texBuffer, upload_width, upload_height);
 	free(trans);
 	return miplevel;
@@ -969,7 +974,19 @@ Vk_LoadPic(char *name, byte *pic, int width, int realwidth,
 		FloodFillSkin(pic, width, height);
 
 	if (bits == 8)
-		image->vk_texture.mipLevels = Vk_Upload8(pic, width, height, image->type, &texBuffer, &upload_width, &upload_height);
+	{
+		if (vk_retexturing->value)
+		{
+			byte *image_converted = malloc(width * height * 4);
+			scale2x(pic, image_converted, width, height);
+			image->vk_texture.mipLevels = Vk_Upload8(image_converted, width * 2, height * 2, image->type, &texBuffer, &upload_width, &upload_height);
+			free(image_converted);
+		}
+		else
+		{
+			image->vk_texture.mipLevels = Vk_Upload8(pic, width, height, image->type, &texBuffer, &upload_width, &upload_height);
+		}
+	}
 	else
 		image->vk_texture.mipLevels = Vk_Upload32(pic, width, height, image->type, &texBuffer, &upload_width, &upload_height);
 

--- a/src/client/refresh/vk/vk_image.c
+++ b/src/client/refresh/vk/vk_image.c
@@ -561,8 +561,9 @@ void	Vk_ImageList_f (void)
 			break;
 		}
 
-		R_Printf(PRINT_ALL, " %3i %3i RGB: %s\n",
-			image->upload_width, image->upload_height, image->name);
+		R_Printf(PRINT_ALL, " %4i %4i RGB: %s (%dx%d)\n",
+			image->upload_width, image->upload_height, image->name,
+			image->width, image->height);
 	}
 	R_Printf(PRINT_ALL, "Total texel count (not counting mipmaps): %i\n", texels);
 }

--- a/src/client/refresh/vk/vk_image.c
+++ b/src/client/refresh/vk/vk_image.c
@@ -917,7 +917,8 @@ static uint32_t Vk_Upload8 (byte *data, int width, int height, imagetype_t type,
 		}
 	}
 
-	if (vk_retexturing->value)
+	// optimize 8bit images only when we forced such logic
+	if (vk_retexturing->value >= 2)
 	{
 		SmoothColorImage(trans, s, s >> 7);
 	}
@@ -976,7 +977,8 @@ Vk_LoadPic(char *name, byte *pic, int width, int realwidth,
 
 	if (bits == 8)
 	{
-		if (vk_retexturing->value)
+		// resize 8bit images only when we forced such logic
+		if (vk_retexturing->value >= 2)
 		{
 			byte *image_converted = malloc(width * height * 4);
 			scale2x(pic, image_converted, width, height);
@@ -1098,7 +1100,7 @@ Vk_LoadImage(char *name, const char* namewe, const char *ext, imagetype_t type, 
 {
 	image_t	*image = NULL;
 
-	// with retexturing and not skin
+	// with retexturing
 	if (vk_retexturing->value)
 	{
 		image = Vk_LoadHiColorImage(name, namewe, ext, type, samplerType);

--- a/src/client/refresh/vk/vk_model.c
+++ b/src/client/refresh/vk/vk_model.c
@@ -433,7 +433,7 @@ static void Mod_LoadTexinfo (lump_t *l)
 		    out->next = NULL;
 		Com_sprintf (name, sizeof(name), "textures/%s.wal", in->texture);
 
-		out->image = Vk_FindImage (name, it_wall, NULL);
+		out->image = Vk_FindImage (name, it_wall);
 		if (!out->image)
 		{
 			R_Printf(PRINT_ALL, "Couldn't load %s\n", name);
@@ -1010,7 +1010,7 @@ static void Mod_LoadAliasModel (model_t *mod, void *buffer)
 	for (i=0 ; i<pheader->num_skins ; i++)
 	{
 		mod->skins[i] = Vk_FindImage ((char *)pheader + pheader->ofs_skins + i*MAX_SKINNAME
-			, it_skin, NULL);
+			, it_skin);
 	}
 
 	mod->mins[0] = -32;
@@ -1063,7 +1063,7 @@ static void Mod_LoadSpriteModel (model_t *mod, void *buffer)
 		sprout->frames[i].origin_y = LittleLong (sprin->frames[i].origin_y);
 		memcpy (sprout->frames[i].name, sprin->frames[i].name, MAX_SKINNAME);
 		mod->skins[i] = Vk_FindImage (sprout->frames[i].name,
-			it_sprite, NULL);
+			it_sprite);
 	}
 
 	mod->type = mod_sprite;
@@ -1125,13 +1125,13 @@ struct model_s *RE_RegisterModel (char *name)
 
 			sprout = (dsprite_t *)mod->extradata;
 			for (i=0 ; i<sprout->numframes ; i++)
-				mod->skins[i] = Vk_FindImage (sprout->frames[i].name, it_sprite, NULL);
+				mod->skins[i] = Vk_FindImage (sprout->frames[i].name, it_sprite);
 		}
 		else if (mod->type == mod_alias)
 		{
 			pheader = (dmdl_t *)mod->extradata;
 			for (i=0 ; i<pheader->num_skins ; i++)
-				mod->skins[i] = Vk_FindImage ((char *)pheader + pheader->ofs_skins + i*MAX_SKINNAME, it_skin, NULL);
+				mod->skins[i] = Vk_FindImage ((char *)pheader + pheader->ofs_skins + i*MAX_SKINNAME, it_skin);
 //PGM
 			mod->numframes = pheader->num_frames;
 //PGM

--- a/src/client/refresh/vk/vk_rmain.c
+++ b/src/client/refresh/vk/vk_rmain.c
@@ -123,6 +123,7 @@ cvar_t	*vk_mip_nearfilter;
 cvar_t	*vk_sampleshading;
 cvar_t	*vk_device_idx;
 cvar_t	*vk_retexturing;
+cvar_t	*vk_nolerp_list;
 
 cvar_t	*vid_fullscreen;
 cvar_t	*vid_gamma;
@@ -1177,6 +1178,8 @@ R_Register( void )
 	vk_sampleshading = ri.Cvar_Get("vk_sampleshading", "1", CVAR_ARCHIVE);
 	vk_device_idx = ri.Cvar_Get("vk_device", "-1", CVAR_ARCHIVE);
 	vk_retexturing = ri.Cvar_Get("vk_retexturing", "1", CVAR_ARCHIVE);
+	/* don't bilerp characters and crosshairs */
+	vk_nolerp_list = ri.Cvar_Get("vk_nolerp_list", "pics/conchars.pcx pics/ch1.pcx pics/ch2.pcx pics/ch3.pcx", 0);
 
 	// clamp vk_msaa to accepted range so that video menu doesn't crash on us
 	if (vk_msaa->value < 0)

--- a/src/client/refresh/vk/vk_rmain.c
+++ b/src/client/refresh/vk/vk_rmain.c
@@ -97,7 +97,6 @@ cvar_t	*vk_validation;
 cvar_t	*vk_bitdepth;
 cvar_t	*vk_picmip;
 cvar_t	*vk_skymip;
-cvar_t	*vk_round_down;
 cvar_t	*vk_flashblend;
 cvar_t	*vk_finish;
 cvar_t	*r_clear;
@@ -1152,7 +1151,6 @@ R_Register( void )
 	vk_bitdepth = ri.Cvar_Get("vk_bitdepth", "0", 0);
 	vk_picmip = ri.Cvar_Get("vk_picmip", "0", 0);
 	vk_skymip = ri.Cvar_Get("vk_skymip", "0", 0);
-	vk_round_down = ri.Cvar_Get("vk_round_down", "1", 0);
 	vk_flashblend = ri.Cvar_Get("vk_flashblend", "0", 0);
 	vk_finish = ri.Cvar_Get("vk_finish", "0", CVAR_ARCHIVE);
 	r_clear = ri.Cvar_Get("r_clear", "0", CVAR_ARCHIVE);

--- a/src/client/refresh/vk/vk_rmain.c
+++ b/src/client/refresh/vk/vk_rmain.c
@@ -1176,7 +1176,7 @@ R_Register( void )
 	vk_mip_nearfilter = ri.Cvar_Get("vk_mip_nearfilter", "0", CVAR_ARCHIVE);
 	vk_sampleshading = ri.Cvar_Get("vk_sampleshading", "1", CVAR_ARCHIVE);
 	vk_device_idx = ri.Cvar_Get("vk_device", "-1", CVAR_ARCHIVE);
-	vk_retexturing = ri.Cvar_Get("vk_retexturing", "0", CVAR_ARCHIVE);
+	vk_retexturing = ri.Cvar_Get("vk_retexturing", "1", CVAR_ARCHIVE);
 
 	// clamp vk_msaa to accepted range so that video menu doesn't crash on us
 	if (vk_msaa->value < 0)

--- a/src/client/refresh/vk/vk_rmisc.c
+++ b/src/client/refresh/vk/vk_rmisc.c
@@ -58,7 +58,7 @@ void RE_InitParticleTexture (void)
 		}
 	}
 	r_particletexture = Vk_LoadPic("***particle***", (byte *)data,
-		8, 8, 8, 8, it_sprite, 32, NULL);
+		8, 8, 8, 8, it_sprite, 32);
 
 	//
 	// particle texture
@@ -74,7 +74,7 @@ void RE_InitParticleTexture (void)
 		}
 	}
 	r_squaretexture = Vk_LoadPic("***square***", (byte *)data,
-		8, 8, 8, 8, it_sprite, 32, NULL);
+		8, 8, 8, 8, it_sprite, 32);
 
 	//
 	// also use this for bad textures, but without alpha
@@ -90,7 +90,7 @@ void RE_InitParticleTexture (void)
 		}
 	}
 	r_notexture = Vk_LoadPic("***r_notexture***", (byte *)data,
-		8, 8, 8, 8, it_wall, 32, NULL);
+		8, 8, 8, 8, it_wall, 32);
 }
 
 

--- a/src/client/refresh/vk/vk_warp.c
+++ b/src/client/refresh/vk/vk_warp.c
@@ -686,7 +686,7 @@ void RE_SetSky (char *name, float rotate, vec3_t axis)
 
 		Com_sprintf(pathname, sizeof(pathname), "env/%s%s.tga", skyname, suf[i]);
 
-		sky_images[i] = Vk_FindImage(pathname, it_sky, NULL);
+		sky_images[i] = Vk_FindImage(pathname, it_sky);
 		if (!sky_images[i])
 			sky_images[i] = r_notexture;
 


### PR DESCRIPTION
* remove scrap logic, we have already use sub allocation on vk_util 
* rename gammatable to overbrightable and apply only to world textures
* restore near color only for transparent images (sky and wall can be 0xFF)
* scale 8bit images with enabled retexturing (only for images without override and `vk_retexturing` == 2)
* remove scale down for textures if texture is not power-of-two
* add `vk_nolerp_list` support
* add `vk_retexturing` documetation an enable by default.