### PR TITLE
Fix P_ProjectSource forward declaration

### DIFF
--- a/src/game/savegame/tables/gamefunc_decs.h
+++ b/src/game/savegame/tables/gamefunc_decs.h
@@ -133,7 +133,7 @@ extern void NoAmmoWeaponChange ( edict_t * ent ) ;
 extern void ChangeWeapon ( edict_t * ent ) ;
 extern qboolean Pickup_Weapon ( edict_t * ent , edict_t * other ) ;
 extern void PlayerNoise ( edict_t * who , vec3_t where , int type ) ;
-extern void P_ProjectSource ( gclient_t * client , vec3_t point , vec3_t distance , vec3_t forward , vec3_t right , vec3_t result ) ;
+extern void P_ProjectSource ( edict_t * ent , vec3_t distance , vec3_t forward , vec3_t right , vec3_t result ) ;
 extern void ClientEndServerFrame ( edict_t * ent ) ;
 extern void G_SetClientFrame ( edict_t * ent ) ;
 extern void G_SetClientSound ( edict_t * ent ) ;


### PR DESCRIPTION
The definition for P_ProjectSource looks like it changed here: https://github.com/yquake2/yquake2/commit/85fb607010ee151b2d6bc217647b41fa687aa0dc#diff-d8777409dd928ef41e564600cc9bdd7ccf260032f18b570a45f750e208936c03R44

This means that the forward declaration is wrong and this pull request fixes that.

I'm not sure if this bad forward declaration caused any issues, but this breaks compilation on my C++ fork of this project and this seemed better to fix here.