### PR TITLE
Vulkan restart tweaks

### DIFF
--- a/src/client/refresh/vk/header/local.h
+++ b/src/client/refresh/vk/header/local.h
@@ -152,7 +152,7 @@ extern	cvar_t	*vk_pixel_size;
 extern	cvar_t	*r_fixsurfsky;
 
 extern	cvar_t	*vid_fullscreen;
-extern	cvar_t	*vid_refresh;
+extern	cvar_t	*vid_renderer;
 extern	cvar_t	*vid_gamma;
 
 extern	int		c_visible_lightmaps;

--- a/src/client/refresh/vk/header/local.h
+++ b/src/client/refresh/vk/header/local.h
@@ -152,6 +152,7 @@ extern	cvar_t	*vk_pixel_size;
 extern	cvar_t	*r_fixsurfsky;
 
 extern	cvar_t	*vid_fullscreen;
+extern	cvar_t	*vid_refresh;
 extern	cvar_t	*vid_gamma;
 
 extern	int		c_visible_lightmaps;

--- a/src/client/refresh/vk/header/model.h
+++ b/src/client/refresh/vk/header/model.h
@@ -248,3 +248,4 @@ int		Hunk_End (void);
 void	Hunk_Free (void *base);
 
 void	Mod_FreeAll (void);
+void	Mod_FreeModelsKnown (void);

--- a/src/client/refresh/vk/vk_common.c
+++ b/src/client/refresh/vk/vk_common.c
@@ -1665,7 +1665,7 @@ void QVk_Restart(void)
 	if (!QVk_Init())
 		ri.Sys_Error(ERR_FATAL, "Unable to restart Vulkan renderer");
 	QVk_PostInit();
-	vid_refresh->modified = true;
+	vid_renderer->modified = true;
 }
 
 void QVk_PostInit(void)

--- a/src/client/refresh/vk/vk_common.c
+++ b/src/client/refresh/vk/vk_common.c
@@ -1664,6 +1664,7 @@ void QVk_Restart(void)
 	if (!QVk_Init())
 		ri.Sys_Error(ERR_FATAL, "Unable to restart Vulkan renderer");
 	QVk_PostInit();
+	vid_refresh->modified = true;
 }
 
 void QVk_PostInit(void)
@@ -2097,7 +2098,8 @@ VkResult QVk_EndFrame(qboolean force)
 {
 	// continue only if QVk_BeginFrame() had been previously issued
 	if (!vk_frameStarted)
-		return VK_NOT_READY;
+		return VK_SUCCESS;
+
 	// this may happen if Sys_Error is issued mid-frame, so we need to properly advance the draw pipeline
 	if (force)
 	{

--- a/src/client/refresh/vk/vk_common.c
+++ b/src/client/refresh/vk/vk_common.c
@@ -1654,6 +1654,7 @@ void QVk_WaitAndShutdownAll (void)
 	}
 
 	Mod_FreeAll();
+	Mod_FreeModelsKnown();
 	Vk_ShutdownImages();
 	QVk_Shutdown();
 }

--- a/src/client/refresh/vk/vk_model.c
+++ b/src/client/refresh/vk/vk_model.c
@@ -101,7 +101,7 @@ void Mod_Reallocate (void)
 		models_known_max *= 2;
 		// free up
 		Mod_FreeAll();
-		free(models_known);
+		Mod_FreeModelsKnown();
 	}
 
 	if (models_known_max < (mod_max * 4))
@@ -175,6 +175,17 @@ void Mod_FreeAll (void)
 		if (models_known[i].extradatasize)
 			Mod_Free (&models_known[i]);
 	}
