### PR TITLE
Fix segmentation fault on FreeBSD.

### DIFF
--- a/src/backends/unix/shared/hunk.c
+++ b/src/backends/unix/shared/hunk.c
@@ -76,7 +76,7 @@ Hunk_Begin(int maxsize)
 #if defined(PROT_MAX)
 	/* For now it is FreeBSD exclusif but could possibly be extended
 	   to other like DFBSD for example */
-	prot = PROT_MAX(prot);
+	prot |= PROT_MAX(prot);
 #endif
 
 	membase = mmap(0, maxhunksize, prot,


### PR DESCRIPTION
Specify correct protection flags when calling mmap() on FreeBSD.
prot | PROT_MAX (prot) are the correct flags because just PROT_MAX
(prot) leaves current protection flags set to PROT_NONE which causes
segmentation fault when reading or writing to the mapped region.