### PR TITLE
Console warning and fix for triggered monsters with no targetname

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -144,6 +144,12 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   set to `0` footstep sounds are never generated. Cheat protected to
   `1`.
 
+* **g_fix_triggered**: This cvar, when set to `1`, forces monsters to
+  spawn in normally if they are set to a triggered spawn but do not
+  have a targetname. There are a few cases of this in GroundZero and
+  The Reckoning. This cvar is disabled by default to maintain the
+  original gameplay experience.
+
 * **g_disruptor (Ground Zero only)**: This boolean cvar controls the
   availability of the Disruptor weapon to players. The Disruptor is
   a weapon that was cut from Ground Zero during development but all

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -55,6 +55,7 @@ cvar_t *maxentities;
 cvar_t *g_select_empty;
 cvar_t *dedicated;
 cvar_t *g_footsteps;
+cvar_t *g_fix_triggered;
 
 cvar_t *filterban;
 

--- a/src/game/g_monster.c
+++ b/src/game/g_monster.c
@@ -774,6 +774,16 @@ monster_start(edict_t *self)
 		self->spawnflags |= 1;
 	}
 
+	if ((self->spawnflags & 2) && !self->targetname)
+	{
+		if (g_fix_triggered->value)
+		{
+			self->spawnflags &= ~2;
+		}
+
+		gi.dprintf ("triggered %s at %s has no targetname\n", self->classname, vtos (self->s.origin));
+	}
+
 	if (!(self->monsterinfo.aiflags & AI_GOOD_GUY))
 	{
 		level.total_monsters++;

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -520,6 +520,7 @@ extern cvar_t *needpass;
 extern cvar_t *g_select_empty;
 extern cvar_t *dedicated;
 extern cvar_t *g_footsteps;
+extern cvar_t *g_fix_triggered;
 
 extern cvar_t *filterban;
 

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -237,6 +237,7 @@ InitGame(void)
 	skill = gi.cvar("skill", "1", CVAR_LATCH);
 	maxentities = gi.cvar("maxentities", "1024", CVAR_LATCH);
 	g_footsteps = gi.cvar("g_footsteps", "1", CVAR_ARCHIVE);
+	g_fix_triggered = gi.cvar ("g_fix_triggered", "0", 0);
 
 	/* change anytime vars */
 	dmflags = gi.cvar("dmflags", "0", CVAR_SERVERINFO);


### PR DESCRIPTION
Prints a console warning when triggered spawn monsters with no targetname are spawned, and adds a new cvar g_fix_triggered that forces such monsters to spawn normally so they can be fought by the player.