### PR TITLE
Fix text indicating MSAA samples for Vulkan

### DIFF
--- a/src/client/refresh/vk/vk_rmisc.c
+++ b/src/client/refresh/vk/vk_rmisc.c
@@ -224,7 +224,7 @@ void Vk_Strings_f(void)
 	R_Printf(PRINT_ALL, "   resolution: %dx%d", vid.width, vid.height);
 	if (msaa > 0)
 	{
-		R_Printf(PRINT_ALL, " (MSAAx%d)\n", 2 << (msaa - 1));
+		R_Printf(PRINT_ALL, " (MSAAx%d)\n", msaa);
 	}
 	else
 	{


### PR DESCRIPTION
Minor fix so the number of samples is printed correctly. Related to #646.