### PR TITLE
Flush keys when server data is parsed

### DIFF
--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -829,6 +829,9 @@ CL_ParseServerData(void)
 	char *str;
 	int i;
 
+	/* Clear all key states */
+	In_FlushQueue();
+
 	Com_DPrintf("Serverdata packet received.\n");
 
 	/* wipe the client_state_t struct */

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -819,16 +819,6 @@ IN_Update(void)
 }
 
 /*
- * Removes all pending events from SDLs queue.
- */
-void
-In_FlushQueue(void)
-{
-	SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
-	Key_MarkAllUp();
-}
-
-/*
  * Move handling
  */
 void
@@ -975,6 +965,17 @@ static void
 IN_JoyAltSelectorUp(void)
 {
 	joy_altselector_pressed = false;
+}
+
+/*
+ * Removes all pending events from SDLs queue.
+ */
+void
+In_FlushQueue(void)
+{
+	SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+	Key_MarkAllUp();
+	IN_JoyAltSelectorUp();
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -576,7 +576,7 @@ IN_Update(void)
 						}
 						else
 						{
-							Com_Printf("Pressed unknown key with SDL_Keycode %d, SDL_Scancode %d.\n", kc, (int)sc);
+							Com_DPrintf("Pressed unknown key with SDL_Keycode %d, SDL_Scancode %d.\n", kc, (int)sc);
 						}
 					}
 				}


### PR DESCRIPTION
This makes sure key states are reset when the game is reloaded, fixing #633 

Additionally, a debug statement in `sdl.c` has been changed to only output in debug mode as it was making testing hard (couldn't see the messages because it kept overwriting output from quicksave) :)