### PR TITLE
Rename `cl_anglekicks` to `cl_kickangles` for consistency with Q2PRO

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -56,8 +56,8 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   time for the next frame. The later is more CPU friendly but rather
   inaccurate, especially on Windows. Use with care.
 
-* **cl_anglekicks**: If set to `0` angle kicks (weapon recoil, damage
-  hits and the like) are ignored. Cheat protected. Defaults to `1`.
+* **cl_kickangles**: If set to `0` angle kicks (weapon recoil, damage
+  hits and the like) are ignored. Cheat-protected. Defaults to `1`.
 
 * **cl_async**: If set to `1` (the default) the client is asynchronous.
   The client framerate is fixed, the renderer framerate is variable.

--- a/src/client/cl_entities.c
+++ b/src/client/cl_entities.c
@@ -764,7 +764,7 @@ CL_CalcViewValues(void)
 		}
 	}
 
-	if (cl_anglekicks->value)
+	if (cl_kickangles->value)
 	{
 		for (i = 0; i < 3; i++)
 		{

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -48,7 +48,7 @@ cvar_t *cl_add_particles;
 cvar_t *cl_add_lights;
 cvar_t *cl_add_entities;
 cvar_t *cl_add_blend;
-cvar_t *cl_anglekicks;
+cvar_t *cl_kickangles;
 
 cvar_t *cl_shownet;
 cvar_t *cl_showmiss;
@@ -494,7 +494,7 @@ CL_InitLocal(void)
 	cl_add_lights = Cvar_Get("cl_lights", "1", 0);
 	cl_add_particles = Cvar_Get("cl_particles", "1", 0);
 	cl_add_entities = Cvar_Get("cl_entities", "1", 0);
-	cl_anglekicks = Cvar_Get("cl_anglekicks", "1", 0);
+	cl_kickangles = Cvar_Get("cl_kickangles", "1", 0);
 	cl_gun = Cvar_Get("cl_gun", "2", CVAR_ARCHIVE);
 	cl_footsteps = Cvar_Get("cl_footsteps", "1", 0);
 	cl_noskins = Cvar_Get("cl_noskins", "0", 0);
@@ -663,7 +663,7 @@ cheatvar_t cheatvars[] = {
 	{"sw_draworder", "0"},
 	{"gl_lightmap", "0"},
 	{"gl_saturatelighting", "0"},
-	{"cl_anglekicks", "1"},
+	{"cl_kickangles", "1"},
 	{NULL, NULL}
 };
 
@@ -949,4 +949,3 @@ CL_Shutdown(void)
 	IN_Shutdown();
 	VID_Shutdown();
 }
-

--- a/src/client/header/client.h
+++ b/src/client/header/client.h
@@ -314,7 +314,7 @@ extern	cvar_t	*cl_vwep;
 extern	cvar_t  *horplus;
 extern	cvar_t	*cin_force43;
 extern	cvar_t	*vid_fullscreen;
-extern	cvar_t	*cl_anglekicks;
+extern	cvar_t	*cl_kickangles;
 extern  cvar_t  *cl_r1q2_lightstyle;
 
 typedef struct


### PR DESCRIPTION
Q2PRO already has a `cl_kickangles` cvar (which behaves the same as Yamagi Quake 2's and is also cheat-protected). I think we should rename Yamagi Quake 2's cvar so that Q2PRO users can feel more at home :slightly_smiling_face:

### cvar in Q2PRO

![Q2PRO console](https://user-images.githubusercontent.com/180032/104870037-bb9b4f80-5947-11eb-8ee0-7754fa2bc344.png)