+}
+
+/*
+================
+Mod_FreeModelsKnown
+================
+*/
+void Mod_FreeModelsKnown (void)
+{
+	free(models_known);
+	models_known = NULL;
 }
 
 /*

--- a/src/client/refresh/vk/vk_rmain.c
+++ b/src/client/refresh/vk/vk_rmain.c
@@ -130,7 +130,7 @@ cvar_t	*vk_nolerp_list;
 cvar_t  *r_fixsurfsky;
 
 cvar_t	*vid_fullscreen;
-cvar_t	*vid_refresh;
+cvar_t	*vid_renderer;
 cvar_t	*vid_gamma;
 static cvar_t	*viewsize;
 
@@ -1195,7 +1195,7 @@ R_Register( void )
 		ri.Cvar_Set("r_msaa_samples", "0");
 
 	vid_fullscreen = ri.Cvar_Get("vid_fullscreen", "0", CVAR_ARCHIVE);
-	vid_refresh = ri.Cvar_Get("vid_refresh", "0", CVAR_NOSET);
+	vid_renderer = ri.Cvar_Get("vid_renderer", "gl1", CVAR_ARCHIVE);
 	vid_gamma = ri.Cvar_Get("vid_gamma", "1.0", CVAR_ARCHIVE);
 	viewsize = ri.Cvar_Get("viewsize", "100", CVAR_ARCHIVE);
 

--- a/src/client/vid/vid.c
+++ b/src/client/vid/vid.c
@@ -286,6 +286,7 @@ VID_GetModeInfo(int *width, int *height, int mode)
 // Global console variables.
 cvar_t *vid_gamma;
 cvar_t *vid_fullscreen;
+cvar_t *vid_refresh;
 cvar_t *vid_renderer;
 
 // Global video state, used throughout the client.
@@ -489,6 +490,12 @@ VID_CheckChanges(void)
 		// Unblock the client.
 		cls.disable_screen = false;
 	}
+
+	if (vid_refresh->modified)
+	{
+		vid_refresh->modified = false;
+		cl.refresh_prepped = false;
+	}
 }
 
 /*
@@ -500,6 +507,7 @@ VID_Init(void)
 	// Console variables
 	vid_gamma = Cvar_Get("vid_gamma", "1.0", CVAR_ARCHIVE);
 	vid_fullscreen = Cvar_Get("vid_fullscreen", "0", CVAR_ARCHIVE);
+	vid_refresh = Cvar_Get("vid_refresh", "0", CVAR_NOSET);
 	vid_renderer = Cvar_Get("vid_renderer", "gl1", CVAR_ARCHIVE);
 
 	// Commands

--- a/src/client/vid/vid.c
+++ b/src/client/vid/vid.c
@@ -286,7 +286,6 @@ VID_GetModeInfo(int *width, int *height, int mode)
 // Global console variables.
 cvar_t *vid_gamma;
 cvar_t *vid_fullscreen;
-cvar_t *vid_refresh;
 cvar_t *vid_renderer;
 
 // Global video state, used throughout the client.
@@ -487,13 +486,16 @@ VID_CheckChanges(void)
 			}
 		}
 
+		// Ignore possible changes in vid_renderer above.
+		vid_renderer->modified = false;
+
 		// Unblock the client.
 		cls.disable_screen = false;
 	}
 
-	if (vid_refresh->modified)
+	if (vid_renderer->modified)
 	{
-		vid_refresh->modified = false;
+		vid_renderer->modified = false;
 		cl.refresh_prepped = false;
 	}
 }
@@ -507,7 +509,6 @@ VID_Init(void)
 	// Console variables
 	vid_gamma = Cvar_Get("vid_gamma", "1.0", CVAR_ARCHIVE);
 	vid_fullscreen = Cvar_Get("vid_fullscreen", "0", CVAR_ARCHIVE);
-	vid_refresh = Cvar_Get("vid_refresh", "0", CVAR_NOSET);
 	vid_renderer = Cvar_Get("vid_renderer", "gl1", CVAR_ARCHIVE);
 
 	// Commands


### PR DESCRIPTION
This pull request essentially fixes two issues:

* ERROR: Mod_PointInLeaf: bad model when restarting the Vulkan renderer. This is solved by making the restart happen at the end of the frame instead of at the beginning of it, and signaling the server the client needs to be re-registered again to rebuild the list of models.

* Memory leak when restarting the Vulkan renderer, due to "models_known" not being freed before allocating it again.

For the first point I used the same approach taken in vkQuake2 of using a global cvar_t called vid_refresh. It's my understanding, from reading other parts of the code, that such an approach is a bit hackish and there should be a message sent from the client  to the server to properly communicate this, but my knowledge of the code base is lacking here, so I preferred to get the fix out and let others with more experience tune it as needed.