### PR TITLE
Avoid restarting the whole video on VK_ERROR_OUT_OF_DATE_KHR

### DIFF
--- a/src/client/refresh/vk/header/qvk.h
+++ b/src/client/refresh/vk/header/qvk.h
@@ -260,6 +260,8 @@ extern qvktexture_t vk_colorbuffer;
 extern qvktexture_t vk_colorbufferWarp;
 // indicator if the frame is currently being rendered
 extern qboolean vk_frameStarted;
+// Indicates if the renderer needs to be restarted.
+extern qboolean vk_restartNeeded;
 
 // function pointers
 extern PFN_vkCreateDebugUtilsMessengerEXT qvkCreateDebugUtilsMessengerEXT;
@@ -271,8 +273,12 @@ extern PFN_vkCmdEndDebugUtilsLabelEXT qvkCmdEndDebugUtilsLabelEXT;
 extern PFN_vkCmdInsertDebugUtilsLabelEXT qvkInsertDebugUtilsLabelEXT;
 
 // The Interface Functions (tm)
-qboolean	QVk_Init(SDL_Window *window);
+void		QVk_SetWindow(SDL_Window*);
+qboolean	QVk_Init(void);
+void		QVk_PostInit(void);
+void		QVk_WaitAndShutdownAll(void);
 void		QVk_Shutdown(void);
+void		QVk_Restart(void);
 void		QVk_CreateValidationLayers(void);
 void		QVk_DestroyValidationLayers(void);
 qboolean	QVk_CreateDevice(int preferredDeviceIdx);


### PR DESCRIPTION
While attempting to solve #659 I started the game in fullscreen mode under Gnome and immediately discovered the game entered an infinite renderer restart loop. A few seconds after the renderer had been initialized and was already drawing frames, it received VK_ERROR_OUT_OF_DATE_KHR, which triggered a restart of the whole video system. The game flickered while restarting it (including creating a new game window, I guess) and the story repeated itself a few seconds later.

It appears this is a known issue and also affects or affected [vkQuake](https://github.com/Novum/vkQuake/issues/211) and [vkQuake2](https://github.com/kondrak/vkQuake2/issues/95) and @kondrak solved some months ago by restarting Vulkan without touching the game Window. This pull request implements a similar solution, simplified (so probably incomplete :stuck_out_tongue:) and adapted to yquake2.

This PR can be considered work-in-progress and testing is welcome. At least it solves the infinite reload problem for me. Hopefully, but unlikely, it also solves #659. While doing some back-and-forth switching from "keep resolution" to "switch resolution" and vice versa, I also made the running demo "crash" to the game console with:

```
********************
ERROR: Mod_PointInLeaf: bad model
********************
```

And in those situations I also get the following validation error:

```
==== ShutdownGame ====
VUID-VkPresentInfoKHR-pImageIndices-01296(ERROR / SPEC): msgNum: -945112042 - Validation Error: [ VUID-VkPresentInfoKHR-pImageIndices-01296 ] Object 0: handle = 0x3b83d28, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0xc7aabc16 | vkQueuePresentKHR(): Images passed to present must be in layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR or VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR but is in VK_IMAGE_LAYOUT_UNDEFINED. The Vulkan spec states: Each element of pImageIndices must be the index of a presentable image acquired from the swapchain specified by the corresponding element of the pSwapchains array, and the presented image subresource must be in the VK_IMAGE_LAYOUT_PRESENT_SRC_KHR layout at the time the operation is executed on a VkDevice (https://github.com/KhronosGroup/Vulkan-Docs/search?q=)VUID-VkPresentInfoKHR-pImageIndices-01296)
    Objects: 1
        [0] 0x3b83d28, type: 4, name: NULL
```

So my guess is there's still work to do.