### PR TITLE
Add a cvar `g_commanderbody_nogod` to make the com. body destructable.

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -144,6 +144,10 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   set to `0` footstep sounds are never generated. Cheat protected to
   `1`.
 
+* **g_commanderbody_nogod**: If set to `1` the tank commanders body
+  entity can be destroyed. If the to `0` (the default) it is
+  indestructible.
+
 * **g_disruptor (Ground Zero only)**: This boolean cvar controls the
   availability of the Disruptor weapon to players. The Disruptor is
   a weapon that was cut from Ground Zero during development but all

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -55,6 +55,7 @@ cvar_t *maxentities;
 cvar_t *g_select_empty;
 cvar_t *dedicated;
 cvar_t *g_footsteps;
+cvar_t *g_commanderbody_nogod;
 
 cvar_t *filterban;
 

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -520,6 +520,7 @@ extern cvar_t *needpass;
 extern cvar_t *g_select_empty;
 extern cvar_t *dedicated;
 extern cvar_t *g_footsteps;
+extern cvar_t *g_commanderbody_nogod;
 
 extern cvar_t *filterban;
 

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -237,6 +237,7 @@ InitGame(void)
 	skill = gi.cvar("skill", "1", CVAR_LATCH);
 	maxentities = gi.cvar("maxentities", "1024", CVAR_LATCH);
 	g_footsteps = gi.cvar("g_footsteps", "1", CVAR_ARCHIVE);
+	g_commanderbody_nogod = gi.cvar("g_commanderbody_nogod", "0", CVAR_ARCHIVE);
 
 	/* change anytime vars */
 	dmflags = gi.cvar("dmflags", "0", CVAR_SERVERINFO);

--- a/src/game/savegame/tables/gamefunc_decs.h
+++ b/src/game/savegame/tables/gamefunc_decs.h
@@ -812,6 +812,7 @@ extern void misc_deadsoldier_die ( edict_t * self , edict_t * inflictor , edict_
 extern void SP_misc_banner ( edict_t * ent ) ;
 extern void misc_banner_think ( edict_t * ent ) ;
 extern void SP_monster_commander_body ( edict_t * self ) ;
+extern void commander_body_die ( edict_t * self , edict_t * inflictor , edict_t * attacker , int damage , vec3_t point ) ;
 extern void commander_body_drop ( edict_t * self ) ;
 extern void commander_body_use ( edict_t * self , edict_t * other , edict_t * activator ) ;
 extern void commander_body_think ( edict_t * self ) ;

--- a/src/game/savegame/tables/gamefunc_list.h
+++ b/src/game/savegame/tables/gamefunc_list.h
@@ -812,6 +812,7 @@
 {"SP_misc_banner", (byte *)SP_misc_banner},
 {"misc_banner_think", (byte *)misc_banner_think},
 {"SP_monster_commander_body", (byte *)SP_monster_commander_body},
+{"commander_body_die", (byte *)commander_body_die},
 {"commander_body_drop", (byte *)commander_body_drop},
 {"commander_body_use", (byte *)commander_body_use},
 {"commander_body_think", (byte *)commander_body_think},


### PR DESCRIPTION
The commanders body entity is special, because it's spawned in god mode.
That's no problem in the baseq2 and addons campaigns. But it may break
some custom maps and prevents some hacks, one example is putting the
entity inside an killbox.

Submitted by Тихомиров Eвгений.

Yamagi, please add 
self->die = commander_body_die;
on line 1674  src/game/g_misc.c
cause if not it will fault the game