### PR TITLE
Map fixes for old and newly discovered bugs + removed code hacks

### DIFF
--- a/doc/020_installation.md
+++ b/doc/020_installation.md
@@ -134,6 +134,45 @@ some global settings to saner defaults. To use it copy *stuff/yq2.cfg*
 into the *baseq2/* directory.
 
 
+### Fixed Map Data Files
+
+As an optional feature, Yamagi Quake II provides fixed map data files
+(.ent files). These files provide a replacement entity list in order
+to fix some map bugs that have been discovered by players over the
+years.
+
+These fixes include fixes for bad  monster counts in some
+maps/difficulty settings, fixing broken spawn chains that made it
+impossible to spawn some monsters, removing DM-only items that spawn
+in unreachable areas in SP/co-op, and so on. You can find detailed
+changelogs for each map by opening the .ent files with a text editor
+and reading the comment section at the top (lines starting with "//").
+
+
+#### Download And Setup
+
+1. Download the .ent files from the yquake2 repositories on GitHub.
+
+   *baseq2*: yquake2/yquake2/stuff/mapfixes/baseq2/
+   *juggernaut*: yquake2/yquake2/stuff/mapfixes/juggernaut/
+   *xatrix*: yquake2/xatrix/stuff/mapfixes/
+   *rogue*: yquake2/rogue/stuff/mapfixes/
+   *zaero*: yquake2/zaero/stuff/mapfixes/
+
+2. Once you have the .ent files you want, put them in the respective
+   */maps* sub-folder. So *xatrix* .ent files should go into your local
+   */xatrix/maps* folder (create this folder if it does not exist).
+3. You will see a notification message in the console if an .ent file
+   was loaded. If you see this message, you know the map fixes are in
+   effect.
+
+
+#### Reporting Map Bugs
+
+If you know of any map bugs that are not addressed here, by all means
+report them to us through our GitHub repositories.
+
+
 ## The Demo Version
 
 A free demo version of Quake II is available and supported by Yamagi

--- a/src/game/g_spawn.c
+++ b/src/game/g_spawn.c
@@ -584,10 +584,6 @@ SpawnEntities(const char *mapname, char *entities, const char *spawnpoint)
 	const char *com_token;
 	int i;
 	float skill_level;
-	static qboolean monster_count_city2 = false;
-	static qboolean monster_count_city3 = false;
-	static qboolean monster_count_cool1 = false;
-	static qboolean monster_count_lab = false;
 
 	if (!mapname || !entities || !spawnpoint)
 	{
@@ -663,53 +659,6 @@ SpawnEntities(const char *mapname, char *entities, const char *spawnpoint)
 		   	!Q_stricmp(ent->model, "*27"))
 		{
 			ent->spawnflags &= ~SPAWNFLAG_NOT_HARD;
-		}
-
-		/*
-		 * The 'monsters' count in city3.bsp is wrong.
-		 * There're two monsters triggered in a hidden
-		 * and unreachable room next to the security
-		 * pass.
-		 *
-		 * We need to make sure that this hack is only
-		 * applied once!
-		 */
-		if (!Q_stricmp(level.mapname, "city3") && !monster_count_city3)
-		{
-			level.total_monsters = level.total_monsters - 2;
-			monster_count_city3 = true;
-		}
-
-		/* A slightly other problem in city2.bsp. There's a floater
-		 * with missing trigger on the right gallery above the data
-		 * spinner console, right before the door to the staircase.
-		 */
-		if ((skill->value > 0) && !Q_stricmp(level.mapname, "city2") && !monster_count_city2)
-		{
-			level.total_monsters = level.total_monsters - 1;
-			monster_count_city2 = true;
-		}
-
-		/*
-		 * Nearly the same problem exists in cool1.bsp.
-		 * On medium skill a gladiator is spawned in a
-		 * crate that's never triggered.
-		 */
-		if ((skill->value == 1) && !Q_stricmp(level.mapname, "cool1") && !monster_count_cool1)
-		{
-			level.total_monsters = level.total_monsters - 1;
-			monster_count_cool1 = true;
-		}
-
-		/*
-		 * Nearly the same problem exists in lab.bsp.
-		 * On medium skill two parasites are spawned
-		 * in a hidden place that never triggers.
-		 */
-		if ((skill->value == 1) && !Q_stricmp(level.mapname, "lab") && !monster_count_lab)
-		{
-			level.total_monsters = level.total_monsters - 2;
-			monster_count_lab = true;
 		}
 
 		/* remove things (except the world) from

--- a/stuff/mapfixes/baseq2/base2.ent
+++ b/stuff/mapfixes/baseq2/base2.ent
@@ -1,0 +1,3708 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Fixed unused target_explosive (222)
+//
+// This explosion is by the ceiling fan near the start of the level.
+{
+"nextmap" "base3"
+"classname" "worldspawn"
+"message" "Installation"
+"sky" "unit1_"
+"sounds" "7"
+}
+{
+"origin" "112 -800 8"
+"targetname" "base3b"
+"classname" "info_player_coop"
+"angle" "0"
+}
+{
+"origin" "112 -752 8"
+"targetname" "base3b"
+"classname" "info_player_coop"
+"angle" "0"
+}
+{
+"origin" "112 -852 8"
+"targetname" "base3b"
+"angle" "0"
+"classname" "info_player_coop"
+}
+{
+"origin" "828 2232 -224"
+"targetname" "base1"
+"classname" "info_player_coop"
+"angle" "180"
+}
+{
+"origin" "876 2232 -224"
+"targetname" "base1"
+"classname" "info_player_coop"
+"angle" "180"
+}
+{
+"origin" "856 2356 -224"
+"targetname" "base1"
+"angle" "180"
+"classname" "info_player_coop"
+}
+{
+"origin" "804 -1768 44"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "544 -1888 24"
+"spawnflags" "769"
+"angle" "90"
+"classname" "monster_gunner"
+}
+{
+"origin" "336 -1792 24"
+"targetname" "t88"
+"angle" "90"
+"spawnflags" "1"
+"classname" "monster_gunner"
+}
+{
+"origin" "96 -96 8"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_infantry"
+}
+{
+"origin" "-616 320 -128"
+"spawnflags" "769"
+"angle" "225"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "424 1688 24"
+"spawnflags" "769"
+"angle" "90"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "808 1792 32"
+"spawnflags" "769"
+"angle" "180"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "32 1568 -168"
+"item" "ammo_bullets"
+"spawnflags" "769"
+"angle" "270"
+"classname" "monster_infantry"
+}
+{
+"origin" "480 1632 -168"
+"spawnflags" "769"
+"angle" "180"
+"classname" "monster_infantry"
+}
+{
+"origin" "-112 2144 -160"
+"spawnflags" "768"
+"angle" "90"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "800 2528 32"
+"spawnflags" "768"
+"angle" "180"
+"classname" "monster_soldier_light"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "296 1192 -104"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "400 1184 -104"
+}
+{
+"classname" "func_timer"
+"wait" "90"
+"targetname" "t107"
+"target" "t108"
+"origin" "480 1384 64"
+"spawnflags" "2048"
+}
+{
+"model" "*1"
+"classname" "trigger_once"
+"spawnflags" "2048"
+"target" "t107"
+}
+{
+"classname" "target_speaker"
+"noise" "world/v_bas6.wav"
+"spawnflags" "2048"
+"attenuation" "-1"
+"origin" "504 1416 72"
+"targetname" "t108"
+}
+{
+"model" "*2"
+"target" "t106"
+"spawnflags" "2048"
+"classname" "trigger_once"
+}
+{
+"targetname" "t106"
+"origin" "-80 400 96"
+"target" "t105"
+"wait" "90"
+"classname" "func_timer"
+}
+{
+"origin" "-120 424 96"
+"delay" ".5"
+"targetname" "t102"
+"target" "t103"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-120 448 96"
+"delay" ".3"
+"targetname" "t103"
+"target" "t104"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-120 400 96"
+"targetname" "t105"
+"target" "t102"
+"spawnflags" "2048"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t103"
+"spawnflags" "2048"
+"origin" "-144 424 96"
+"noise" "world/flyby1.wav"
+"attenuation" "-1"
+"classname" "target_speaker"
+}
+{
+"targetname" "t102"
+"spawnflags" "2048"
+"origin" "-144 400 96"
+"noise" "world/flyby1.wav"
+"attenuation" "-1"
+"classname" "target_speaker"
+}
+{
+"targetname" "t104"
+"spawnflags" "2048"
+"classname" "target_speaker"
+"attenuation" "-1"
+"noise" "world/flyby1.wav"
+"origin" "-144 448 96"
+}
+{
+"origin" "88 1896 -128"
+"targetname" "t101"
+"noise" "world/v_bas1.wav"
+"spawnflags" "2048"
+"attenuation" "-1"
+"classname" "target_speaker"
+}
+{
+"model" "*3"
+"target" "t101"
+"spawnflags" "2048"
+"classname" "trigger_once"
+}
+{
+"origin" "-80 1768 -120"
+"classname" "target_explosion"
+"targetname" "t20"
+"dmg" "1"
+}
+{
+"origin" "-72 1824 -120"
+"delay" ".2"
+"targetname" "t20"
+"classname" "target_explosion"
+"dmg" "1"
+}
+{
+"origin" "-16 1672 -120"
+"delay" ".4"
+"targetname" "t20"
+"dmg" "1"
+"classname" "target_explosion"
+}
+{
+"origin" "672 2320 -192"
+"targetname" "t100"
+"attenuation" "-1"
+"noise" "world/v_bas3.wav"
+"spawnflags" "2048"
+"classname" "target_speaker"
+}
+{
+"model" "*4"
+"target" "t100"
+"spawnflags" "2048"
+"classname" "trigger_once"
+}
+{
+"origin" "624 2264 -200"
+"targetname" "t97"
+"spawnflags" "0"
+"target" "t98"
+"classname" "trigger_relay"
+"delay" "1"
+}
+{
+"origin" "648 2264 -200"
+"spawnflags" "0"
+"targetname" "t76"
+"target" "t97"
+"classname" "trigger_relay"
+"delay" "1"
+}
+{
+"origin" "600 2264 -200"
+"targetname" "t98"
+"spawnflags" "0"
+"target" "t99"
+"delay" "3"
+"classname" "trigger_relay"
+}
+{
+"origin" "624 2240 -200"
+"targetname" "t98"
+"spawnflags" "2048"
+"classname" "target_speaker"
+"attenuation" "-1"
+"noise" "world/explod1.wav"
+}
+{
+"origin" "648 2240 -200"
+"targetname" "t97"
+"spawnflags" "2048"
+"classname" "target_speaker"
+"attenuation" "-1"
+"noise" "world/explod1.wav"
+}
+{
+"origin" "600 2240 -200"
+"targetname" "t99"
+"spawnflags" "2048"
+"noise" "world/explod1.wav"
+"attenuation" "-1"
+"classname" "target_speaker"
+}
+{
+"origin" "624 2360 -256"
+"classname" "misc_deadsoldier"
+"spawnflags" "2"
+}
+{
+"origin" "384 992 88"
+"target" "t96"
+"targetname" "t61"
+"delay" "4"
+"classname" "trigger_relay"
+}
+{
+"origin" "368 936 88"
+"attenuation" "-1"
+"spawnflags" "2048"
+"noise" "world/v_bas2.wav"
+"classname" "target_speaker"
+"targetname" "t96"
+}
+{
+"origin" "-112 360 96"
+"random" "15"
+"wait" "30"
+"spawnflags" "2049"
+"target" "t95"
+"classname" "func_timer"
+}
+{
+"spawnflags" "2048"
+"origin" "-144 360 96"
+"targetname" "t95"
+"noise" "world/flyby1.wav"
+"attenuation" "-1"
+"classname" "target_speaker"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "270"
+"spawnflags" "257"
+"origin" "576 1776 24"
+}
+{
+"classname" "ammo_slugs"
+"spawnflags" "1792"
+"origin" "576 2656 16"
+}
+{
+"origin" "0 1976 136"
+"angles" "20 45 0"
+"classname" "info_player_intermission"
+}
+{
+"classname" "info_player_intermission"
+"angles" "20 215 0"
+"origin" "856 670 220"
+}
+{
+"model" "*5"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1536"
+"origin" "88 -1384 16"
+}
+{
+"model" "*6"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"classname" "trigger_always"
+"spawnflags" "1792"
+"target" "t67"
+"origin" "256 -856 72"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1792"
+"origin" "-296 -352 0"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health_small"
+"origin" "-96 -200 0"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health_small"
+"origin" "-96 -160 0"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "1792"
+"origin" "-96 -240 0"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "1792"
+"origin" "-96 -416 0"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-224 -36 44"
+}
+{
+"classname" "item_invulnerability"
+"spawnflags" "1792"
+"origin" "-224 -36 16"
+}
+{
+"model" "*7"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*8"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"classname" "weapon_rocketlauncher"
+"spawnflags" "1792"
+"origin" "704 -704 -136"
+}
+{
+"model" "*9"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"model" "*10"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-224 -416 -4"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-224 -352 44"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-96 -304 44"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-96 -416 44"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-96 -160 44"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "412 -1856 16"
+"spawnflags" "1792"
+"classname" "item_armor_jacket"
+}
+{
+"origin" "304 -1856 16"
+"classname" "ammo_shells"
+"spawnflags" "1792"
+}
+{
+"origin" "344 -1856 16"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "80 -1576 16"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "80 -1624 16"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "608 1440 16"
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+}
+{
+"origin" "608 1404 16"
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+}
+{
+"origin" "-856 360 -136"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-856 264 -136"
+"spawnflags" "1792"
+"classname" "weapon_grenadelauncher"
+}
+{
+"origin" "500 -1056 16"
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+}
+{
+"origin" "464 -1056 16"
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+}
+{
+"origin" "536 -1056 16"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "840 2608 72"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "720 2608 72"
+}
+{
+"origin" "32 2444 -176"
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+}
+{
+"origin" "32 2480 -176"
+"classname" "ammo_shells"
+}
+{
+"origin" "704 -704 -112"
+"light" "80"
+"classname" "light"
+}
+{
+"model" "*11"
+"_minlight" ".1"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"spawnflags" "1536"
+"classname" "item_health"
+"origin" "-656 360 -140"
+}
+{
+"classname" "item_health"
+"origin" "-616 360 -140"
+}
+{
+"origin" "-616 240 -136"
+"spawnflags" "1792"
+"classname" "item_armor_combat"
+}
+{
+"model" "*12"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-32 -32 8"
+"angle" "0"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "112 -1296 24"
+"angle" "0"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-912 -72 -136"
+"angle" "0"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "96 1632 -168"
+"angle" "0"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "688 2520 -232"
+"angle" "180"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "360 1896 24"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "424 -224 8"
+"angle" "45"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "24 -320 8"
+"angle" "0"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "280 -1976 24"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-224 2400 -168"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-96 2600 24"
+"angle" "315"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "152 -960 0"
+"spawnflags" "1792"
+"classname" "weapon_chaingun"
+}
+{
+"origin" "864 2568 16"
+"spawnflags" "1792"
+"classname" "weapon_railgun"
+}
+{
+"spawnflags" "1024"
+"origin" "240 -1632 -72"
+"classname" "ammo_grenades"
+}
+{
+"classname" "weapon_shotgun"
+"origin" "-224 -344 -144"
+}
+{
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+"origin" "1012 -704 232"
+}
+{
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+"origin" "-4 -1792 248"
+}
+{
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+"origin" "-4 -1600 248"
+}
+{
+"spawnflags" "1"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"origin" "184 -1052 180"
+}
+{
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-232 456 120"
+"volume" ".2"
+}
+{
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "296 456 120"
+"volume" ".4"
+}
+{
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+"origin" "736 456 120"
+"volume" ".4"
+}
+{
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+"origin" "480 184 120"
+"volume" ".4"
+}
+{
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+"origin" "0 168 120"
+"volume" ".2"
+}
+{
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "792 280 120"
+"volume" ".4"
+}
+{
+"attenuation" "-1"
+"classname" "target_speaker"
+"noise" "world/battle2.wav"
+"spawnflags" "2048"
+"targetname" "t93"
+"origin" "636 626 96"
+}
+{
+"wait" "19"
+"random" "8"
+"classname" "func_timer"
+"spawnflags" "1"
+"target" "t93"
+"origin" "644 594 96"
+}
+{
+"spawnflags" "1"
+"classname" "func_timer"
+"random" "4"
+"wait" "15"
+"target" "t91"
+"origin" "620 234 96"
+}
+{
+"attenuation" "-1"
+"spawnflags" "2048"
+"noise" "world/battle3.wav"
+"classname" "target_speaker"
+"targetname" "t91"
+"origin" "612 250 96"
+}
+{
+"spawnflags" "1"
+"classname" "func_timer"
+"random" "8"
+"wait" "19"
+"target" "t92"
+"origin" "660 458 96"
+}
+{
+"attenuation" "-1"
+"spawnflags" "2048"
+"noise" "world/explod2.wav"
+"classname" "target_speaker"
+"targetname" "t92"
+"volume" ".5"
+"origin" "652 490 32"
+}
+{
+"classname" "func_timer"
+"spawnflags" "1"
+"target" "t94"
+"random" "7"
+"wait" "16"
+"origin" "-42 474 62"
+}
+{
+"attenuation" "-1"
+"classname" "target_speaker"
+"noise" "world/battle1.wav"
+"spawnflags" "2048"
+"targetname" "t94"
+"origin" "-50 514 62"
+}
+{
+"classname" "item_armor_shard"
+"origin" "40 2128 -168"
+}
+{
+"classname" "item_armor_shard"
+"origin" "40 2088 -168"
+}
+{
+"classname" "item_armor_shard"
+"origin" "40 2168 -168"
+}
+{
+"spawnflags" "2048"
+"classname" "item_armor_shard"
+"origin" "840 2552 16"
+}
+{
+"spawnflags" "2048"
+"classname" "item_armor_shard"
+"origin" "872 2584 16"
+}
+{
+"spawnflags" "2048"
+"origin" "840 2640 24"
+"classname" "ammo_bullets"
+}
+{
+"spawnflags" "2048"
+"origin" "760 2640 24"
+"classname" "ammo_bullets"
+}
+{
+"classname" "ammo_grenades"
+"origin" "116 -994 0"
+}
+{
+"classname" "item_health_large"
+"origin" "28 -480 72"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_rockets"
+"origin" "272 -544 8"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "1"
+"classname" "monster_gunner"
+"angle" "270"
+"target" "t89"
+"origin" "120 -2136 24"
+"item" "ammo_bullets"
+}
+{
+"classname" "path_corner"
+"targetname" "t89"
+"target" "t90"
+"origin" "120 -2272 8"
+}
+{
+"classname" "path_corner"
+"target" "t89"
+"targetname" "t90"
+"origin" "120 -2048 8"
+}
+{
+"model" "*13"
+"classname" "trigger_once"
+"target" "t88"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "0"
+"targetname" "t48"
+"spawnflags" "1"
+"origin" "544 -1296 24"
+}
+{
+"classname" "ammo_shells"
+"origin" "368 -1008 16"
+}
+{
+"classname" "ammo_shells"
+"origin" "368 -1048 16"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "76 -704 0"
+}
+{
+"origin" "216 -1824 -78"
+"classname" "ammo_shells"
+}
+{
+"origin" "160 -152 0"
+"classname" "ammo_shells"
+}
+{
+"origin" "160 -200 0"
+"classname" "ammo_shells"
+}
+{
+"classname" "target_speaker"
+"noise" "world/lite_on2.wav"
+"targetname" "t74"
+"attenuation" "-1"
+"origin" "648 -1024 112"
+"spawnflags" "2048"
+}
+{
+"origin" "236 2016 -160"
+"classname" "ammo_bullets"
+}
+{
+"classname" "ammo_shells"
+"origin" "32 2520 -176"
+}
+{
+"classname" "item_health_large"
+"origin" "288 2464 -176"
+}
+{
+"classname" "ammo_bullets"
+"origin" "258 -992 0"
+}
+{
+"origin" "712 440 168"
+"spawnflags" "1"
+"target" "t77"
+"classname" "target_crosslevel_target"
+}
+{
+"origin" "776 512 184"
+"targetname" "t77"
+"classname" "monster_flyer"
+"angle" "225"
+"spawnflags" "3"
+}
+{
+"origin" "744 568 96"
+"targetname" "t77"
+"classname" "monster_flyer"
+"angle" "225"
+"spawnflags" "3"
+}
+{
+"origin" "600 632 184"
+"targetname" "t77"
+"spawnflags" "3"
+"angle" "225"
+"classname" "monster_flyer"
+}
+{
+"classname" "target_help"
+"targetname" "t76"
+"origin" "808 2344 -208"
+"message" "Use sewer tunnels to gain\naccess to the Comm Center."
+}
+{
+"model" "*14"
+"classname" "trigger_once"
+"target" "t76"
+}
+{
+"origin" "16 -416 40"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "16 -416 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "16 -288 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "16 -288 40"
+"classname" "light"
+"light" "80"
+}
+{
+"classname" "target_secret"
+"targetname" "t75"
+"message" "You have found a secret area."
+"origin" "-168 -344 -88"
+}
+{
+"classname" "target_secret"
+"targetname" "t73"
+"message" "You have found a secret."
+"origin" "248 -1816 -56"
+}
+{
+"spawnflags" "2048"
+"targetname" "t67"
+"classname" "target_goal"
+"origin" "272 -752 48"
+}
+{
+"classname" "target_goal"
+"targetname" "t5"
+"origin" "-856 296 -64"
+}
+{
+"targetname" "t73"
+"origin" "-44 -2272 -72"
+"angle" "0"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "624 -1040 96"
+"target" "t74"
+"delay" "3.5"
+"targetname" "t6"
+"classname" "trigger_relay"
+}
+{
+"origin" "848 2296 -72"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"model" "*15"
+"targetname" "block"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"origin" "64 -2080 72"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"origin" "56 -2216 72"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"origin" "-24 -96 72"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"origin" "352 -1880 104"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"origin" "88 -1296 72"
+}
+{
+"origin" "416 -1456 0"
+"noise" "world/amb15.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "552 -1728 -56"
+"noise" "world/amb15.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"origin" "768 -1384 72"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"origin" "672 2608 96"
+}
+{
+"noise" "world/drip_amb.wav"
+"origin" "720 -888 -136"
+"classname" "target_speaker"
+"spawnflags" "1"
+}
+{
+"origin" "816 -696 -136"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+}
+{
+"origin" "496 -736 -136"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "224 -2096 -56"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb15.wav"
+}
+{
+"origin" "360 -2272 -56"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb15.wav"
+}
+{
+"origin" "536 -2256 -56"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb15.wav"
+}
+{
+"origin" "552 -2016 -56"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb15.wav"
+}
+{
+"origin" "544 -1456 0"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb15.wav"
+}
+{
+"origin" "208 -1856 -56"
+"noise" "world/amb15.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "616 1352 64"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "352 -1992 72"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "392 1688 32"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+}
+{
+"origin" "552 1888 32"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+}
+{
+"origin" "104 1784 32"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "208 2008 96"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-40 2464 96"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "320 1184 64"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "288 2600 96"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "-240 2240 -144"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "-240 1984 -144"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "64 1960 -144"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "-40 2080 96"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "440 1880 -176"
+"noise" "world/spark2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"noise" "world/comp_hum2.wav"
+"origin" "416 1952 -104"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"targetname" "t20"
+"origin" "-128 1800 -104"
+"noise" "world/turbine1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "320 1176 -128"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+}
+{
+"origin" "624 1360 -128"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+}
+{
+"origin" "624 1176 -128"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "480 1000 104"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "24 1176 -128"
+"noise" "world/comp_hum3.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "720 -384 8"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "832 -144 8"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "392 -248 8"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "800 -536 8"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "160 -744 -88"
+"noise" "world/amb5.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "96 -240 -88"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+}
+{
+"origin" "96 -416 -88"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "32 -352 72"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-736 256 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+}
+{
+"origin" "-568 96 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+}
+{
+"origin" "-424 104 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+}
+{
+"origin" "-360 288 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+}
+{
+"origin" "-768 -56 -152"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"noise" "world/drip_amb.wav"
+"origin" "24 -248 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+}
+{
+"noise" "world/drip_amb.wav"
+"origin" "-96 -304 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+}
+{
+"origin" "-192 -376 -144"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/drip_amb"
+}
+{
+"noise" "world/drip_amb.wav"
+"origin" "104 -416 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+}
+{
+"noise" "world/drip_amb.wav"
+"origin" "48 -808 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+}
+{
+"noise" "world/drip_amb.wav"
+"origin" "152 -672 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+}
+{
+"noise" "world/drip_amb.wav"
+"origin" "248 -672 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+}
+{
+"noise" "world/drip_amb.wav"
+"origin" "256 -864 -152"
+"classname" "target_speaker"
+"spawnflags" "1"
+}
+{
+"noise" "world/drip_amb.wav"
+"origin" "-160 -96 -152"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "272 -840 40"
+"killtarget" "block"
+"targetname" "t6"
+"classname" "trigger_relay"
+}
+{
+"origin" "544 1568 -176"
+"classname" "item_health"
+}
+{
+"origin" "600 1568 -176"
+"classname" "item_health"
+}
+{
+"origin" "64 -488 88"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "152 -8 8"
+"classname" "item_health_large"
+}
+{
+"origin" "-56 1696 -176"
+"classname" "item_health_large"
+}
+{
+"model" "*16"
+"spawnflags" "2048"
+"speed" "200"
+"wait" "-1"
+"angle" "-2"
+"classname" "func_door"
+"targetname" "t73"
+"_minlight" ".1"
+}
+{
+"origin" "-40 -1760 -72"
+"angle" "0"
+"classname" "monster_soldier_light"
+"targetname" "t73"
+}
+{
+"model" "*17"
+"spawnflags" "2048"
+"classname" "func_door"
+"angle" "-2"
+"wait" "-1"
+"speed" "200"
+"targetname" "t73"
+"_minlight" ".1"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "456 -1944 -84"
+}
+{
+"model" "*18"
+"targetname" "block"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "0"
+"targetname" "t73"
+"origin" "0 -2272 -72"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "16"
+"angle" "0"
+"origin" "-240 -432 -160"
+}
+{
+"style" "1"
+"classname" "func_areaportal"
+"targetname" "t48"
+}
+{
+"origin" "288 -1384 24"
+"classname" "item_health_small"
+}
+{
+"origin" "168 -1408 0"
+"classname" "misc_deadsoldier"
+"spawnflags" "9"
+}
+{
+"origin" "256 -1344 0"
+"classname" "misc_deadsoldier"
+"spawnflags" "1"
+}
+{
+"origin" "160 -1304 0"
+"spawnflags" "2"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "936 -1280 24"
+"classname" "ammo_bullets"
+}
+{
+"origin" "936 -1328 24"
+"classname" "ammo_bullets"
+}
+{
+"origin" "440 352 -96"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "808 1832 24"
+"classname" "item_armor_jacket"
+}
+{
+"origin" "224 1696 24"
+"classname" "item_health"
+}
+{
+"origin" "160 1696 24"
+"classname" "item_health"
+}
+{
+"origin" "-48 2520 72"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-48 2416 72"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "240 2608 72"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "344 2608 72"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "616 2608 72"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "840 2520 72"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-40 2032 72"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-40 2136 72"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*19"
+"classname" "trigger_once"
+"target" "t68"
+}
+{
+"origin" "-232 -344 -120"
+"light" "80"
+"classname" "light"
+}
+{
+"angle" "90"
+"origin" "448 352 -136"
+"spawnflags" "32"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "100 -540 -16"
+"classname" "misc_explobox"
+}
+{
+"model" "*20"
+"target" "t67"
+"classname" "trigger_once"
+}
+{
+"origin" "160 -2024 24"
+"classname" "ammo_shells"
+}
+{
+"origin" "424 -2024 24"
+"classname" "item_health_small"
+}
+{
+"origin" "424 -2072 24"
+"classname" "item_health_small"
+}
+{
+"origin" "560 -1776 -96"
+"spawnflags" "4"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "88 -1720 -96"
+"spawnflags" "4"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "304 -1824 -96"
+"spawnflags" "1"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "304 -1888 -72"
+"classname" "weapon_supershotgun"
+"target" "t73"
+}
+{
+"origin" "920 -1008 24"
+"classname" "item_health_small"
+}
+{
+"origin" "920 -1048 24"
+"classname" "item_health_small"
+}
+{
+"origin" "864 -616 8"
+"classname" "ammo_shells"
+}
+{
+"origin" "32 -416 0"
+"classname" "item_health"
+}
+{
+"origin" "32 -376 0"
+"classname" "item_health"
+}
+{
+"origin" "190 -992 0"
+"classname" "ammo_bullets"
+}
+{
+"origin" "224 -992 0"
+"classname" "ammo_bullets"
+}
+{
+"origin" "448 -704 32"
+"angle" "0"
+"classname" "monster_infantry"
+"targetname" "t68"
+}
+{
+"origin" "576 -1032 32"
+"angle" "45"
+"classname" "monster_soldier_light"
+"targetname" "t68"
+}
+{
+"style" "6"
+"light" "130"
+"origin" "-224 -352 -80"
+"classname" "light"
+"_color" "1.000000 0.976000 0.064000"
+}
+{
+"model" "*21"
+"mass" "800"
+"dmg" "1"
+"health" "20"
+"classname" "func_explosive"
+"target" "t75"
+}
+{
+"spawnflags" "1536"
+"origin" "-696 360 -140"
+"classname" "item_health"
+}
+{
+"origin" "608 1016 16"
+"classname" "item_health_small"
+}
+{
+"origin" "608 1056 16"
+"classname" "item_health_small"
+}
+{
+"origin" "608 976 16"
+"classname" "item_health_small"
+}
+{
+"origin" "608 1248 -168"
+"classname" "ammo_bullets"
+}
+{
+"origin" "608 1312 -168"
+"classname" "ammo_bullets"
+}
+{
+"spawnflags" "2048"
+"origin" "800 2640 24"
+"classname" "ammo_bullets"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "512 864 124"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "512 800 124"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "480 1008 128"
+}
+{
+"origin" "432 1056 128"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "432 1056 48"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "544 1020 48"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "624 992 80"
+}
+{
+"origin" "192 1696 80"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "384 1696 80"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "768 1792 80"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "80 1472 80"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "80 1360 80"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "192 1624 -104"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "384 1624 -104"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "384 1696 -104"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "384 1496 -104"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "192 1688 -104"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "192 1496 -104"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "64 2432 -120"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "64 2176 -120"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "848 2360 -184"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "848 2232 -184"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "832 2292 -224"
+"angle" "180"
+"classname" "info_player_start"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "156 1964 -132"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "232 1964 -132"
+}
+{
+"origin" "-12 2028 8"
+"targetname" "t66"
+"spawnflags" "1"
+"classname" "point_combat"
+}
+{
+"origin" "408 1504 -176"
+"targetname" "t37"
+"classname" "point_combat"
+}
+{
+"origin" "-936 -72 -128"
+"angle" "45"
+"classname" "monster_soldier_light"
+}
+{
+"model" "*22"
+"target" "t65"
+"classname" "trigger_once"
+}
+{
+"origin" "-848 360 -128"
+"targetname" "t65"
+"angle" "315"
+"classname" "monster_soldier_light"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "90"
+"target" "t60"
+"spawnflags" "1"
+"origin" "752 -568 16"
+}
+{
+"origin" "760 1792 32"
+"targetname" "t62"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_soldier_light"
+}
+{
+"model" "*23"
+"spawnflags" "2048"
+"target" "t62"
+"classname" "trigger_once"
+}
+{
+"model" "*24"
+"spawnflags" "2048"
+"targetname" "t62"
+"speed" "200"
+"_minlight" ".2"
+"wait" "-1"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"origin" "552 1216 24"
+"classname" "item_health_small"
+}
+{
+"origin" "600 1216 24"
+"classname" "item_health_small"
+}
+{
+"origin" "-24 1896 16"
+"classname" "ammo_bullets"
+}
+{
+"origin" "32 1896 16"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-96 2408 -168"
+"classname" "item_health_small"
+}
+{
+"origin" "-144 2408 -168"
+"classname" "item_health_small"
+}
+{
+"origin" "480 2112 -240"
+"classname" "item_health"
+}
+{
+"model" "*25"
+"target" "t61"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "544 344 40"
+"dmg" "1"
+"targetname" "t61"
+"classname" "target_explosion"
+"delay" "1.5"
+}
+{
+"origin" "520 392 40"
+"dmg" "1"
+"delay" "1"
+"targetname" "t61"
+"classname" "target_explosion"
+}
+{
+"origin" "488 296 40"
+"dmg" "1"
+"delay" ".4"
+"targetname" "t61"
+"classname" "target_explosion"
+}
+{
+"origin" "400 336 56"
+"dmg" "1"
+"delay" ".2"
+"targetname" "t61"
+"classname" "target_explosion"
+}
+{
+"origin" "448 416 72"
+"dmg" "1"
+"delay" ".4"
+"targetname" "t61"
+"classname" "target_explosion"
+}
+{
+"origin" "424 464 40"
+"dmg" "1"
+"delay" ".8"
+"targetname" "t61"
+"classname" "target_explosion"
+}
+{
+"origin" "416 432 40"
+"dmg" "1"
+"delay" ".1"
+"targetname" "t61"
+"classname" "target_explosion"
+}
+{
+"origin" "544 448 40"
+"dmg" "1"
+"delay" "1.2"
+"targetname" "t61"
+"classname" "target_explosion"
+}
+{
+"classname" "info_player_start"
+"angle" "0"
+"targetname" "base3b"
+"origin" "8 -800 8"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_infantry"
+"angle" "90"
+"target" "t56"
+"spawnflags" "257"
+"origin" "808 -480 8"
+}
+{
+"classname" "path_corner"
+"targetname" "t57"
+"target" "t58"
+"origin" "752 -200 -8"
+}
+{
+"classname" "path_corner"
+"targetname" "t59"
+"target" "t60"
+"origin" "752 -200 -8"
+}
+{
+"classname" "path_corner"
+"target" "t57"
+"targetname" "t60"
+"origin" "752 -520 -8"
+}
+{
+"classname" "path_corner"
+"targetname" "t58"
+"target" "t59"
+"origin" "576 -200 -8"
+}
+{
+"classname" "path_corner"
+"targetname" "t55"
+"target" "t56"
+"origin" "808 -192 -8"
+}
+{
+"classname" "path_corner"
+"target" "t55"
+"targetname" "t56"
+"origin" "808 -448 -8"
+}
+{
+"model" "*26"
+"classname" "trigger_once"
+"target" "t52"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "270"
+"targetname" "t52"
+"origin" "272 -288 24"
+"spawnflags" "1"
+}
+{
+"angle" "270"
+"classname" "monster_soldier_ss"
+"targetname" "t48"
+"origin" "312 -1328 24"
+"spawnflags" "768"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "96 -184 96"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "74 -704 76"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "76 -896 0"
+"light" "64"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "88 -800 64"
+}
+{
+"origin" "8 -800 116"
+"classname" "light"
+"light" "64"
+}
+{
+"model" "*27"
+"_minlight" ".2"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"origin" "432 592 24"
+"targetname" "t45"
+"classname" "monster_soldier_light"
+"angle" "90"
+"spawnflags" "1"
+}
+{
+"model" "*28"
+"target" "t44"
+"classname" "trigger_once"
+}
+{
+"origin" "192 536 24"
+"targetname" "t44"
+"angle" "0"
+"classname" "monster_soldier_light"
+"spawnflags" "257"
+}
+{
+"origin" "88 544 24"
+"target" "t43"
+"angle" "90"
+"classname" "monster_soldier_light"
+"spawnflags" "1"
+}
+{
+"origin" "-288 600 -144"
+"target" "t43"
+"targetname" "t42"
+"classname" "path_corner"
+}
+{
+"origin" "88 600 8"
+"targetname" "t43"
+"target" "t42"
+"classname" "path_corner"
+}
+{
+"origin" "512 800 24"
+"target" "t45"
+"targetname" "t41"
+"angle" "90"
+"classname" "monster_infantry"
+"spawnflags" "1"
+}
+{
+"model" "*29"
+"target" "t41"
+"classname" "trigger_once"
+}
+{
+"origin" "592 976 8"
+"targetname" "t40"
+"target" "t39"
+"classname" "path_corner"
+}
+{
+"origin" "248 976 8"
+"target" "t40"
+"targetname" "t39"
+"classname" "path_corner"
+}
+{
+"item" "ammo_bullets"
+"spawnflags" "1"
+"origin" "304 976 24"
+"target" "t39"
+"angle" "180"
+"classname" "monster_infantry"
+}
+{
+"model" "*30"
+"target" "t38"
+"classname" "trigger_once"
+}
+{
+"spawnflags" "1"
+"origin" "304 1800 24"
+"targetname" "t38"
+"angle" "0"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "496 1216 24"
+"target" "t36"
+"angle" "180"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "144 1216 8"
+"target" "t36"
+"targetname" "t35"
+"classname" "path_corner"
+}
+{
+"origin" "440 1216 8"
+"targetname" "t36"
+"target" "t35"
+"classname" "path_corner"
+}
+{
+"spawnflags" "1"
+"origin" "96 1320 -160"
+"target" "t34"
+"angle" "270"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "96 1272 -176"
+"targetname" "t34"
+"target" "t33"
+"classname" "path_corner"
+}
+{
+"origin" "576 1224 -176"
+"target" "t33"
+"targetname" "t32"
+"classname" "path_corner"
+}
+{
+"origin" "48 1224 -176"
+"targetname" "t33"
+"target" "t32"
+"classname" "path_corner"
+}
+{
+"origin" "48 1456 -176"
+"target" "t33"
+"targetname" "t32"
+"classname" "path_corner"
+}
+{
+"spawnflags" "257"
+"origin" "32 1512 32"
+"targetname" "t30"
+"classname" "monster_soldier_light"
+}
+{
+"model" "*31"
+"target" "t30"
+"classname" "trigger_once"
+}
+{
+"spawnflags" "1"
+"target" "t37"
+"origin" "560 1504 -160"
+"targetname" "t31"
+"angle" "180"
+"classname" "monster_infantry"
+}
+{
+"origin" "464 1512 -104"
+"target" "t31"
+"targetname" "t30"
+"classname" "trigger_relay"
+}
+{
+"model" "*32"
+"target" "t30"
+"classname" "trigger_multiple"
+}
+{
+"origin" "320 1968 -152"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "288 1896 -112"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "400 1896 -112"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*33"
+"speed" "100"
+"classname" "func_door"
+"angle" "-1"
+"wait" "-1"
+"_minlight" ".2"
+"targetname" "t29"
+"spawnflags" "2048"
+}
+{
+"model" "*34"
+"classname" "func_button"
+"angle" "90"
+"wait" "-1"
+"target" "t29"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_bullets"
+"origin" "202 2016 -160"
+}
+{
+"classname" "weapon_machinegun"
+"origin" "162 2016 -160"
+}
+{
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+"angle" "270"
+"target" "t28"
+"origin" "384 1816 -160"
+}
+{
+"classname" "path_corner"
+"target" "t25"
+"targetname" "t26"
+"origin" "192 1768 -176"
+}
+{
+"classname" "path_corner"
+"targetname" "t27"
+"target" "t28"
+"origin" "384 1496 -176"
+}
+{
+"classname" "path_corner"
+"targetname" "t25"
+"target" "t27"
+"origin" "192 1488 -176"
+}
+{
+"classname" "path_corner"
+"targetname" "t25"
+"target" "t26"
+"origin" "40 1768 -176"
+}
+{
+"classname" "path_corner"
+"targetname" "t28"
+"target" "t26"
+"origin" "384 1768 -176"
+}
+{
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+"angle" "180"
+"target" "t23"
+"origin" "240 1912 -160"
+}
+{
+"classname" "path_corner"
+"targetname" "t23"
+"target" "t24"
+"origin" "128 1912 -176"
+}
+{
+"classname" "path_corner"
+"target" "t23"
+"targetname" "t24"
+"origin" "376 1912 -176"
+}
+{
+"target" "t66"
+"spawnflags" "257"
+"classname" "monster_soldier_light"
+"angle" "90"
+"targetname" "t21"
+"origin" "184 1792 32"
+}
+{
+"model" "*35"
+"classname" "trigger_multiple"
+"target" "t21"
+}
+{
+"spawnflags" "257"
+"classname" "monster_soldier_light"
+"angle" "180"
+"targetname" "t21"
+"origin" "816 2576 32"
+}
+{
+"model" "*36"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t20"
+}
+{
+"spawnflags" "1"
+"classname" "monster_infantry"
+"angle" "180"
+"targetname" "t20"
+"origin" "-80 1896 -168"
+}
+{
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+"angle" "180"
+"targetname" "t19"
+"origin" "288 2528 -232"
+}
+{
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+"angle" "90"
+"targetname" "t19"
+"origin" "120 2088 -232"
+}
+{
+"angle" "135"
+"classname" "monster_soldier_ss"
+"target" "t18"
+"origin" "416 2208 -232"
+}
+{
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+"angle" "90"
+"targetname" "t18"
+"target" "t19"
+"origin" "352 2144 -232"
+}
+{
+"classname" "path_corner"
+"targetname" "t16"
+"target" "t17"
+"origin" "-200 2000 -176"
+}
+{
+"classname" "path_corner"
+"targetname" "t15"
+"target" "t16"
+"origin" "-160 2304 -176"
+}
+{
+"classname" "path_corner"
+"targetname" "t14"
+"target" "t15"
+"origin" "-64 2304 -176"
+}
+{
+"target" "t16"
+"classname" "path_corner"
+"targetname" "t17"
+"origin" "-200 2152 -176"
+}
+{
+"classname" "path_corner"
+"targetname" "t13"
+"target" "t14"
+"origin" "272 2304 -248"
+}
+{
+"classname" "path_corner"
+"targetname" "t12"
+"target" "t13"
+"origin" "384 2368 -248"
+}
+{
+"classname" "path_corner"
+"target" "t12"
+"origin" "440 2368 -248"
+"targetname" "t22"
+}
+{
+"origin" "-120 -760 72"
+"map" "base3$base2b"
+"targetname" "t11"
+"classname" "target_changelevel"
+}
+{
+"model" "*37"
+"target" "t11"
+"classname" "trigger_multiple"
+"angle" "180"
+}
+{
+"classname" "target_changelevel"
+"targetname" "t9"
+"origin" "-912 104 -232"
+"map" "base3$base2a"
+}
+{
+"model" "*38"
+"classname" "trigger_multiple"
+"target" "t9"
+}
+{
+"model" "*39"
+"target" "t8"
+"classname" "trigger_multiple"
+}
+{
+"origin" "856 2264 56"
+"map" "base1$base2"
+"targetname" "t8"
+"classname" "target_changelevel"
+}
+{
+"origin" "480 2448 -256"
+"classname" "misc_explobox"
+}
+{
+"origin" "544 2496 -256"
+"classname" "misc_explobox"
+}
+{
+"origin" "-248 544 -24"
+"light" "150"
+"classname" "light"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "248 -1992 -84"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "56 -2040 -84"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "376 -1800 -84"
+}
+{
+"origin" "56 -1848 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "200 -1656 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "200 -1496 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "208 -1912 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "376 -1912 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "248 -2184 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "56 -2184 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "584 -2184 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "584 -2104 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "456 -2184 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "456 -2104 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "456 -1800 -84"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "56 -1672 -84"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "64 -2080 32"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "64 -2208 32"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "40 -2080 160"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "40 -2208 160"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "48 -2208 104"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "48 -2080 104"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "352 -2288 56"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "144 -2288 56"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "160 -2064 56"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "352 -2080 56"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "352 -1968 64"
+}
+{
+"classname" "light"
+"origin" "-4 -1596 148"
+"light" "450"
+}
+{
+"classname" "light"
+"origin" "1012 -708 124"
+"light" "450"
+}
+{
+"origin" "280 -800 24"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "224 -800 24"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "560 -848 -88"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "832 -832 -88"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "832 -680 -136"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "560 -696 -136"
+"light" "120"
+"classname" "light"
+}
+{
+"style" "32"
+"targetname" "t74"
+"spawnflags" "1"
+"origin" "768 -1072 80"
+"light" "175"
+"classname" "light"
+}
+{
+"origin" "920 -616 168"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "920 -616 40"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "928 -800 40"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "928 -800 168"
+"light" "100"
+"classname" "light"
+}
+{
+"model" "*40"
+"origin" "450 -958 -18"
+"targetname" "t6"
+"distance" "90"
+"spawnflags" "65"
+"wait" "-1"
+"speed" "35"
+"classname" "func_door_rotating"
+}
+{
+"origin" "944 -1024 68"
+"light" "150"
+"classname" "light"
+}
+{
+"light" "450"
+"origin" "-4 -1788 148"
+"classname" "light"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "416 -1696 56"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "576 -1576 56"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "120 -1872 56"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "184 -1672 56"
+"classname" "light"
+"light" "150"
+}
+{
+"model" "*41"
+"_minlight" ".2"
+"target" "t7"
+"classname" "func_button"
+"angle" "0"
+}
+{
+"model" "*42"
+"spawnflags" "2048"
+"team" "1"
+"classname" "func_door"
+"angle" "270"
+"speed" "50"
+"lip" "32"
+}
+{
+"model" "*43"
+"spawnflags" "2048"
+"team" "1"
+"angle" "90"
+"classname" "func_door"
+"speed" "50"
+"lip" "32"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "904 2304 -216"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "712 2368 -184"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "712 2240 -184"
+}
+{
+"origin" "848 2296 -28"
+"classname" "light"
+"light" "150"
+}
+{
+"model" "*44"
+"_minlight" ".2"
+"targetname" "t7"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "848 2360 -124"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "848 2232 -124"
+}
+{
+"origin" "704 2232 -160"
+"light" "200"
+"classname" "light"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "832 -1296 80"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "696 -1296 80"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "608 -1296 80"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "480 -1296 80"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "768 -1216 80"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "344 -1296 80"
+}
+{
+"model" "*45"
+"_minlight" ".1"
+"classname" "func_door"
+"angle" "-1"
+"target" "t48"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "-888 92 -308"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-888 96 -208"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-888 92 20"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-748 292 -208"
+"classname" "light"
+"light" "100"
+"_color" "0.666667 1.000000 0.986928"
+}
+{
+"origin" "-696 224 -208"
+"classname" "light"
+"light" "100"
+"_color" "0.666667 1.000000 0.986928"
+}
+{
+"origin" "-648 160 -208"
+"classname" "light"
+"light" "100"
+"_color" "0.666667 1.000000 0.986928"
+}
+{
+"origin" "-644 56 -208"
+"classname" "light"
+"light" "100"
+"_color" "0.666667 1.000000 0.986928"
+}
+{
+"origin" "-636 -44 -208"
+"classname" "light"
+"light" "100"
+"_color" "0.666667 1.000000 0.986928"
+}
+{
+"origin" "-860 -68 -204"
+"classname" "light"
+"light" "100"
+"_color" "0.666667 1.000000 0.986928"
+}
+{
+"origin" "-784 -60 -204"
+"classname" "light"
+"light" "100"
+"_color" "0.666667 1.000000 0.986928"
+}
+{
+"origin" "-728 -4 -204"
+"classname" "light"
+"light" "100"
+"_color" "0.666667 1.000000 0.986928"
+}
+{
+"origin" "-724 92 -204"
+"classname" "light"
+"light" "100"
+"_color" "0.666667 1.000000 0.986928"
+}
+{
+"origin" "-728 184 -204"
+"classname" "light"
+"light" "100"
+"_color" "0.000000 0.666667 1.000000"
+}
+{
+"origin" "-816 268 -208"
+"_color" "0.666667 1.000000 0.986928"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-968 -72 -96"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-608 288 -96"
+"light" "120"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-888 92 -404"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-888 92 -108"
+}
+{
+"model" "*46"
+"spawnflags" "2048"
+"target" "t5"
+"angle" "180"
+"classname" "func_button"
+"wait" "-1"
+}
+{
+"origin" "-728 96 -40"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-896 -64 -72"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-876 264 -108"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-888 92 124"
+"light" "64"
+"classname" "light"
+}
+{
+"model" "*47"
+"origin" "-888 180 -156"
+"_minlight" ".2"
+"targetname" "t5"
+"wait" "-1"
+"speed" "35"
+"spawnflags" "64"
+"distance" "-90"
+"classname" "func_door_rotating"
+}
+{
+"model" "*48"
+"origin" "-888 12 -156"
+"_minlight" ".2"
+"targetname" "t5"
+"distance" "90"
+"wait" "-1"
+"speed" "35"
+"spawnflags" "64"
+"classname" "func_door_rotating"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "448 -768 80"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "448 -640 80"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "448 -896 80"
+}
+{
+"classname" "func_group"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "168 -584 96"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "168 -888 96"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "168 -768 96"
+}
+{
+"classname" "func_group"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-56 -96 96"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-48 -96 24"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "188 -1048 176"
+}
+{
+"light" "250"
+"classname" "light"
+"origin" "188 -1048 96"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "188 -1048 20"
+}
+{
+"model" "*49"
+"origin" "256 -800 -9"
+"targetname" "t67"
+"classname" "func_door_rotating"
+"wait" "-1"
+"distance" "90"
+"spawnflags" "144"
+"speed" "50"
+"target" "t6"
+"dmg" "1"
+}
+{
+"light" "300"
+"classname" "light"
+"origin" "416 -864 352"
+}
+{
+"light" "250"
+"classname" "light"
+"origin" "560 -912 112"
+}
+{
+"classname" "light"
+"light" "300"
+"origin" "416 -728 352"
+}
+{
+"style" "32"
+"targetname" "t74"
+"spawnflags" "1"
+"origin" "672 -1076 16"
+"classname" "light"
+"light" "120"
+}
+{
+"style" "32"
+"targetname" "t74"
+"spawnflags" "1"
+"origin" "864 -1076 16"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*50"
+"dmg" "10"
+"_minlight" ".2"
+"lip" "132"
+"classname" "func_plat"
+}
+{
+"origin" "8 1248 -28"
+"light" "64"
+"classname" "light"
+"_color" "0.643137 0.882353 1.000000"
+}
+{
+"origin" "12 1312 -168"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "12 1504 -168"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "632 1376 -28"
+"_color" "0.643137 0.882353 1.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "632 1312 -28"
+"_color" "0.643137 0.882353 1.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "632 1176 -28"
+"_color" "0.643137 0.882353 1.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "544 1176 -28"
+"_color" "0.643137 0.882353 1.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "416 1184 -36"
+"_color" "1.000000 0.000000 0.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "352 1184 -36"
+"_color" "1.000000 0.000000 0.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "288 1184 -36"
+"_color" "1.000000 0.000000 0.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "160 1176 -28"
+"_color" "0.643137 0.882353 1.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "96 1176 -28"
+"_color" "0.643137 0.882353 1.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "8 1176 -28"
+"_color" "0.643137 0.882353 1.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "8 1592 -28"
+"_color" "0.643137 0.882353 1.000000"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "632 1504 -28"
+"_color" "0.643137 0.882353 1.000000"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-128 1792 16"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-128 1792 128"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-128 1792 -88"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*51"
+"origin" "-128 1792 -32"
+"classname" "func_rotating"
+"spawnflags" "1"
+"speed" "450"
+"_minlight" ".2"
+}
+{
+"model" "*52"
+"origin" "-128 1792 184"
+"_minlight" ".2"
+"speed" "450"
+"spawnflags" "2051"
+"classname" "func_rotating"
+}
+{
+"origin" "-80 1408 -96"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "480 1008 48"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "200 1880 -88"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "16 1832 -88"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-176 1928 -88"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "-176 2112 -88"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "-168 2304 -88"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "416 1864 -88"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "224 1816 88"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "416 1808 88"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "576 1816 88"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "584 1664 88"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "576 1464 88"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "432 1288 176"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "432 1472 176"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "432 1472 -32"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "432 1288 -32"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "128 1296 -32"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "128 1472 -32"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "576 1280 88"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "128 1296 176"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "128 1472 176"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "528 2136 128"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "352 2160 128"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "304 2376 128"
+"light" "250"
+"classname" "light"
+}
+{
+"light" "250"
+"classname" "light"
+"origin" "504 2280 128"
+}
+{
+"light" "250"
+"classname" "light"
+"origin" "616 2360 128"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "456 2248 -160"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "248 2232 -160"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "248 2464 -160"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "440 2456 -160"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "576 2464 -160"
+}
+{
+"origin" "568 584 40"
+"classname" "light"
+}
+{
+"origin" "280 384 40"
+"classname" "light"
+}
+{
+"origin" "-8 408 40"
+"classname" "light"
+}
+{
+"origin" "-96 232 48"
+"classname" "light"
+}
+{
+"origin" "-104 240 304"
+"classname" "light"
+}
+{
+"origin" "-104 496 304"
+"classname" "light"
+}
+{
+"origin" "120 336 304"
+"classname" "light"
+}
+{
+"origin" "336 344 304"
+"classname" "light"
+}
+{
+"origin" "624 344 304"
+"classname" "light"
+}
+{
+"origin" "616 592 304"
+"classname" "light"
+}
+{
+"origin" "-48 632 440"
+"classname" "light"
+}
+{
+"origin" "768 744 440"
+"classname" "light"
+}
+{
+"origin" "648 344 40"
+"classname" "light"
+}
+{
+"origin" "848 2292 -224"
+"angle" "180"
+"classname" "info_player_start"
+"targetname" "base1"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "-80 1408 148"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-80 1408 104"
+}
+{
+"origin" "608 -704 24"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "608 -704 104"
+}
+{
+"origin" "608 -704 200"
+"light" "100"
+"classname" "light"
+}
+{
+"model" "*53"
+"message" "This door is opened elsewhere."
+"classname" "func_door"
+"angle" "-1"
+"_minlight" ".2"
+"targetname" "t6"
+"wait" "-1"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-120 -800 116"
+}
+{
+"model" "*54"
+"target" "t4"
+"classname" "func_button"
+"angle" "0"
+}
+{
+"model" "*55"
+"spawnflags" "2048"
+"wait" "-1"
+"targetname" "t72"
+"classname" "func_door"
+"angle" "270"
+"speed" "50"
+"lip" "32"
+"_minlight" ".2"
+"team" "tits"
+}
+{
+"model" "*56"
+"spawnflags" "2048"
+"targetname" "t72"
+"wait" "-1"
+"angle" "90"
+"classname" "func_door"
+"speed" "50"
+"lip" "32"
+"_minlight" ".2"
+"team" "tits"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "825 -1728 40"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "632 -1744 56"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "576 -1872 56"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "592 -2272 56"
+}
+{
+"model" "*57"
+"classname" "func_door"
+"angle" "-2"
+"targetname" "t4"
+"_minlight" ".2"
+}
+{
+"origin" "576 -2096 56"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "648 -1848 -84"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "648 -1928 -84"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "584 -2104 -84"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "584 -2184 -84"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "632 -1800 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "632 -1720 104"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "632 -1720 248"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "632 -1800 248"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "632 -1720 168"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "632 -1800 168"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "776 -1824 120"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "776 -1696 120"
+}
+{
+"spawnflags" "1"
+"origin" "800 -1836 40"
+"map" "eou1_.cin+*bunk1$start"
+"classname" "target_changelevel"
+"targetname" "t69"
+}
+{
+"classname" "misc_gib_head"
+"origin" "600 -1816 -80"
+}
+{
+"classname" "item_quad"
+"origin" "624 -2192 88"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "624 -1888 96"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "624 -1632 96"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t4"
+"delay" "1"
+"target" "t69"
+"origin" "800 -1816 64"
+}
+{
+"model" "*58"
+"spawnflags" "2048"
+"message" "This is the end of the unit."
+"classname" "trigger_once"
+}
+{
+"model" "*59"
+"wait" "-1"
+"target" "t72"
+"angle" "0"
+"classname" "func_button"
+}
+{
+"origin" "744 -2272 -72"
+"targetname" "t73"
+"angle" "180"
+"classname" "monster_soldier_light"
+}
+{
+"model" "*60"
+"spawnflags" "2048"
+"_minlight" ".1"
+"targetname" "t73"
+"classname" "func_door"
+"angle" "-2"
+"wait" "-1"
+"speed" "200"
+}
+{
+"targetname" "t73"
+"classname" "monster_soldier_light"
+"angle" "180"
+"origin" "696 -2272 -72"
+}
+{
+"model" "*61"
+"spawnflags" "2048"
+"_minlight" ".1"
+"targetname" "t73"
+"classname" "func_door"
+"angle" "-2"
+"wait" "-1"
+"speed" "200"
+}
+{
+"targetname" "t73"
+"classname" "monster_soldier_light"
+"angle" "180"
+"origin" "696 -2016 -72"
+}
+{
+"spawnflags" "1"
+"classname" "target_speaker"
+"noise" "world/amb12.wav"
+"origin" "776 -1760 -56"
+}
+{
+"origin" "616 -1864 48"
+"targetname" "t72"
+"classname" "target_goal"
+}

--- a/stuff/mapfixes/baseq2/biggun.ent
+++ b/stuff/mapfixes/baseq2/biggun.ent
@@ -1,0 +1,2760 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Removed unusable entity target_actor (2016)
+//
+// 2. Renamed field "duration" to "count" for target_earthquake (1377)
+//
+// This makes the earthquake last 15 seconds instead of just 5.
+// If you want the earthquake length to go back to the way it was,
+// simply remove this field line (1384) entirely.
+{
+"message" "Big Gun"
+"nextmap" "hangar1"
+"classname" "worldspawn"
+"sky" "unit7_"
+"sounds" "10"
+"spawnflags" "1792"
+}
+{
+"origin" "1752 648 -240"
+"classname" "ammo_bullets"
+"spawnflags" "1024"
+}
+{
+"origin" "1792 624 -240"
+"classname" "ammo_bullets"
+"spawnflags" "1024"
+}
+{
+"origin" "1792 664 -240"
+"spawnflags" "1536"
+"classname" "ammo_bullets"
+}
+{
+"model" "*1"
+"classname" "trigger_push"
+"angle" "270"
+"speed" "50"
+}
+{
+"classname" "monster_flyer"
+"angle" "270"
+"targetname" "t132"
+"spawnflags" "258"
+"origin" "1440 480 48"
+}
+{
+"angle" "270"
+"classname" "monster_flyer"
+"targetname" "t132"
+"spawnflags" "258"
+"origin" "1440 528 48"
+}
+{
+"classname" "monster_flyer"
+"angle" "270"
+"targetname" "t132"
+"spawnflags" "258"
+"origin" "1440 432 48"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1440 448 56"
+}
+{
+"model" "*2"
+"classname" "func_explosive"
+"dmg" "1"
+"targetname" "t132"
+}
+{
+"classname" "trigger_relay"
+"delay" "1.3"
+"target" "t134"
+"targetname" "t133"
+"origin" "1504 320 -184"
+}
+{
+"noise" "world/klaxon2.wav"
+"attenuation" "-1"
+"classname" "target_speaker"
+"targetname" "t134"
+"origin" "1504 344 -184"
+}
+{
+"classname" "target_speaker"
+"attenuation" "-1"
+"noise" "world/klaxon2.wav"
+"targetname" "t133"
+"origin" "1536 344 -184"
+}
+{
+"classname" "trigger_relay"
+"target" "t131"
+"targetname" "t133"
+"delay" "2.5"
+"origin" "1360 296 -184"
+}
+{
+"classname" "ammo_rockets"
+"origin" "2016 -24 -240"
+}
+{
+"classname" "item_armor_shard"
+"origin" "1424 360 -240"
+}
+{
+"classname" "item_armor_shard"
+"origin" "1384 360 -240"
+}
+{
+"classname" "item_armor_shard"
+"origin" "1408 320 -240"
+}
+{
+"classname" "item_health"
+"origin" "1248 232 -240"
+}
+{
+"classname" "item_health"
+"origin" "1248 192 -240"
+}
+{
+"classname" "ammo_bullets"
+"origin" "1416 -168 -240"
+}
+{
+"classname" "ammo_bullets"
+"origin" "1376 -168 -240"
+}
+{
+"classname" "ammo_bullets"
+"origin" "1376 -128 -240"
+}
+{
+"classname" "target_explosion"
+"delay" "1.8"
+"origin" "1352 128 -168"
+"dmg" "1"
+"targetname" "t131"
+}
+{
+"classname" "target_explosion"
+"delay" "1.6"
+"origin" "1344 48 -176"
+"dmg" "1"
+"targetname" "t131"
+}
+{
+"origin" "1360 88 -104"
+"delay" "2"
+"classname" "target_explosion"
+"dmg" "1"
+"targetname" "t131"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1352 96 -368"
+}
+{
+"classname" "target_explosion"
+"delay" "1"
+"targetname" "t131"
+"origin" "1312 136 -208"
+}
+{
+"classname" "target_explosion"
+"delay" ".9"
+"targetname" "t131"
+"origin" "1408 176 -192"
+}
+{
+"classname" "target_explosion"
+"delay" ".8"
+"targetname" "t131"
+"origin" "1336 96 -240"
+}
+{
+"classname" "target_explosion"
+"targetname" "t131"
+"origin" "1376 16 -232"
+}
+{
+"classname" "target_explosion"
+"delay" ".6"
+"targetname" "t131"
+"origin" "1304 56 -240"
+}
+{
+"classname" "target_explosion"
+"delay" ".4"
+"targetname" "t131"
+"origin" "1408 80 -240"
+}
+{
+"classname" "target_explosion"
+"delay" ".2"
+"targetname" "t131"
+"origin" "1352 208 -232"
+}
+{
+"classname" "target_explosion"
+"delay" "1.4"
+"targetname" "t131"
+"origin" "1360 136 -152"
+}
+{
+"classname" "trigger_relay"
+"target" "t132"
+"targetname" "t131"
+"delay" "1.4"
+"origin" "1352 -24 -208"
+}
+{
+"model" "*3"
+"classname" "func_explosive"
+"dmg" "1"
+"targetname" "t132"
+}
+{
+"classname" "trigger_relay"
+"delay" "1.9"
+"target" "t130"
+"targetname" "t131"
+"origin" "1440 224 -208"
+}
+{
+"model" "*4"
+"classname" "trigger_once"
+"target" "t133"
+}
+{
+"model" "*5"
+"classname" "func_door"
+"angle" "-2"
+"wait" "-1"
+"speed" "300"
+"spawnflags" "1"
+"targetname" "t130"
+}
+{
+"origin" "1816 -1744 -128"
+"_color" "1.000000 0.500000 0.500000"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "1904 -1344 -312"
+"_color" "1.000000 0.500000 0.500000"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "1904 -1152 -312"
+"_color" "1.000000 0.500000 0.500000"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "1576 -1744 -128"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.500000 0.500000"
+}
+{
+"origin" "1488 -1152 -312"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.500000 0.500000"
+}
+{
+"origin" "1488 -1344 -312"
+"_color" "1.000000 0.500000 0.500000"
+"light" "200"
+"classname" "light"
+}
+{
+"model" "*6"
+"count" "2"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*7"
+"count" "1"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*8"
+"count" "2"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*9"
+"count" "1"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*10"
+"count" "1"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*11"
+"count" "2"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*12"
+"classname" "func_killbox"
+"targetname" "t117"
+}
+{
+"angle" "270"
+"classname" "info_player_deathmatch"
+"origin" "1696 1000 -232"
+}
+{
+"angle" "180"
+"classname" "info_player_deathmatch"
+"origin" "2144 288 -40"
+}
+{
+"angle" "180"
+"classname" "info_player_deathmatch"
+"origin" "1088 -896 -360"
+}
+{
+"angle" "180"
+"classname" "info_player_deathmatch"
+"origin" "2304 -896 -360"
+}
+{
+"angle" "90"
+"classname" "info_player_deathmatch"
+"origin" "2112 -1600 -232"
+}
+{
+"angle" "90"
+"classname" "info_player_deathmatch"
+"origin" "1280 -1600 -232"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "270"
+"origin" "2592 800 -376"
+}
+{
+"origin" "1600 -1576 -160"
+"delay" "10"
+"target" "t129"
+"targetname" "t41"
+"classname" "trigger_relay"
+}
+{
+"origin" "1592 -1648 -144"
+"targetname" "t129"
+"attenuation" "-1"
+"noise" "world/v_gun2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1712 616 -248"
+"noise" "world/v_gun1.wav"
+"attenuation" "-1"
+"targetname" "t128"
+"classname" "target_speaker"
+}
+{
+"model" "*13"
+"target" "t128"
+"classname" "trigger_once"
+}
+{
+"origin" "1504 -1248 -328"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "1456 -608 -232"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "1712 864 -168"
+"noise" "world/amb23.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"model" "*14"
+"wait" "-1"
+"team" "fps"
+"spawnflags" "8"
+"message" "This door is opened elsewhere."
+"classname" "func_door"
+"angle" "270"
+"target" "t96"
+"targetname" "t106"
+}
+{
+"model" "*15"
+"classname" "func_door"
+"spawnflags" "8"
+"target" "t96"
+"targetname" "t106"
+"team" "fps"
+"wait" "-1"
+"angle" "90"
+}
+{
+"model" "*16"
+"classname" "func_door"
+"angle" "180"
+"_minlight" "0.2"
+"targetname" "t94"
+"target" "t78"
+"spawnflags" "2048"
+"team" "fps4343"
+}
+{
+"model" "*17"
+"classname" "func_door"
+"angle" "0"
+"_minlight" "0.2"
+"targetname" "t94"
+"target" "t78"
+"spawnflags" "2048"
+"team" "fps4343"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"origin" "1728 960 -168"
+}
+{
+"origin" "1544 96 -168"
+"spawnflags" "1"
+"noise" "world/amb21.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1696 -56 -168"
+"spawnflags" "1"
+"noise" "world/amb21.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1696 248 -168"
+"spawnflags" "1"
+"noise" "world/amb21.wav"
+"classname" "target_speaker"
+}
+{
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1888 -1248 -328"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"origin" "1936 -608 -232"
+}
+{
+"model" "*18"
+"classname" "func_wall"
+"_minlight" "0.2"
+"spawnflags" "2050"
+"targetname" "t98"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1792"
+"origin" "2760 840 -384"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1792"
+"origin" "2688 840 -384"
+}
+{
+"classname" "weapon_bfg"
+"spawnflags" "1792"
+"origin" "2528 800 -384"
+}
+{
+"classname" "ammo_slugs"
+"spawnflags" "0"
+"origin" "1936 480 -48"
+}
+{
+"classname" "weapon_railgun"
+"spawnflags" "1792"
+"origin" "2128 -144 -48"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_rockets"
+"origin" "1552 -968 -368"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "1792"
+"origin" "1840 -968 -368"
+}
+{
+"classname" "weapon_rocketlauncher"
+"spawnflags" "1792"
+"origin" "1696 -856 -368"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_shells"
+"origin" "1440 -1424 -368"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1792"
+"origin" "1952 -1424 -368"
+}
+{
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+"origin" "1440 -1088 -368"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "1904 -1680 -176"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "1488 -1680 -176"
+}
+{
+"classname" "weapon_grenadelauncher"
+"spawnflags" "1792"
+"origin" "1696 -1728 -176"
+}
+{
+"classname" "trigger_always"
+"target" "t97"
+"spawnflags" "1792"
+"origin" "1784 -160 -232"
+}
+{
+"classname" "trigger_always"
+"target" "t93"
+"spawnflags" "1792"
+"origin" "1640 -128 -232"
+}
+{
+"classname" "trigger_always"
+"target" "t78"
+"origin" "1744 344 -224"
+}
+{
+"origin" "2784 704 -336"
+"classname" "light"
+"light" "110"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "2880 704 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "110"
+"classname" "light"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t124"
+"target" "t126"
+"origin" "1040 760 184"
+"delay" "0.1"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t124"
+"target" "t127"
+"origin" "984 784 184"
+"delay" "0.3"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t124"
+"target" "t125"
+"origin" "1024 712 168"
+"delay" "0.2"
+}
+{
+"classname" "func_timer"
+"target" "t124"
+"origin" "984 720 168"
+"spawnflags" "1"
+"wait" "1.5"
+"random" "0.5"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t120"
+"target" "t122"
+"origin" "1016 744 120"
+"delay" "0.4"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t120"
+"target" "t123"
+"origin" "1056 712 120"
+"delay" "0.3"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t120"
+"target" "t121"
+"delay" "0.1"
+"origin" "960 760 120"
+}
+{
+"classname" "func_timer"
+"target" "t120"
+"origin" "984 720 120"
+"spawnflags" "1"
+"wait" "1.5"
+"random" "0.5"
+}
+{
+"classname" "target_explosion"
+"targetname" "t122"
+"origin" "1056 792 120"
+}
+{
+"classname" "target_explosion"
+"targetname" "t123"
+"origin" "1096 712 120"
+}
+{
+"classname" "target_explosion"
+"targetname" "t125"
+"origin" "1088 704 184"
+}
+{
+"classname" "target_explosion"
+"targetname" "t126"
+"origin" "1088 832 184"
+}
+{
+"classname" "target_explosion"
+"targetname" "t127"
+"origin" "960 832 120"
+}
+{
+"classname" "target_explosion"
+"targetname" "t121"
+"origin" "936 792 120"
+}
+{
+"classname" "info_player_intermission"
+"angles" "0 45 0"
+"origin" "944 688 136"
+}
+{
+"origin" "1656 -1592 -168"
+"angle" "180"
+"classname" "monster_soldier_ss"
+}
+{
+"model" "*19"
+"target" "t119"
+"classname" "trigger_once"
+}
+{
+"model" "*20"
+"target" "t118"
+"classname" "trigger_once"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "100"
+"classname" "light"
+"origin" "1856 688 -168"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "100"
+"classname" "light"
+"origin" "1872 776 -168"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "100"
+"classname" "light"
+"origin" "1632 1024 -176"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "100"
+"classname" "light"
+"origin" "1632 896 -176"
+}
+{
+"origin" "1408 136 56"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1792 56 56"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1792 136 56"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "1792 256 56"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1792 -64 56"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1920 56 56"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1920 136 56"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "1920 256 56"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1920 -64 56"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1408 56 56"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1472 256 56"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1472 -64 56"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1600 56 56"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "1600 -64 56"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "1600 256 56"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "1600 136 56"
+"light" "130"
+"classname" "light"
+}
+{
+"targetname" "t117"
+"origin" "2496 576 -232"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"origin" "2496 832 -232"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"origin" "2496 256 -232"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"origin" "2240 96 -192"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"origin" "2144 176 24"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"dmg" "10000"
+"classname" "target_explosion"
+"origin" "1664 768 -144"
+}
+{
+"targetname" "t117"
+"origin" "1664 1096 -144"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"origin" "1696 96 24"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"dmg" "10000"
+"classname" "target_explosion"
+"origin" "2784 704 -352"
+}
+{
+"targetname" "t117"
+"dmg" "10000"
+"classname" "target_explosion"
+"origin" "1960 952 8"
+}
+{
+"targetname" "t117"
+"dmg" "10000"
+"classname" "target_explosion"
+"origin" "1408 -320 -144"
+}
+{
+"targetname" "t117"
+"origin" "2016 360 -200"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"origin" "1088 -896 -304"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"dmg" "10000"
+"classname" "target_explosion"
+"origin" "1984 -320 -144"
+}
+{
+"targetname" "t117"
+"origin" "1696 -888 -248"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"origin" "1440 -1248 -168"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"targetname" "t117"
+"dmg" "10000"
+"classname" "target_explosion"
+"origin" "2304 -896 -304"
+}
+{
+"targetname" "t117"
+"origin" "1536 -1664 -80"
+"dmg" "10000"
+"classname" "target_explosion"
+}
+{
+"origin" "1952 -1248 -168"
+"targetname" "t117"
+"classname" "target_explosion"
+"dmg" "10000"
+}
+{
+"origin" "1856 -1664 -80"
+"targetname" "t117"
+"dmg" "10000"
+"classname" "target_explosion"
+}
+{
+"origin" "1696 -856 -160"
+"target" "t117"
+"delay" "10"
+"targetname" "t107"
+"classname" "trigger_relay"
+}
+{
+"model" "*21"
+"count" "1"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*22"
+"count" "2"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*23"
+"count" "1"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*24"
+"count" "2"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*25"
+"count" "1"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*26"
+"count" "2"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*27"
+"team" "countdown"
+"classname" "target_character"
+"count" "1"
+}
+{
+"model" "*28"
+"team" "countdown"
+"classname" "target_character"
+"count" "2"
+}
+{
+"classname" "item_health"
+"origin" "1632 -328 -240"
+}
+{
+"classname" "item_health"
+"origin" "1760 -328 -240"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "0"
+"spawnflags" "1"
+"origin" "1416 -328 -232"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "180"
+"spawnflags" "1"
+"origin" "1976 -328 -232"
+}
+{
+"model" "*29"
+"message" "This door is opened elsewhere."
+"target" "t95"
+"classname" "func_door"
+"angle" "-1"
+"targetname" "t92"
+"_minlight" "0.2"
+}
+{
+"classname" "ammo_shells"
+"origin" "2144 -224 -48"
+}
+{
+"classname" "ammo_shells"
+"origin" "2080 -224 -48"
+}
+{
+"classname" "item_health_large"
+"origin" "1856 424 -48"
+}
+{
+"_color" "1.000000 0.694118 0.392157"
+"light" "120"
+"classname" "light"
+"origin" "2000 336 -160"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "1728 576 88"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "1632 832 88"
+}
+{
+"classname" "item_health_small"
+"origin" "1600 616 -240"
+}
+{
+"classname" "item_health_small"
+"origin" "1600 576 -240"
+}
+{
+"classname" "item_health_small"
+"origin" "1600 536 -240"
+}
+{
+"classname" "item_health_small"
+"origin" "1600 656 -240"
+}
+{
+"classname" "ammo_rockets"
+"origin" "1856 680 -240"
+}
+{
+"classname" "item_armor_combat"
+"origin" "1912 760 -176"
+}
+{
+"classname" "item_health"
+"origin" "1592 864 -240"
+}
+{
+"classname" "item_health"
+"origin" "1888 1128 -240"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb21.wav"
+"spawnflags" "1"
+"origin" "1848 96 -168"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb20.wav"
+"origin" "1696 -776 -336"
+}
+{
+"targetname" "t119"
+"angle" "180"
+"classname" "monster_soldier_ss"
+"origin" "1928 -1152 -360"
+}
+{
+"targetname" "t119"
+"angle" "180"
+"classname" "monster_soldier_ss"
+"origin" "1928 -1344 -360"
+}
+{
+"targetname" "t118"
+"angle" "0"
+"classname" "monster_soldier_ss"
+"origin" "1464 -1344 -360"
+}
+{
+"targetname" "t118"
+"angle" "0"
+"classname" "monster_soldier_ss"
+"origin" "1464 -1152 -360"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "0"
+"origin" "1736 -1592 -168"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb18.wav"
+"origin" "1696 -1496 -120"
+}
+{
+"classname" "target_goal"
+"targetname" "t41"
+"origin" "1768 -1624 -40"
+}
+{
+"classname" "target_goal"
+"targetname" "t93"
+"origin" "1432 -72 -40"
+}
+{
+"classname" "target_explosion"
+"targetname" "t116"
+"origin" "1920 -672 -208"
+}
+{
+"classname" "target_explosion"
+"targetname" "t115"
+"origin" "1920 -544 -208"
+}
+{
+"random" "0.5"
+"wait" "2"
+"delay" "0.6"
+"classname" "func_timer"
+"targetname" "t114"
+"target" "t116"
+"origin" "1960 -656 -224"
+}
+{
+"random" "0.5"
+"wait" "2"
+"delay" "0.6"
+"classname" "func_timer"
+"targetname" "t114"
+"target" "t115"
+"origin" "1960 -568 -224"
+}
+{
+"classname" "func_timer"
+"target" "t113"
+"targetname" "t114"
+"delay" "0.6"
+"wait" "2"
+"random" "0.5"
+"origin" "1432 -560 -224"
+}
+{
+"classname" "func_timer"
+"target" "t112"
+"targetname" "t114"
+"delay" "0.6"
+"wait" "2"
+"random" "0.5"
+"origin" "1432 -648 -224"
+}
+{
+"model" "*30"
+"spawnflags" "4"
+"classname" "trigger_once"
+"target" "t114"
+"targetname" "t109"
+}
+{
+"classname" "target_explosion"
+"targetname" "t113"
+"origin" "1472 -544 -208"
+}
+{
+"classname" "target_explosion"
+"targetname" "t112"
+"origin" "1472 -672 -208"
+}
+{
+"classname" "target_help"
+"targetname" "t93"
+"message" "Lock down laser guard."
+"origin" "1464 336 -200"
+}
+{
+"classname" "target_help"
+"targetname" "t111"
+"message" "Eliminate all resistance."
+"origin" "1648 1072 -200"
+}
+{
+"classname" "target_help"
+"targetname" "t111"
+"spawnflags" "1"
+"message" "Destroy Big Gun."
+"origin" "1744 1072 -200"
+}
+{
+"model" "*31"
+"classname" "trigger_once"
+"target" "t111"
+}
+{
+"origin" "2144 96 -160"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.694118 0.392157"
+}
+{
+"origin" "2016 96 -160"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.694118 0.392157"
+}
+{
+"origin" "2048 384 -112"
+"classname" "light"
+"light" "110"
+"_color" "1.000000 0.694118 0.392157"
+}
+{
+"classname" "trigger_relay"
+"target" "t110"
+"targetname" "t108"
+"delay" "0.6"
+"origin" "1808 -944 16"
+}
+{
+"classname" "target_explosion"
+"targetname" "t110"
+"origin" "1896 -912 16"
+}
+{
+"model" "*32"
+"spawnflags" "4"
+"classname" "trigger_once"
+"targetname" "t41"
+"target" "t109"
+}
+{
+"model" "*33"
+"_minlight" "0.2"
+"spawnflags" "1"
+"classname" "func_object"
+"targetname" "t110"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1376 -640 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1376 -512 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1376 -384 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1760 -288 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1632 -288 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1504 -288 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1376 -288 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1888 -288 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "2016 -288 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "2016 -384 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "2016 -512 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "2016 -640 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "2016 -768 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1984 -896 0"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "1536 -896 0"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "1408 -896 0"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "1376 -768 0"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "1856 -896 0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1696 -896 0"
+}
+{
+"model" "*34"
+"classname" "trigger_once"
+"target" "t109"
+"spawnflags" "4"
+"targetname" "t41"
+}
+{
+"classname" "trigger_relay"
+"target" "t108"
+"targetname" "t109"
+"origin" "1528 -872 -64"
+}
+{
+"classname" "target_explosion"
+"targetname" "t108"
+"origin" "1536 -904 16"
+}
+{
+"model" "*35"
+"classname" "func_object"
+"spawnflags" "1"
+"targetname" "t108"
+"_minlight" "0.2"
+}
+{
+"model" "*36"
+"classname" "trigger_once"
+"message" "Evacuate immediately."
+"targetname" "t41"
+"delay" "2"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t41"
+"target" "t107"
+"delay" "12"
+"origin" "1720 -1576 -160"
+}
+{
+"classname" "target_earthquake"
+"speed" "100"
+"count" "15"
+"targetname" "t107"
+"origin" "1776 -1584 -160"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t97"
+"target" "t106"
+"origin" "1744 -80 -184"
+}
+{
+"classname" "target_explosion"
+"targetname" "t104"
+"origin" "1592 160 -256"
+}
+{
+"classname" "target_explosion"
+"targetname" "t105"
+"origin" "1616 16 -256"
+}
+{
+"classname" "target_explosion"
+"targetname" "t102"
+"origin" "1776 176 -256"
+}
+{
+"classname" "target_explosion"
+"targetname" "t100"
+"origin" "1696 -24 -256"
+}
+{
+"classname" "target_explosion"
+"targetname" "t103"
+"origin" "1696 216 -256"
+}
+{
+"classname" "target_explosion"
+"targetname" "t101"
+"origin" "1768 16 -256"
+}
+{
+"classname" "func_timer"
+"targetname" "t99"
+"random" "2"
+"wait" "5"
+"delay" "0.5"
+"origin" "1672 80 -104"
+"target" "t105"
+"spawnflags" "2048"
+}
+{
+"classname" "func_timer"
+"targetname" "t99"
+"random" "2"
+"wait" "5"
+"delay" "1"
+"origin" "1720 80 -104"
+"target" "t101"
+"spawnflags" "2048"
+}
+{
+"classname" "func_timer"
+"targetname" "t99"
+"random" "2"
+"wait" "5"
+"delay" "0.5"
+"origin" "1720 112 -104"
+"target" "t102"
+"spawnflags" "2048"
+}
+{
+"classname" "func_timer"
+"targetname" "t99"
+"random" "2"
+"wait" "5"
+"delay" "1"
+"origin" "1672 112 -104"
+"target" "t104"
+"spawnflags" "2048"
+}
+{
+"classname" "func_timer"
+"targetname" "t99"
+"random" "2"
+"wait" "5"
+"origin" "1696 136 -104"
+"target" "t103"
+"spawnflags" "2048"
+}
+{
+"classname" "func_timer"
+"targetname" "t99"
+"random" "2"
+"wait" "5"
+"origin" "1696 56 -104"
+"target" "t100"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"target" "t99"
+"origin" "1696 96 -48"
+"targetname" "t106"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t97"
+"killtarget" "mifs"
+"origin" "1640 -80 -184"
+}
+{
+"classname" "target_speaker"
+"noise" "world/10_0.wav"
+"spawnflags" "4"
+"origin" "1648 -1568 -160"
+"attenuation" "-1"
+"targetname" "t107"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t97"
+"origin" "1672 -80 -184"
+"target" "t98"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t97"
+"killtarget" "t76"
+"origin" "1696 -80 -184"
+}
+{
+"style" "1"
+"targetname" "t96"
+"classname" "func_areaportal"
+}
+{
+"classname" "func_group"
+}
+{
+"style" "2"
+"targetname" "t95"
+"classname" "func_areaportal"
+}
+{
+"model" "*37"
+"target" "t94"
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+}
+{
+"model" "*38"
+"targetname" "t93"
+"target" "t92"
+"spawnflags" "4"
+"classname" "trigger_multiple"
+}
+{
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.694118 0.392157"
+"origin" "2048 384 32"
+}
+{
+"_color" "1.000000 0.694118 0.392157"
+"light" "120"
+"classname" "light"
+"origin" "2080 -32 32"
+}
+{
+"_color" "1.000000 0.694118 0.392157"
+"light" "120"
+"classname" "light"
+"origin" "2080 96 32"
+}
+{
+"_color" "1.000000 0.694118 0.392157"
+"light" "120"
+"classname" "light"
+"origin" "2080 224 32"
+}
+{
+"_color" "1.000000 0.694118 0.392157"
+"light" "120"
+"classname" "light"
+"origin" "2272 96 -160"
+}
+{
+"_color" "1.000000 0.694118 0.392157"
+"light" "120"
+"classname" "light"
+"origin" "1888 416 32"
+}
+{
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.694118 0.392157"
+"origin" "2016 -160 32"
+}
+{
+"model" "*39"
+"classname" "func_plat"
+"_minlight" "0.2"
+}
+{
+"deathtarget" "t93"
+"classname" "monster_boss2"
+"angle" "0"
+"origin" "1352 96 -360"
+"spawnflags" "0"
+"targetname" "t131"
+}
+{
+"classname" "func_timer"
+"target" "t90"
+"wait" "20"
+"spawnflags" "2049"
+"origin" "1560 264 -232"
+}
+{
+"classname" "trigger_relay"
+"target" "t89"
+"delay" "2"
+"origin" "1608 320 -232"
+"targetname" "t90"
+}
+{
+"classname" "trigger_relay"
+"target" "t89"
+"delay" "10"
+"origin" "1608 288 -232"
+"targetname" "t90"
+}
+{
+"classname" "path_corner"
+"targetname" "t88"
+"origin" "1696 96 -24"
+}
+{
+"classname" "target_laser"
+"target" "t88"
+"spawnflags" "66"
+"targetname" "t89"
+"origin" "1696 96 -240"
+}
+{
+"_color" "1.000000 0.501961 0.000000"
+"light" "80"
+"classname" "light"
+"origin" "1696 -472 -336"
+}
+{
+"_color" "1.000000 0.501961 0.000000"
+"light" "80"
+"classname" "light"
+"origin" "1696 -592 -336"
+}
+{
+"_color" "1.000000 0.501961 0.000000"
+"light" "80"
+"classname" "light"
+"origin" "1696 -688 -336"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t86"
+"target" "t87"
+"delay" "0.1"
+"origin" "1704 -400 -336"
+}
+{
+"classname" "func_timer"
+"target" "t86"
+"spawnflags" "1"
+"delay" "0.2"
+"origin" "1696 -384 -336"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t86"
+"target" "t87"
+"origin" "1688 -400 -336"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t84"
+"target" "t85"
+"delay" "0.1"
+"origin" "1704 -528 -336"
+}
+{
+"classname" "func_timer"
+"target" "t84"
+"delay" "0.4"
+"origin" "1696 -512 -336"
+"spawnflags" "1"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t84"
+"target" "t85"
+"origin" "1688 -528 -336"
+}
+{
+"classname" "trigger_relay"
+"target" "t82"
+"targetname" "t83"
+"origin" "1688 -648 -336"
+}
+{
+"classname" "trigger_relay"
+"target" "t82"
+"targetname" "t83"
+"delay" "0.1"
+"origin" "1704 -648 -336"
+}
+{
+"classname" "func_timer"
+"target" "t83"
+"spawnflags" "1"
+"delay" "0.6"
+"origin" "1696 -632 -336"
+}
+{
+"classname" "func_timer"
+"target" "t81"
+"spawnflags" "1"
+"wait" "1"
+"origin" "1696 -712 -336"
+"delay" "0.8"
+}
+{
+"classname" "trigger_relay"
+"target" "t80"
+"targetname" "t81"
+"origin" "1688 -728 -336"
+}
+{
+"classname" "trigger_relay"
+"target" "t80"
+"targetname" "t81"
+"delay" "0.1"
+"origin" "1704 -728 -336"
+}
+{
+"style" "32"
+"classname" "light"
+"_color" "1.000000 0.349020 0.035294"
+"targetname" "t82"
+"origin" "1696 -664 -336"
+"spawnflags" "1"
+}
+{
+"style" "33"
+"_color" "1.000000 0.349020 0.035294"
+"classname" "light"
+"targetname" "t85"
+"origin" "1696 -544 -336"
+"spawnflags" "1"
+}
+{
+"style" "34"
+"_color" "1.000000 0.349020 0.035294"
+"classname" "light"
+"targetname" "t80"
+"origin" "1696 -744 -336"
+"spawnflags" "1"
+}
+{
+"style" "35"
+"classname" "light"
+"_color" "1.000000 0.349020 0.035294"
+"targetname" "t87"
+"origin" "1696 -416 -336"
+"spawnflags" "1"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.351064 0.037234"
+"origin" "1568 -360 -104"
+}
+{
+"_color" "1.000000 0.351064 0.037234"
+"light" "130"
+"classname" "light"
+"origin" "1696 -360 -104"
+}
+{
+"_color" "1.000000 0.351064 0.037234"
+"light" "130"
+"classname" "light"
+"origin" "1824 -360 -104"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.351064 0.037234"
+"origin" "1696 -792 -104"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.351064 0.037234"
+"origin" "1824 -792 -104"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.351064 0.037234"
+"origin" "1944 -360 -104"
+}
+{
+"_color" "1.000000 0.351064 0.037234"
+"light" "130"
+"classname" "light"
+"origin" "1448 -792 -104"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.351064 0.037234"
+"origin" "1448 -704 -104"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.351064 0.037234"
+"origin" "1448 -576 -104"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.351064 0.037234"
+"origin" "1448 -448 -104"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.351064 0.037234"
+"origin" "1448 -360 -104"
+}
+{
+"_color" "1.000000 0.351064 0.037234"
+"light" "130"
+"classname" "light"
+"origin" "1944 -704 -104"
+}
+{
+"_color" "1.000000 0.351064 0.037234"
+"light" "130"
+"classname" "light"
+"origin" "1944 -576 -104"
+}
+{
+"_color" "1.000000 0.351064 0.037234"
+"light" "130"
+"classname" "light"
+"origin" "1944 -448 -104"
+}
+{
+"_color" "1.000000 0.351064 0.037234"
+"light" "130"
+"classname" "light"
+"origin" "1568 -792 -104"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.351064 0.037234"
+"origin" "1944 -792 -104"
+}
+{
+"classname" "path_corner"
+"targetname" "t79"
+"origin" "1696 -352 -336"
+}
+{
+"classname" "target_laser"
+"origin" "1696 -920 -336"
+"target" "t79"
+"spawnflags" "2115"
+"dmg" "1000"
+}
+{
+"classname" "func_timer"
+"target" "t77"
+"spawnflags" "2049"
+"wait" "10"
+"origin" "1560 304 -232"
+"delay" "5"
+"targetname" "mifs"
+}
+{
+"origin" "1696 384 -192"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"style" "3"
+"classname" "func_areaportal"
+"targetname" "t78"
+}
+{
+"origin" "1632 640 -192"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"model" "*40"
+"_minlight" "0.2"
+"lip" "48"
+"speed" "40"
+"targetname" "t76"
+"spawnflags" "32"
+"wait" "-1"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"origin" "1696 96 -224"
+"targetname" "t77"
+"target" "t76"
+"classname" "trigger_relay"
+}
+{
+"model" "*41"
+"team" "llama"
+"lip" "32"
+"targetname" "t76"
+"spawnflags" "2088"
+"wait" "-1"
+"classname" "func_door"
+"angle" "270"
+}
+{
+"model" "*42"
+"team" "llama"
+"lip" "32"
+"targetname" "t76"
+"spawnflags" "2088"
+"wait" "-1"
+"classname" "func_door"
+"angle" "0"
+}
+{
+"model" "*43"
+"team" "llama"
+"lip" "32"
+"targetname" "t76"
+"spawnflags" "2050"
+"wait" "-1"
+"classname" "func_door"
+"angle" "180"
+}
+{
+"model" "*44"
+"team" "llama"
+"lip" "32"
+"targetname" "t76"
+"spawnflags" "2050"
+"wait" "-1"
+"angle" "90"
+"classname" "func_door"
+}
+{
+"origin" "1760 768 -192"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"origin" "1632 768 -192"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "100"
+"classname" "light"
+"origin" "1760 640 -192"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "100"
+"classname" "light"
+"origin" "1760 896 -192"
+}
+{
+"origin" "1696 896 -176"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"origin" "1696 1024 -176"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "100"
+"classname" "light"
+"origin" "1760 1024 -192"
+}
+{
+"origin" "1632 1128 -192"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "100"
+"classname" "light"
+"origin" "1760 1128 -192"
+}
+{
+"origin" "1816 776 -168"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"origin" "1888 1128 -192"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"origin" "1760 1088 88"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 1.000000 1.000000"
+}
+//{
+//"origin" "1904 960 -248"
+//"targetname" "t73"
+//"spawnflags" "16"
+//"classname" "target_actor"
+//}
+{
+"origin" "1632 704 -96"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"origin" "1600 576 88"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "1888 704 88"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "1760 832 88"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "1760 640 -96"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "1632 960 88"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "1760 960 88"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "100"
+"classname" "light"
+"origin" "1696 512 -192"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "1632 1088 88"
+}
+{
+"origin" "1664 816 -232"
+"classname" "info_player_coop"
+"angle" "180"
+}
+{
+"origin" "1792 768 -232"
+"classname" "info_player_coop"
+"angle" "270"
+}
+{
+"origin" "1624 728 -232"
+"classname" "info_player_coop"
+"angle" "180"
+}
+{
+"origin" "1744 816 -232"
+"angle" "180"
+"classname" "info_player_coop"
+}
+{
+"classname" "light"
+"origin" "1888 896 -128"
+"light" "130"
+"_color" "0.984127 1.000000 0.662698"
+}
+{
+"classname" "light"
+"origin" "2040 896 -128"
+"light" "130"
+"_color" "0.984127 1.000000 0.662698"
+}
+{
+"classname" "light"
+"origin" "2040 1024 -128"
+"light" "130"
+"_color" "0.984127 1.000000 0.662698"
+}
+{
+"delay" "1.8"
+"target" "t66"
+"targetname" "t61"
+"origin" "1952 880 -144"
+"classname" "trigger_relay"
+}
+{
+"origin" "1912 976 -184"
+"targetname" "t65"
+"noise" "world/explod2.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t66"
+"origin" "1928 848 -184"
+"noise" "weapons/grenlx1a.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1968 912 -144"
+"delay" "0.6"
+"target" "t64"
+"targetname" "t61"
+"classname" "trigger_relay"
+}
+{
+"delay" "1.4"
+"origin" "2016 904 -144"
+"target" "t65"
+"targetname" "t61"
+"classname" "trigger_relay"
+}
+{
+"model" "*45"
+"targetname" "t65"
+"mass" "400"
+"classname" "func_explosive"
+}
+{
+"_color" "0.984127 1.000000 0.662698"
+"light" "130"
+"origin" "1888 1024 -128"
+"classname" "light"
+}
+{
+"origin" "1840 896 -256"
+"wait" "-1"
+"target" "t63"
+"targetname" "t62"
+"classname" "path_corner"
+}
+{
+"origin" "1840 896 384"
+"wait" "-1"
+"targetname" "t63"
+"target" "t62"
+"classname" "path_corner"
+}
+{
+"model" "*46"
+"target" "t61"
+"classname" "trigger_once"
+}
+{
+"wait" "-1"
+"origin" "1904 960 -272"
+"target" "t60"
+"targetname" "t59"
+"classname" "path_corner"
+}
+{
+"origin" "1904 960 384"
+"wait" "-1"
+"targetname" "t60"
+"target" "t59"
+"classname" "path_corner"
+}
+{
+"model" "*47"
+"_minlight" "0.2"
+"targetname" "t64"
+"speed" "600"
+"dmg" "1000"
+"spawnflags" "2"
+"target" "t63"
+"classname" "func_train"
+}
+{
+"model" "*48"
+"targetname" "t61"
+"mass" "800"
+"dmg" "1"
+"classname" "func_explosive"
+}
+{
+"model" "*49"
+"speed" "600"
+"targetname" "t61"
+"dmg" "1000"
+"spawnflags" "2"
+"_minlight" "0.2"
+"target" "t60"
+"classname" "func_train"
+}
+{
+"classname" "target_changelevel"
+"targetname" "t58"
+"map" "eou7_.cin+*hangar1$unitstart"
+"origin" "2888 696 -328"
+}
+{
+"model" "*50"
+"classname" "func_button"
+"angle" "0"
+"target" "t58"
+"wait" "-1"
+}
+{
+"model" "*51"
+"message" "Laser guard locked down."
+"targetname" "t41"
+"classname" "trigger_once"
+"target" "t97"
+}
+{
+"model" "*52"
+"wait" "-1"
+"angle" "90"
+"classname" "func_button"
+"target" "t41"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"targetname" "t3"
+"origin" "1696 -1072 -336"
+}
+{
+"classname" "target_laser"
+"target" "t3"
+"spawnflags" "67"
+"origin" "1696 -1200 -336"
+}
+{
+"model" "*53"
+"classname" "func_plat"
+}
+{
+"model" "*54"
+"classname" "func_plat"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "2112 -1600 32"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "2112 -1504 -128"
+}
+{
+"light" "150"
+"_color" "1.000000 1.000000 0.000000"
+"classname" "light"
+"origin" "2416 968 -288"
+}
+{
+"light" "150"
+"_color" "1.000000 1.000000 0.000000"
+"classname" "light"
+"origin" "2528 968 -288"
+}
+{
+"classname" "light"
+"_color" "1.000000 1.000000 0.000000"
+"light" "150"
+"origin" "2640 968 -288"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"classname" "light"
+"origin" "2344 704 -336"
+}
+{
+"light" "120"
+"origin" "2560 896 -232"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "2688 896 -232"
+"light" "120"
+}
+{
+"classname" "light"
+"origin" "2816 896 -232"
+"light" "120"
+}
+{
+"light" "120"
+"origin" "2560 512 -232"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "2688 512 -232"
+"light" "120"
+}
+{
+"classname" "light"
+"origin" "2816 512 -232"
+"light" "120"
+}
+{
+"light" "120"
+"origin" "2400 704 -232"
+"classname" "light"
+}
+{
+"light" "120"
+"origin" "2400 608 -232"
+"classname" "light"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "2496 224 -40"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "2496 96 -40"
+}
+{
+"_color" "1.000000 1.000000 1.000000"
+"light" "120"
+"classname" "light"
+"origin" "2368 96 -40"
+}
+{
+"classname" "light"
+"origin" "2400 800 -232"
+"light" "120"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "1280 -1600 32"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "1280 -1504 -128"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*55"
+"origin" "1696 -1664 -130"
+"classname" "func_rotating"
+"spawnflags" "1"
+"speed" "30"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1552 -968 -256"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1408 -960 -160"
+}
+{
+"origin" "2496 448 -296"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "1728 -1536 -88"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"origin" "1664 -1536 -88"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"origin" "1536 -1600 32"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1728 -1600 32"
+}
+{
+"origin" "1728 -1728 32"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1664 -1600 32"
+}
+{
+"origin" "1664 -1728 32"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1856 -1728 32"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1536 -1728 32"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1664 -1344 32"
+}
+{
+"classname" "light"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "1576 -1780 -136"
+}
+{
+"classname" "light"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "1520 -1492 -328"
+}
+{
+"origin" "1760 704 88"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"origin" "2496 352 -40"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 1.000000 1.000000"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1984 -960 -160"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "2144 -976 -160"
+}
+{
+"origin" "1840 -1040 -32"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"origin" "2144 -1040 -32"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"origin" "1248 -1040 -32"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"origin" "1248 -976 -160"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1552 -1040 -32"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1088 -1024 -160"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1728 -1216 32"
+}
+{
+"origin" "1728 -1344 32"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1664 -1216 32"
+}
+{
+"origin" "1856 -1600 32"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1536 -1216 32"
+}
+{
+"origin" "1536 -1344 32"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1856 -1344 32"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1088 -1408 -160"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "120"
+"classname" "light"
+"origin" "2112 -896 -272"
+}
+{
+"origin" "2176 -896 -272"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "120"
+"classname" "light"
+"origin" "1280 -896 -272"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "2304 -896 -160"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1088 -896 -160"
+}
+{
+"origin" "1840 -968 -256"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"origin" "1088 -1152 -160"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"origin" "1088 -1280 -160"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"origin" "1856 -1216 32"
+"classname" "light"
+"light" "120"
+"_color" "0.923729 1.000000 0.385593"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "2304 -1024 -160"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "2304 -1152 -160"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "2304 -1280 -160"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "2304 -1408 -160"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1376 -1376 -112"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1376 -1120 -112"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1376 -1248 -112"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "2016 -1248 -112"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "2016 -1376 -112"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "2016 -1120 -112"
+}
+{
+"origin" "1872 -1494 -332"
+"classname" "light"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "1816 -1780 -136"
+"_color" "1.000000 0.000000 0.000000"
+"classname" "light"
+}
+{
+"classname" "func_group"
+"spawnflags" "1"
+}
+{
+"targetname" "bstart"
+"origin" "1696 1128 -232"
+"angle" "270"
+"classname" "info_player_start"
+}
+{
+"_color" "0.923729 1.000000 0.385593"
+"light" "120"
+"classname" "light"
+"origin" "1696 -800 16"
+}
+{
+"origin" "1216 -896 -272"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"model" "*56"
+"count" "1"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"model" "*57"
+"count" "2"
+"classname" "target_character"
+"team" "countdown"
+}
+{
+"classname" "target_string"
+"origin" "1672 -1120 -240"
+"team" "countdown"
+"targetname" "t14"
+}
+{
+"targetname" "t107"
+"style" "0"
+"origin" "1720 -1120 -240"
+"classname" "func_clock"
+"target" "t14"
+"spawnflags" "14"
+"count" "10"
+"pathtarget" "boom"
+}

--- a/stuff/mapfixes/baseq2/city1.ent
+++ b/stuff/mapfixes/baseq2/city1.ent
@@ -1,0 +1,6759 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Fixed 3x monster_hover (1162, 4068, 4274) never activating on Easy
+//
+// Was caused by spawnflags not being set to Medium+. Changed their
+// spawnflags from 2 to 258.
+{
+"spawnflags" "1"
+"classname" "worldspawn"
+"message" "Outer Courts"
+"sky" "unit9_"
+"sounds" "6"
+"nextmap" "city2"
+}
+{
+"classname" "misc_teleporter"
+"angle" "45"
+"target" "t304"
+"spawnflags" "1792"
+"origin" "-792 -1076 78"
+}
+{
+"classname" "misc_teleporter_dest"
+"angle" "270"
+"origin" "-784 -2464 1080"
+"targetname" "t304"
+"spawnflags" "1792"
+}
+{
+"origin" "24 -2632 456"
+"spawnflags" "2048"
+"classname" "item_adrenaline"
+}
+{
+"origin" "198 -2504 668"
+"classname" "light"
+"light" "64"
+"_color" "0.000000 1.000000 0.500000"
+}
+{
+"origin" "204 -2552 672"
+"spawnflags" "1792"
+"classname" "light"
+"light" "64"
+"_color" "0.000000 1.000000 0.500000"
+}
+{
+"origin" "254 -2488 668"
+"classname" "light"
+"light" "64"
+"_color" "0.000000 1.000000 0.500000"
+}
+{
+"targetname" "t91"
+"classname" "monster_hover"
+"spawnflags" "2"
+"origin" "-1651 -146 380"
+"item" "ammo_cells"
+}
+{
+"origin" "-1980 -1544 104"
+"targetname" "t1"
+"classname" "info_notnull"
+}
+{
+"targetname" "t74"
+"spawnflags" "1"
+"angle" "180"
+"origin" "-2632 -168 -280"
+"classname" "monster_soldier"
+"item" "ammo_shells"
+}
+{
+"origin" "-2948 -124 -232"
+"volume" "0.4"
+"spawnflags" "2048"
+"noise" "world/explod1.wav"
+"targetname" "t101"
+"classname" "target_speaker"
+}
+{
+"origin" "-3052 -116 -252"
+"targetname" "t101"
+"item" "ammo_bullets"
+"spawnflags" "1026"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-3052 -164 -252"
+"targetname" "t101"
+"spawnflags" "1282"
+"classname" "monster_soldier_ss"
+}
+{
+"spawnflags" "2048"
+"delay" "0.5"
+"target" "t246"
+"origin" "-664 -2116 1024"
+"targetname" "t302"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"delay" "0.5"
+"target" "t64"
+"origin" "-664 -2140 1024"
+"targetname" "t302"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"delay" "0.5"
+"target" "t303"
+"origin" "-664 -2092 1024"
+"targetname" "t302"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-684 -2164 1024"
+"target" "t302"
+"targetname" "t301"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-692 -2192 1024"
+"target" "t301"
+"targetname" "t240"
+"classname" "trigger_relay"
+}
+{
+"origin" "-168 -2628 488"
+"target" "t301"
+"targetname" "t121"
+"classname" "trigger_relay"
+}
+{
+"target" "t301"
+"origin" "-540 -1880 248"
+"targetname" "t46"
+"classname" "trigger_relay"
+}
+{
+"origin" "184 -2464 736"
+"spawnflags" "2048"
+"targetname" "t300"
+"classname" "target_secret"
+}
+{
+"model" "*1"
+"message" "You have found a secret area."
+"spawnflags" "2048"
+"target" "t300"
+"classname" "trigger_once"
+}
+{
+"style" "32"
+"origin" "-2414 184 -264"
+"targetname" "red2"
+"_color" "1.000000 0.156863 0.125490"
+"spawnflags" "2048"
+"light" "120"
+"classname" "light"
+}
+{
+"classname" "info_player_start"
+"origin" "176 -2384 336"
+"angle" "180"
+}
+{
+"model" "*2"
+"classname" "trigger_multiple"
+"delay" "0.5"
+"target" "t297"
+}
+{
+"origin" "-2056 96 -168"
+"targetname" "city1XL"
+"angle" "270"
+"classname" "info_player_coop"
+}
+{
+"origin" "-2040 -56 -168"
+"targetname" "city1XL"
+"classname" "info_player_coop"
+"angle" "270"
+}
+{
+"origin" "-2000 96 -168"
+"targetname" "city1XL"
+"angle" "270"
+"classname" "info_player_coop"
+}
+{
+"origin" "-2096 128 72"
+"targetname" "city1XH"
+"classname" "info_player_coop"
+"angle" "270"
+}
+{
+"origin" "-1976 128 72"
+"targetname" "city1XH"
+"classname" "info_player_coop"
+"angle" "270"
+}
+{
+"origin" "-2032 -8 72"
+"targetname" "city1XH"
+"angle" "270"
+"classname" "info_player_coop"
+}
+{
+"origin" "216 -2464 328"
+"angle" "135"
+"targetname" "unitstart"
+"classname" "info_player_coop"
+}
+{
+"origin" "64 -2296 328"
+"angle" "180"
+"targetname" "unitstart"
+"classname" "info_player_coop"
+}
+{
+"origin" "152 -2240 328"
+"angle" "225"
+"targetname" "unitstart"
+"classname" "info_player_coop"
+}
+{
+"model" "*3"
+"classname" "trigger_multiple"
+"wait" "10"
+"target" "t297"
+}
+{
+"model" "*4"
+"classname" "trigger_multiple"
+"target" "t299"
+"targetname" "sewmsg"
+"spawnflags" "2048"
+"wait" "320"
+}
+{
+"classname" "trigger_relay"
+"killtarget" "sewmsg"
+"targetname" "t184"
+"origin" "-1280 624 464"
+"spawnflags" "2048"
+}
+{
+"classname" "target_speaker"
+"targetname" "t299"
+"attenuation" "-1"
+"noise" "world/v_bas2.wav"
+"origin" "-2056 -208 112"
+"spawnflags" "2048"
+}
+{
+"classname" "target_speaker"
+"targetname" "t298"
+"attenuation" "-1"
+"origin" "-72 -2328 376"
+"noise" "world/v_cit1.wav"
+"spawnflags" "2048"
+}
+{
+"model" "*5"
+"classname" "trigger_once"
+"target" "t298"
+"spawnflags" "2048"
+}
+{
+"classname" "target_speaker"
+"origin" "-288 -2352 512"
+"targetname" "t297"
+"noise" "world/flyby1.wav"
+"attenuation" "-1"
+"spawnflags" "2048"
+}
+{
+"model" "*6"
+"classname" "trigger_once"
+"target" "t297"
+"attenuation" "-1"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"origin" "-376 -2680 312"
+"target" "t292"
+"targetname" "t295"
+}
+{
+"classname" "point_combat"
+"origin" "-392 -2664 312"
+"target" "t291"
+"targetname" "t294"
+}
+{
+"classname" "point_combat"
+"origin" "-360 -2664 312"
+"target" "t293"
+"targetname" "t296"
+}
+{
+"classname" "point_combat"
+"origin" "-552 -2664 304"
+"targetname" "t293"
+}
+{
+"classname" "point_combat"
+"origin" "-584 -2664 304"
+"targetname" "t291"
+}
+{
+"classname" "point_combat"
+"origin" "-568 -2680 312"
+"targetname" "t292"
+}
+{
+"classname" "weapon_grenadelauncher"
+"spawnflags" "1792"
+"origin" "-784 -2576 1072"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-784 -2528 1072"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "-780 -2686 1080"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "100"
+"origin" "-1645 -155 241"
+}
+{
+"origin" "-2141 -126 -128"
+"noise" "world/amb24.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2896 32 -272"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "150"
+"origin" "-1800 -144 72"
+"classname" "light"
+}
+{
+"origin" "-1732 16 8"
+"classname" "ammo_shells"
+}
+{
+"origin" "-2779 292 -397"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-1648 -153 196"
+"targetname" "t290"
+"classname" "info_null"
+}
+{
+"style" "33"
+"targetname" "t290"
+"origin" "-1648 -152 456"
+"_color" "1.000000 0.976471 0.501961"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1384 608 456"
+"targetname" "t289"
+"volume" "0.7"
+"attenuation" "1"
+"noise" "world/brkglas.wav"
+"classname" "target_speaker"
+"spawnflags" "2048"
+}
+{
+"origin" "-32 -2502 656"
+"classname" "point_combat"
+"targetname" "t288"
+"target" "t296"
+}
+{
+"origin" "-32 -2492 656"
+"classname" "point_combat"
+"targetname" "t287"
+"target" "t295"
+}
+{
+"spawnflags" "2048"
+"origin" "174 -2486 640"
+"classname" "point_combat"
+"targetname" "t285"
+"target" "t288"
+}
+{
+"spawnflags" "2048"
+"origin" "172 -2490 640"
+"classname" "point_combat"
+"targetname" "t286"
+"target" "t287"
+}
+{
+"_color" "0.000000 1.000000 0.500000"
+"light" "64"
+"classname" "light"
+"origin" "174 -2488 680"
+}
+{
+"_color" "0.000000 1.000000 0.500000"
+"light" "64"
+"classname" "light"
+"origin" "206 -2448 668"
+}
+{
+"_color" "0.000000 1.000000 0.500000"
+"classname" "light"
+"light" "64"
+"origin" "234 -2600 664"
+}
+{
+"model" "*7"
+"target" "t289"
+"spawnflags" "2048"
+"_minlight" "0.8"
+"dmg" "1"
+"health" "25"
+"mass" "99"
+"classname" "func_explosive"
+}
+{
+"team" "hidey1"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+"origin" "578 -2656 480"
+}
+{
+"spawnflags" "0"
+"classname" "item_power_shield"
+"origin" "-420 -714 100"
+}
+{
+"_cone" "30"
+"target" "t290"
+"classname" "light"
+"light" "400"
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-1648 -154 484"
+}
+{
+"classname" "weapon_grenadelauncher"
+"spawnflags" "1792"
+"origin" "-1728 -176 512"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-1628 -188 524"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "0"
+"origin" "-1740 -132 516"
+}
+{
+"model" "*8"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "180"
+"origin" "-936 448 256"
+}
+{
+"model" "*9"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"model" "*10"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"origin" "-1808 336 614"
+"classname" "light"
+"light" "32"
+}
+{
+"classname" "misc_teleporter_dest"
+"angle" "270"
+"targetname" "valley"
+"origin" "592 -2440 456"
+"spawnflags" "1792"
+}
+{
+"classname" "misc_teleporter"
+"angle" "90"
+"spawnflags" "1792"
+"target" "valley"
+"origin" "-1780 -268 16"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1792"
+"origin" "-2708 -100 -280"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "512"
+"origin" "-2544 -100 -280"
+}
+{
+"classname" "misc_teleporter"
+"origin" "-3080 -136 -272"
+"angle" "0"
+"spawnflags" "1792"
+"target" "t284"
+}
+{
+"origin" "-1864 -1928 408"
+"spawnflags" "1792"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-2032 -1928 408"
+"spawnflags" "1792"
+"light" "120"
+"classname" "light"
+}
+{
+"classname" "misc_teleporter_dest"
+"angle" "0"
+"origin" "-2232 -1928 376"
+"spawnflags" "1792"
+"targetname" "t284"
+}
+{
+"origin" "-1748 -1548 4"
+"angles" "-45 132 0"
+"classname" "info_player_intermission"
+}
+{
+"classname" "weapon_machinegun"
+"origin" "-2168 -1016 -56"
+"spawnflags" "1792"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-1896 -1056 -56"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_slugs"
+"origin" "-880 -2160 912"
+}
+{
+"spawnflags" "2048"
+"classname" "item_adrenaline"
+"origin" "-1152 788 420"
+}
+{
+"spawnflags" "2048"
+"classname" "item_invulnerability"
+"origin" "-952 -1718 588"
+}
+{
+"model" "*11"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "info_player_deathmatch"
+"origin" "-892 -1580 590"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "225"
+"origin" "-28 -1904 112"
+"_minlight" "0.8"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_cells"
+"origin" "-672 -1048 112"
+}
+{
+"classname" "weapon_hyperblaster"
+"spawnflags" "1792"
+"origin" "-612 -1052 112"
+}
+{
+"classname" "weapon_hyperblaster"
+"spawnflags" "1792"
+"origin" "-2112 -236 -88"
+}
+{
+"classname" "misc_teleporter"
+"angle" "90"
+"_minlight" "0.1"
+"target" "t282"
+"origin" "-1812 192 548"
+}
+{
+"origin" "-1808 432 584"
+"light" "64"
+"classname" "light"
+}
+{
+"classname" "misc_teleporter_dest"
+"angle" "180"
+"_minlight" "0.1"
+"origin" "-1696 448 544"
+"targetname" "t283"
+}
+{
+"light" "56"
+"classname" "light"
+"origin" "-1808 504 584"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-1816 192 614"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "-1696 448 612"
+}
+{
+"classname" "weapon_grenadelauncher"
+"spawnflags" "1792"
+"origin" "-1808 328 544"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-1832 376 544"
+}
+{
+"spawnflags" "1792"
+"classname" "misc_teleporter_dest"
+"angle" "90"
+"origin" "-2536 48 472"
+"targetname" "t282"
+}
+{
+"model" "*12"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"model" "*13"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"angle" "90"
+"classname" "misc_teleporter"
+"spawnflags" "1792"
+"_minlight" "0.1"
+"origin" "-1836 -1342 -48"
+"target" "t283"
+}
+{
+"classname" "misc_teleporter"
+"angle" "90"
+"target" "t281"
+"spawnflags" "1792"
+"_minlight" "0.1"
+"origin" "-2236 -1334 -48"
+}
+{
+"classname" "misc_teleporter_dest"
+"angle" "270"
+"origin" "-912 -2008 1000"
+"targetname" "t281"
+"spawnflags" "1792"
+}
+{
+"origin" "184 -2496 328"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-2040 -1960 48"
+"classname" "ammo_grenades"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-984 -1816 544"
+}
+{
+"spawnflags" "2048"
+"origin" "8 -1992 104"
+"classname" "item_armor_combat"
+}
+{
+"classname" "ammo_grenades"
+"origin" "532 -2456 448"
+"spawnflags" "2048"
+}
+{
+"origin" "608 -2456 448"
+"classname" "ammo_shells"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "0"
+"origin" "656 -2496 448"
+"classname" "ammo_slugs"
+}
+{
+"model" "*14"
+"classname" "trigger_once"
+"target" "t199"
+}
+{
+"model" "*15"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"classname" "item_armor_combat"
+"origin" "-2496 -680 -56"
+}
+{
+"classname" "item_quad"
+"origin" "-2176 -1120 336"
+"team" "q2best"
+"spawnflags" "1792"
+}
+{
+"model" "*16"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"model" "*17"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+"origin" "-960 128 412"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "315"
+"origin" "-1452 768 256"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_rockets"
+"origin" "-1352 568 72"
+}
+{
+"classname" "item_armor_combat"
+"spawnflags" "1792"
+"origin" "-1676 -160 212"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-1860 -108 28"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+"origin" "-2488 160 -400"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-2564 156 -388"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-2748 152 -388"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_large"
+"origin" "-2008 -120 -176"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1536"
+"origin" "-2116 -64 -164"
+}
+{
+"spawnflags" "2048"
+"origin" "-3096 -104 -280"
+"classname" "ammo_grenades"
+}
+{
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+"origin" "-2000 -144 104"
+}
+{
+"classname" "item_health_small"
+"origin" "-2060 -360 16"
+}
+{
+"classname" "item_health_small"
+"origin" "-2060 -304 24"
+}
+{
+"classname" "item_health_small"
+"origin" "-2056 -400 16"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1792"
+"origin" "-2312 -1556 92"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "225"
+"origin" "-1380 -1556 104"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1792"
+"origin" "188 -2592 656"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "1792"
+"origin" "-116 -2440 656"
+}
+{
+"classname" "weapon_railgun"
+"spawnflags" "1792"
+"origin" "-904 -2148 1012"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_large"
+"origin" "278 -2591 656"
+}
+{
+"_color" "0.000000 1.000000 0.500000"
+"light" "64"
+"classname" "light"
+"spawnflags" "1792"
+"origin" "260 -2544 672"
+}
+{
+"classname" "item_invulnerability"
+"team" "qbest"
+"origin" "256 -2640 664"
+"spawnflags" "1792"
+}
+{
+"classname" "weapon_rocketlauncher"
+"spawnflags" "1792"
+"origin" "-232 -2344 512"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"origin" "-842 -2694 712"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1792"
+"origin" "168 -2424 336"
+}
+{
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+"origin" "160 -2192 320"
+}
+{
+"spawnflags" "2048"
+"classname" "key_red_key"
+"origin" "-2520 192 -240"
+}
+{
+"model" "*18"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"origin" "-2220 -860 -56"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "270"
+"origin" "-1050 776 416"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_body"
+"origin" "-1429 610 465"
+}
+{
+"classname" "trigger_always"
+"spawnflags" "1792"
+"target" "t20"
+"origin" "-1245 752 456"
+}
+{
+"model" "*19"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"model" "*20"
+"_minlight" "0.1"
+"spawnflags" "2048"
+"wait" "-1"
+"health" "5"
+"delay" "10"
+"lip" "64"
+"angle" "180"
+"classname" "func_door"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1792"
+"origin" "-2800 212 8"
+}
+{
+"model" "*21"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "-1992 -248 -168"
+}
+{
+"classname" "light"
+"_color" "1.000000 0.796078 0.003922"
+"light" "64"
+"origin" "-1808 520 612"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "270"
+"origin" "-1808 532 548"
+"_minlight" "0.1"
+}
+{
+"target" "pumpdoor"
+"classname" "trigger_always"
+"origin" "-1776 -128 -276"
+"spawnflags" "1792"
+}
+{
+"model" "*22"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "light"
+"light" "120"
+"spawnflags" "1792"
+"origin" "-2224 -1928 408"
+}
+{
+"model" "*23"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*24"
+"spawnflags" "1792"
+"message" "This door is opened elsewhere."
+"wait" "-1"
+"_minlight" "0.2"
+"team" "medicdoor"
+"angle" "90"
+"classname" "func_door"
+}
+{
+"model" "*25"
+"spawnflags" "1792"
+"message" "This door is opened elsewhere."
+"wait" "-1"
+"_minlight" "0.2"
+"team" "medicdoor"
+"angle" "270"
+"classname" "func_door"
+}
+{
+"model" "*26"
+"classname" "trigger_once"
+"target" "m1"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_always"
+"target" "t209"
+"spawnflags" "1792"
+"origin" "104 -2344 360"
+}
+{
+"model" "*27"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-608 -2648 368"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-704 -2656 368"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-2032 112 -74"
+"_color" "1.000000 0.920949 0.343874"
+"light" "90"
+"classname" "light"
+}
+{
+"origin" "-2032 180 -188"
+"targetname" "t278"
+"classname" "info_notnull"
+}
+{
+"origin" "-2032 32 -188"
+"targetname" "t277"
+"classname" "info_notnull"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.920949 0.343874"
+"origin" "-2032 176 -74"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_railgun"
+"origin" "-2040 -1940 384"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "180"
+"origin" "-1864 -1928 376"
+}
+{
+"model" "*28"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "point_combat"
+"targetname" "t276"
+"origin" "-32 -2480 656"
+"target" "t294"
+}
+{
+"classname" "point_combat"
+"targetname" "t180"
+"target" "t276"
+"origin" "174 -2496 640"
+"spawnflags" "2048"
+}
+{
+"model" "*29"
+"classname" "trigger_monsterjump"
+"speed" "400"
+"height" "16"
+"angle" "180"
+"spawnflags" "2048"
+}
+{
+"model" "*30"
+"classname" "func_door"
+"angle" "270"
+"team" "medicdoor"
+"targetname" "medguy1"
+"_minlight" "0.1"
+"wait" "-1"
+"message" "This door is opened elsewhere."
+"spawnflags" "2048"
+}
+{
+"model" "*31"
+"classname" "func_door"
+"angle" "90"
+"team" "medicdoor"
+"targetname" "medguy1"
+"_minlight" "0.1"
+"wait" "-1"
+"message" "This door is opened elsewhere."
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"targetname" "t273"
+"target" "t274"
+"origin" "-2080 -864 -72"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"targetname" "t274"
+"origin" "-2080 -904 -72"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"targetname" "t55"
+"target" "t273"
+"origin" "-1912 -864 -72"
+"spawnflags" "2048"
+}
+{
+"classname" "func_timer"
+"random" "2"
+"wait" "4"
+"origin" "-2600 256 464"
+"target" "t272"
+"targetname" "hv1"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"origin" "-2600 232 464"
+"target" "t271"
+"targetname" "t272"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"killtarget" "hv1"
+"origin" "-2600 208 464"
+"targetname" "t271"
+"delay" ".75"
+"spawnflags" "2048"
+}
+{
+"origin" "-2548 208 496"
+"classname" "monster_hover"
+"spawnflags" "258"
+"targetname" "t271"
+"deathtarget" "hv2"
+}
+{
+"origin" "-2032 -1112 112"
+"target" "t190"
+"delay" "1"
+"targetname" "t10"
+"classname" "trigger_relay"
+}
+{
+"origin" "-2584 0 472"
+"killtarget" "hv4"
+"targetname" "t267"
+"classname" "trigger_relay"
+"delay" ".75"
+"spawnflags" "2048"
+}
+{
+"targetname" "hv4"
+"target" "t266"
+"origin" "-2584 48 464"
+"wait" "4"
+"random" "2"
+"classname" "func_timer"
+"spawnflags" "2048"
+}
+{
+"target" "t267"
+"targetname" "t266"
+"origin" "-2584 24 472"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"target" "t264"
+"targetname" "hv2"
+"origin" "-2624 304 464"
+"wait" "4"
+"random" "2"
+"classname" "func_timer"
+"spawnflags" "2048"
+}
+{
+"target" "t265"
+"targetname" "t264"
+"origin" "-2624 280 464"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"targetname" "t265"
+"origin" "-2624 256 464"
+"killtarget" "hv2"
+"classname" "trigger_relay"
+"delay" ".75"
+"spawnflags" "2048"
+}
+{
+"origin" "-2576 208 464"
+"targetname" "hv3"
+"target" "t262"
+"wait" "4"
+"random" "2"
+"classname" "func_timer"
+"spawnflags" "2048"
+}
+{
+"origin" "-2576 184 464"
+"target" "t263"
+"targetname" "t262"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-2576 160 464"
+"killtarget" "hv3"
+"targetname" "t263"
+"classname" "trigger_relay"
+"delay" ".75"
+"spawnflags" "2048"
+}
+{
+"targetname" "t135"
+"message" "Find Communications Laser\nData CD in Upper Palace."
+"origin" "-1264 720 480"
+"classname" "target_help"
+"spawnflags" "2048"
+}
+{
+"model" "*32"
+"angle" "-2"
+"classname" "trigger_push"
+"spawnflags" "2048"
+}
+{
+"model" "*33"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-528 -1968 1032"
+"targetname" "t61"
+"target" "t260"
+"classname" "trigger_relay"
+"spawnflags" "2304"
+}
+{
+"origin" "-552 -1992 1032"
+"targetname" "t121"
+"target" "t260"
+"classname" "trigger_relay"
+"spawnflags" "2304"
+}
+{
+"model" "*34"
+"spawnflags" "2305"
+"target" "t242"
+"targetname" "t260"
+"classname" "trigger_counter"
+"count" "2"
+}
+{
+"origin" "-672 -2392 488"
+"target" "t259"
+"targetname" "t257"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"origin" "-536 -2608 488"
+"target" "t257"
+"targetname" "t256"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"origin" "-184 -2608 488"
+"targetname" "t259"
+"target" "t256"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"origin" "-624 -2600 1032"
+"target" "t255"
+"targetname" "t254"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"origin" "-680 -1904 1032"
+"target" "t254"
+"targetname" "t253"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"origin" "-576 -1976 1032"
+"targetname" "t255"
+"target" "t253"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"origin" "-840 -1800 248"
+"target" "t251"
+"targetname" "t250"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"origin" "-600 -1872 248"
+"target" "t252"
+"targetname" "t251"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"origin" "-848 -2192 248"
+"targetname" "t252"
+"target" "t250"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_shells"
+"origin" "-2544 -632 -56"
+}
+{
+"origin" "-1624 -1584 552"
+"spawnflags" "1"
+"targetname" "t40"
+"angle" "180"
+"classname" "monster_hover"
+}
+{
+"origin" "-1744 -1608 136"
+"target" "medguy1"
+"targetname" "t40"
+"classname" "trigger_relay"
+}
+{
+"origin" "-456 -712 120"
+"targetname" "t249"
+"classname" "target_secret"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-1888 -1264 1248"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-1832 -1256 1248"
+"light" "200"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-1944 -1264 1248"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-1992 -1264 1248"
+"light" "200"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-2048 -1264 1248"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "300"
+"origin" "-2136 -1304 1136"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2136 -1304 1088"
+"light" "300"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-2112 -1264 1248"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-1848 -1264 1072"
+"light" "300"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2128 -1304 1208"
+"light" "300"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-1872 -1264 1208"
+"light" "200"
+"classname" "light"
+}
+{
+"classname" "item_health"
+"origin" "-96 -1944 104"
+}
+{
+"spawnflags" "1536"
+"classname" "item_health"
+"origin" "-144 -1936 104"
+}
+{
+"classname" "item_armor_jacket"
+"origin" "8 -1992 136"
+"spawnflags" "1792"
+}
+{
+"model" "*35"
+"classname" "trigger_push"
+"angle" "-2"
+"speed" "150"
+"spawnflags" "2048"
+}
+{
+"model" "*36"
+"spawnflags" "2048"
+"classname" "trigger_push"
+"angle" "0"
+"speed" "150"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-2616 208 -24"
+}
+{
+"model" "*37"
+"angle" "-2"
+"speed" "100"
+"classname" "trigger_push"
+"spawnflags" "2048"
+}
+{
+"origin" "-888 -1912 536"
+"target" "t238"
+"targetname" "g2"
+"classname" "trigger_relay"
+}
+{
+"origin" "-240 -1360 88"
+"target" "t239"
+"targetname" "t238"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"model" "*38"
+"target" "t238"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"targetname" "t237"
+"classname" "point_combat"
+"origin" "-532 -1760 88"
+"spawnflags" "2048"
+}
+{
+"targetname" "t236"
+"origin" "-508 -1648 96"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"targetname" "t235"
+"target" "t233"
+"origin" "-300 -1448 96"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"targetname" "t234"
+"target" "t232"
+"classname" "point_combat"
+"origin" "-332 -1448 96"
+"spawnflags" "2048"
+}
+{
+"target" "t236"
+"targetname" "t232"
+"origin" "-484 -1664 88"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"target" "t237"
+"targetname" "t233"
+"classname" "point_combat"
+"origin" "-364 -1656 88"
+}
+{
+"item" "item_armor_shard"
+"spawnflags" "1"
+"targetname" "t239"
+"angle" "225"
+"origin" "-336 -1344 104"
+"classname" "monster_soldier_ss"
+}
+{
+"spawnflags" "1"
+"targetname" "t239"
+"target" "t235"
+"angle" "225"
+"origin" "-320 -1280 104"
+"classname" "monster_soldier_ss"
+}
+{
+"item" "item_armor_shard"
+"spawnflags" "257"
+"targetname" "t239"
+"target" "t234"
+"angle" "270"
+"origin" "-368 -1264 104"
+"classname" "monster_soldier_ss"
+}
+{
+"spawnflags" "769"
+"targetname" "t239"
+"angle" "270"
+"origin" "-416 -1208 104"
+"classname" "monster_soldier_ss"
+}
+{
+"spawnflags" "1"
+"targetname" "t239"
+"angle" "225"
+"origin" "-280 -1344 104"
+"classname" "monster_soldier_ss"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/fan1.wav"
+"origin" "-1812 444 528"
+}
+{
+"origin" "-1928 -1264 128"
+"targetname" "t231"
+"target" "t181"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-1912 -1240 120"
+"delay" "360"
+"targetname" "t231"
+"target" "t181"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"wait" "20"
+"random" "10"
+"classname" "func_timer"
+"origin" "-776 -2120 1000"
+"targetname" "t121"
+"target" "t227"
+"spawnflags" "2304"
+}
+{
+"classname" "trigger_relay"
+"origin" "-776 -2088 1000"
+"delay" "4"
+"targetname" "t227"
+"target" "t228"
+"spawnflags" "2304"
+}
+{
+"killtarget" "t121"
+"delay" ".5"
+"classname" "trigger_relay"
+"origin" "-776 -2056 1000"
+"targetname" "t228"
+"spawnflags" "2304"
+}
+{
+"target" "t225"
+"wait" "18"
+"random" "9"
+"classname" "func_timer"
+"origin" "-792 -2216 1000"
+"targetname" "t240"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"origin" "-792 -2184 1000"
+"delay" "4"
+"targetname" "t225"
+"target" "t226"
+"spawnflags" "2048"
+}
+{
+"killtarget" "t43"
+"delay" ".5"
+"classname" "trigger_relay"
+"origin" "-792 -2152 1000"
+"targetname" "t226"
+"spawnflags" "2048"
+}
+{
+"wait" "16"
+"origin" "-776 -2008 1000"
+"classname" "func_timer"
+"random" "8"
+"targetname" "t243"
+"target" "t229"
+"spawnflags" "2304"
+}
+{
+"delay" "10"
+"origin" "-776 -1976 1000"
+"classname" "trigger_relay"
+"targetname" "t229"
+"target" "t230"
+"spawnflags" "2304"
+}
+{
+"origin" "-776 -1944 1000"
+"classname" "trigger_relay"
+"delay" ".5"
+"killtarget" "t65"
+"targetname" "t230"
+"spawnflags" "2304"
+}
+{
+"killtarget" "t61"
+"delay" ".5"
+"classname" "trigger_relay"
+"origin" "-712 -2488 1000"
+"targetname" "t223"
+"spawnflags" "2048"
+}
+{
+"wait" "4"
+"random" "3"
+"classname" "func_timer"
+"origin" "-712 -2552 1000"
+"target" "t224"
+"targetname" "t243"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t222"
+"delay" ".5"
+"killtarget" "t46"
+"origin" "-712 -2584 1000"
+"spawnflags" "2048"
+}
+{
+"classname" "func_timer"
+"random" "3"
+"wait" "4"
+"targetname" "t46"
+"target" "t221"
+"origin" "-712 -2648 1000"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"origin" "-712 -2520 1000"
+"delay" "4"
+"target" "t223"
+"targetname" "t224"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"origin" "-712 -2616 1000"
+"targetname" "t221"
+"target" "t222"
+"spawnflags" "2048"
+}
+{
+"origin" "-2512 -352 32"
+"spawnflags" "1"
+"angle" "270"
+"classname" "monster_tank_commander"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-1632 -160 -184"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-1632 -160 -120"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-1632 -160 -56"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-1632 -160 8"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-1632 -160 72"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-1192 -40 72"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-1192 -104 72"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-1256 -168 72"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-1632 -160 -312"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-1576 -168 72"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-1512 -168 72"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-1448 -168 72"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-1384 -168 72"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-1320 -168 72"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-1192 24 72"
+}
+{
+"origin" "-2896 48 -272"
+"light" "120"
+"classname" "light"
+}
+{
+"attenuation" "-1"
+"volume" ".1"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"origin" "-2200 -1248 336"
+"targetname" "t219"
+"wait" "11"
+}
+{
+"wait" "5"
+"random" "1"
+"spawnflags" "1"
+"classname" "func_timer"
+"origin" "-2208 -1296 320"
+"target" "t219"
+}
+{
+"attenuation" "-1"
+"volume" ".35"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"origin" "-2232 -1248 336"
+"targetname" "t218"
+}
+{
+"wait" "15"
+"random" "5"
+"spawnflags" "1"
+"classname" "func_timer"
+"origin" "-2240 -1296 320"
+"target" "t218"
+}
+{
+"origin" "-2264 -1248 336"
+"classname" "target_speaker"
+"noise" "World/battle5.wav"
+"volume" ".2"
+"attenuation" "-1"
+"targetname" "t217"
+}
+{
+"origin" "-2272 -1296 320"
+"classname" "func_timer"
+"spawnflags" "1"
+"random" "4"
+"wait" "16"
+"target" "t217"
+}
+{
+"model" "*39"
+"classname" "trigger_once"
+"target" "t9"
+}
+{
+"spawnflags" "2048"
+"origin" "228 -2352 380"
+"message" "Find functioning\nData Spinner\nin Outer Courts."
+"classname" "target_help"
+"targetname" "t139"
+}
+{
+"origin" "-2880 208 104"
+"classname" "func_timer"
+"spawnflags" "1"
+"random" "3"
+"wait" "11"
+"target" "t220"
+}
+{
+"origin" "-2872 256 104"
+"classname" "target_speaker"
+"noise" "World/battle5.wav"
+"volume" "0.3"
+"attenuation" "1"
+"targetname" "t220"
+}
+{
+"attenuation" "1"
+"volume" "0.3"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"origin" "-2792 160 -136"
+"targetname" "t212"
+}
+{
+"wait" "12"
+"random" "4"
+"spawnflags" "1"
+"classname" "func_timer"
+"origin" "-2904 136 -136"
+"target" "t212"
+}
+{
+"attenuation" "1"
+"volume" "0.4"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"origin" "-2728 48 320"
+"targetname" "t211"
+}
+{
+"wait" "6"
+"random" "1"
+"spawnflags" "1"
+"classname" "func_timer"
+"origin" "-2736 0 320"
+"target" "t211"
+}
+{
+"attenuation" "1"
+"volume" ".5"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"origin" "-1712 -1536 416"
+"targetname" "t215"
+}
+{
+"wait" "16"
+"random" "2"
+"spawnflags" "1"
+"classname" "func_timer"
+"origin" "-1720 -1584 416"
+"target" "t215"
+}
+{
+"attenuation" "1"
+"volume" "1"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"origin" "-2016 -1608 328"
+"targetname" "t214"
+}
+{
+"wait" "6"
+"random" "3"
+"spawnflags" "1"
+"classname" "func_timer"
+"origin" "-2024 -1656 328"
+"target" "t214"
+}
+{
+"attenuation" "1"
+"volume" ".6"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"origin" "-2200 -1424 200"
+"targetname" "t213"
+}
+{
+"wait" "10"
+"random" "3"
+"spawnflags" "1"
+"classname" "func_timer"
+"origin" "-2208 -1472 200"
+"target" "t213"
+}
+{
+"model" "*40"
+"speed" "150"
+"angle" "-2"
+"classname" "trigger_push"
+}
+{
+"origin" "104 -2360 360"
+"target" "t209"
+"delay" "2"
+"targetname" "t139"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"model" "*41"
+"targetname" "t209"
+"wait" "-1"
+"_minlight" "0.1"
+"team" "dent2"
+"classname" "func_door"
+"angle" "270"
+"spawnflags" "4"
+}
+{
+"model" "*42"
+"targetname" "t209"
+"wait" "-1"
+"_minlight" "0.1"
+"team" "dent2"
+"classname" "func_door"
+"angle" "90"
+"spawnflags" "4"
+}
+{
+"model" "*43"
+"targetname" "t209"
+"wait" "-1"
+"_minlight" "0.1"
+"team" "dent2"
+"classname" "func_door"
+"angle" "-1"
+"spawnflags" "4"
+}
+{
+"origin" "-1816 444 292"
+"noise" "world/curnt3.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1812 444 528"
+"noise" "world/fan1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2048"
+"origin" "-2072 -1920 48"
+"classname" "item_health"
+}
+{
+"light" "150"
+"_style" "2"
+"origin" "24 -2664 528"
+"spawnflags" "1"
+"classname" "light"
+}
+{
+"model" "*44"
+"message" "You have found a secret area."
+"target" "t198"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"targetname" "t198"
+"origin" "304 -2648 312"
+"classname" "target_secret"
+"spawnflags" "2048"
+}
+{
+"origin" "568 -2616 480"
+"classname" "target_speaker"
+"noise" "world/amb3.wav"
+"spawnflags" "1"
+"attenuation" "3"
+"volume" "0.4"
+}
+{
+"origin" "320 -2632 400"
+"classname" "target_speaker"
+"noise" "world/amb3.wav"
+"spawnflags" "1"
+"attenuation" "3"
+"volume" "0.4"
+}
+{
+"origin" "-8 -2336 400"
+"classname" "target_speaker"
+"noise" "world/amb3.wav"
+"spawnflags" "1"
+"attenuation" "3"
+"volume" "0.4"
+}
+{
+"origin" "144 -2336 400"
+"classname" "target_speaker"
+"noise" "world/amb3.wav"
+"spawnflags" "1"
+"attenuation" "3"
+"volume" "0.4"
+}
+{
+"origin" "-232 -2336 424"
+"classname" "target_speaker"
+"noise" "World/battle5.wav"
+"volume" ".4"
+"attenuation" "3"
+"targetname" "t192"
+}
+{
+"classname" "item_adrenaline"
+"origin" "-3096 -152 -280"
+"team" "adren"
+"spawnflags" "2048"
+}
+{
+"angle" "180"
+"classname" "monster_soldier"
+"targetname" "t58"
+"spawnflags" "1536"
+"origin" "-2896 -96 40"
+}
+{
+"classname" "monster_soldier"
+"angle" "180"
+"targetname" "t58"
+"spawnflags" "512"
+"origin" "-2544 -56 40"
+}
+{
+"classname" "item_health"
+"origin" "-2008 -1920 48"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_jacket"
+"origin" "-2040 -1960 80"
+}
+{
+"model" "*45"
+"classname" "trigger_once"
+"target" "t10"
+"wait" "1"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-2040 -1928 40"
+}
+{
+"classname" "target_speaker"
+"noise" "world/lava1.wav"
+"spawnflags" "1"
+"origin" "-1080 -1920 80"
+}
+{
+"origin" "-736 -1832 712"
+"attenuation" "1"
+"volume" "1"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"targetname" "t195"
+}
+{
+"classname" "func_timer"
+"spawnflags" "1"
+"random" "3"
+"wait" "14"
+"origin" "-736 -1824 408"
+"target" "t195"
+}
+{
+"classname" "func_timer"
+"spawnflags" "1"
+"random" "2"
+"wait" "16"
+"origin" "-728 -2208 536"
+"target" "t196"
+}
+{
+"origin" "-728 -2168 536"
+"attenuation" "1"
+"volume" "1"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"targetname" "t196"
+"random" "4"
+}
+{
+"classname" "func_timer"
+"spawnflags" "1"
+"random" "3"
+"wait" "9"
+"origin" "-656 -2616 336"
+"targetname" "t197"
+}
+{
+"origin" "-656 -2576 336"
+"attenuation" "1"
+"volume" ".3"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"target" "t197"
+}
+{
+"classname" "target_speaker"
+"noise" "World/battle5.wav"
+"volume" "1"
+"attenuation" "1"
+"origin" "-352 -1696 680"
+"targetname" "t194"
+}
+{
+"origin" "-352 -1736 680"
+"wait" "7"
+"random" "2"
+"spawnflags" "1"
+"classname" "func_timer"
+"target" "t194"
+}
+{
+"origin" "-560 -2872 632"
+"attenuation" "1"
+"volume" "1"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"targetname" "t191"
+}
+{
+"origin" "-584 -2848 640"
+"wait" "6"
+"random" "2"
+"spawnflags" "1"
+"classname" "func_timer"
+"target" "t191"
+}
+{
+"attenuation" "1"
+"volume" ".6"
+"noise" "World/battle5.wav"
+"classname" "target_speaker"
+"origin" "-368 -2336 440"
+"targetname" "t192"
+}
+{
+"wait" "10"
+"random" "9"
+"spawnflags" "1"
+"classname" "func_timer"
+"origin" "-376 -2384 440"
+"target" "t192"
+}
+{
+"classname" "func_timer"
+"spawnflags" "1"
+"random" "4"
+"wait" "10"
+"origin" "-416 -1840 312"
+"target" "t193"
+}
+{
+"classname" "target_speaker"
+"noise" "World/battle5.wav"
+"volume" "1"
+"attenuation" "1"
+"origin" "-416 -1800 312"
+"targetname" "t193"
+}
+{
+"origin" "-2016 -1736 72"
+"targetname" "t10"
+"classname" "target_explosion"
+"spawnflags" "2048"
+}
+{
+"origin" "-2072 -1732 32"
+"delay" "2.5"
+"targetname" "t10"
+"classname" "target_explosion"
+"spawnflags" "2048"
+}
+{
+"origin" "-2004 -1628 288"
+"target" "t189"
+"delay" "3"
+"targetname" "t10"
+"classname" "trigger_relay"
+}
+{
+"origin" "-2044 -1628 288"
+"target" "t186"
+"delay" "2.5"
+"targetname" "t10"
+"classname" "trigger_relay"
+}
+{
+"delay" "1"
+"origin" "-2088 -1628 288"
+"target" "t185"
+"targetname" "t10"
+"classname" "trigger_relay"
+}
+{
+"origin" "-2036 -1932 132"
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+"spawnflags" "1"
+}
+{
+"model" "*46"
+"targetname" "t190"
+"mass" "500"
+"dmg" "0"
+"classname" "func_explosive"
+"spawnflags" "2048"
+}
+{
+"origin" "258 -2640 656"
+"classname" "item_health_large"
+"spawnflags" "3072"
+}
+{
+"origin" "262 -2539 656"
+"classname" "item_health_large"
+"spawnflags" "1792"
+}
+{
+"classname" "light"
+"light" "90"
+"origin" "-3016 -136 -232"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t184"
+"target" "t135"
+"origin" "-1344 744 440"
+"spawnflags" "2048"
+}
+{
+"noise" "world/lava1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "-2194 -1302 -82"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/lava1.wav"
+"origin" "-1850 -1294 -80"
+}
+{
+"classname" "target_speaker"
+"noise" "world/lava1.wav"
+"spawnflags" "1"
+"origin" "-562 -874 56"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump2.wav"
+"spawnflags" "1"
+"origin" "-1312 600 448"
+}
+{
+"dmg" "0"
+"classname" "target_explosion"
+"targetname" "t101"
+"delay" ".5"
+"origin" "-2952 -144 -232"
+"spawnflags" "2048"
+}
+{
+"dmg" "0"
+"classname" "target_explosion"
+"targetname" "t101"
+"delay" "2"
+"origin" "-2952 -104 -240"
+"spawnflags" "2048"
+}
+{
+"classname" "target_explosion"
+"dmg" "0"
+"targetname" "t101"
+"delay" "3.25"
+"origin" "-2944 -160 -264"
+"spawnflags" "2048"
+}
+{
+"classname" "item_health_large"
+"origin" "-2544 -592 -56"
+}
+{
+"origin" "-2040 -1192 112"
+"classname" "target_speaker"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"targetname" "t181"
+}
+{
+"classname" "ammo_shells"
+"origin" "-1852 436 316"
+}
+{
+"origin" "-1158 522 448"
+"spawnflags" "1"
+"noise" "world/pump2.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt1.wav"
+"classname" "target_speaker"
+"origin" "-1232 488 400"
+}
+{
+"spawnflags" "1"
+"noise" "world/bigpump.wav"
+"classname" "target_speaker"
+"origin" "-1232 480 24"
+}
+{
+"classname" "target_speaker"
+"noise" "world/l_hum1.wav"
+"spawnflags" "1"
+"origin" "-1432 608 448"
+}
+{
+"classname" "item_breather"
+"origin" "-2400 152 -288"
+"spawnflags" "2048"
+}
+{
+"model" "*47"
+"classname" "func_explosive"
+"dmg" "1"
+"mass" "700"
+"targetname" "t101"
+"spawnflags" "2048"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/fan1.wav"
+"origin" "-3024 -144 -216"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t10"
+"target" "t182"
+"origin" "-1720 -1480 536"
+}
+{
+"model" "*48"
+"classname" "trigger_counter"
+"spawnflags" "1"
+"targetname" "t182"
+"count" "2"
+"target" "t183"
+}
+{
+"classname" "trigger_relay"
+"targetname" "medguy1"
+"target" "t182"
+"origin" "-1688 -1480 536"
+}
+{
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"origin" "-1432 -1576 152"
+"targetname" "t181"
+}
+{
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"origin" "-1800 -1384 88"
+"targetname" "t181"
+}
+{
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"origin" "-2232 -1384 88"
+"targetname" "t181"
+}
+{
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"classname" "target_speaker"
+"origin" "-2040 -952 88"
+}
+{
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"classname" "target_speaker"
+"origin" "-2040 -1192 112"
+"targetname" "t181"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"origin" "-1384 -1784 184"
+"targetname" "t181"
+}
+{
+"model" "*49"
+"target" "t231"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "256"
+"target" "monster_hover"
+"angle" "135"
+"classname" "target_spawner"
+"targetname" "t62"
+"origin" "-248 -2692 528"
+}
+{
+"spawnflags" "256"
+"classname" "target_spawner"
+"targetname" "t62"
+"angle" "135"
+"target" "monster_hover"
+"origin" "-324 -2744 528"
+}
+{
+"origin" "-580 -1056 68"
+"classname" "point_combat"
+"targetname" "t178"
+"target" "t179"
+}
+{
+"classname" "point_combat"
+"origin" "-600 -1032 64"
+"targetname" "t177"
+"target" "t178"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"origin" "-272 -1456 92"
+"targetname" "t179"
+"spawnflags" "2048"
+}
+{
+"model" "*50"
+"origin" "-964 -2000 72"
+"targetname" "drtrp1"
+"wait" "6"
+"team" "drtrp"
+"speed" "100"
+"distance" "-90"
+"angle" "-2"
+"spawnflags" "2124"
+"classname" "func_door_rotating"
+}
+{
+"origin" "24 -2664 500"
+"classname" "item_health_mega"
+"spawnflags" "1792"
+}
+{
+"classname" "item_health"
+"origin" "-1360 696 408"
+}
+{
+"origin" "-1200 -80 104"
+"noise" "world/curnt3.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1368 -168 104"
+"noise" "world/curnt3.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1584 -168 104"
+"noise" "world/curnt3.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1632 -152 0"
+"noise" "world/curnt1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1632 -152 -128"
+"noise" "world/curnt1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1632 -160 -296"
+"noise" "world/curnt1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1632 -160 -376"
+"noise" "world/bigpump.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"origin" "-1832 -136 64"
+"classname" "target_speaker"
+}
+{
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"origin" "-1792 -200 -8"
+"classname" "target_speaker"
+}
+{
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"origin" "-1800 -160 -240"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"origin" "-1760 -96 160"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+}
+{
+"classname" "target_speaker"
+"origin" "-1880 -168 -304"
+"spawnflags" "1"
+"noise" "world/curnt3.wav"
+}
+{
+"classname" "target_speaker"
+"origin" "-2064 -164 -304"
+"spawnflags" "1"
+"noise" "world/curnt3.wav"
+}
+{
+"classname" "target_speaker"
+"origin" "-2256 -160 -304"
+"spawnflags" "1"
+"noise" "world/curnt3.wav"
+}
+{
+"origin" "-2408 184 -240"
+"noise" "world/force1.wav"
+"targetname" "red2"
+"classname" "target_speaker"
+"spawnflags" "2049"
+}
+{
+"origin" "-2624 176 -280"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-2768 184 -288"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-2872 240 -288"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-2264 136 -280"
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2008 -80 -176"
+"classname" "item_health_large"
+}
+{
+"origin" "-2008 -196 -176"
+"classname" "item_health_large"
+"spawnflags" "1536"
+}
+{
+"origin" "-1360 736 408"
+"classname" "item_health"
+"spawnflags" "3072"
+}
+{
+"origin" "-1360 656 408"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"origin" "-2448 160 -416"
+"angle" "135"
+"spawnflags" "1"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-2400 -640 53"
+"_color" "1.000000 0.853755 0.268775"
+"light" "175"
+"classname" "light"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/curnt3.wav"
+"origin" "-1200 88 104"
+}
+{
+"classname" "target_goal"
+"targetname" "t135"
+"origin" "-1336 664 440"
+"spawnflags" "2048"
+}
+{
+"origin" "320 -2376 312"
+"targetname" "t174"
+"classname" "target_speaker"
+"noise" "world/spark1.wav"
+"attenuation" "1"
+"volume" "0.5"
+}
+{
+"origin" "328 -2312 312"
+"targetname" "t175"
+"volume" "0.5"
+"attenuation" "1"
+"noise" "world/spark2.wav"
+"classname" "target_speaker"
+}
+{
+"target" "t175"
+"classname" "func_timer"
+"random" "2.5"
+"wait" "5"
+"origin" "308 -2328 312"
+"spawnflags" "1"
+}
+{
+"targetname" "t148"
+"origin" "152 -2520 320"
+"volume" "0.2"
+"attenuation" "1"
+"noise" "world/spark5.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "4"
+"origin" "-1360 596 444"
+"targetname" "t135"
+"classname" "target_crosslevel_trigger"
+}
+{
+"targetname" "t172"
+"target" "red2"
+"origin" "-2396 176 -256"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_rockets"
+"origin" "660 -2608 448"
+"spawnflags" "2048"
+}
+{
+"origin" "-1488 104 344"
+"classname" "item_health"
+}
+{
+"classname" "ammo_cells"
+"origin" "-1208 408 4"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-1240 300 4"
+}
+{
+"origin" "-952 -1718 620"
+"target" "t162"
+"classname" "weapon_machinegun"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "1536"
+"origin" "-2448 -328 24"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-2464 -288 24"
+"classname" "ammo_bullets"
+}
+{
+"classname" "item_health"
+"origin" "-1400 -1920 96"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-1400 -1960 96"
+}
+{
+"target" "t242"
+"origin" "-336 -1816 104"
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-328 -2184 320"
+"spawnflags" "512"
+}
+{
+"classname" "item_health"
+"origin" "-288 -2144 320"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-912 -1640 584"
+}
+{
+"spawnflags" "2560"
+"origin" "-912 -1600 584"
+"classname" "ammo_bullets"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-816 -2624 704"
+}
+{
+"spawnflags" "3584"
+"origin" "-312 -2816 488"
+"classname" "ammo_bullets"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-280 -2540 320"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_bullets"
+"origin" "-320 -2536 320"
+}
+{
+"classname" "ammo_shells"
+"origin" "660 -2656 480"
+"spawnflags" "1792"
+"team" "hidey1"
+}
+{
+"classname" "ammo_slugs"
+"origin" "660 -2532 480"
+"spawnflags" "1792"
+"team" "hidey2"
+}
+{
+"origin" "-1424 -1856 112"
+"angle" "270"
+"spawnflags" "258"
+"targetname" "t160"
+"classname" "monster_gladiator"
+}
+{
+"origin" "-336 -2304 320"
+"classname" "item_health"
+}
+{
+"target" "t160"
+"classname" "item_health"
+"origin" "420 -2584 320"
+"spawnflags" "2048"
+}
+{
+"target" "t160"
+"classname" "item_health"
+"origin" "460 -2584 320"
+}
+{
+"origin" "-224 -2380 580"
+"target" "big_secret"
+"targetname" "t159"
+"message" "A secret door has opened elsewhere."
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"model" "*51"
+"wait" "-1"
+"target" "t159"
+"sounds" "3"
+"angle" "0"
+"classname" "func_button"
+"_minlight" "0.3"
+"spawnflags" "2048"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "360 -2616 504"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "296 -2616 504"
+}
+{
+"origin" "456 -2616 504"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "552 -2616 504"
+"classname" "light"
+"light" "125"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "392 -2616 440"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "456 -2616 440"
+}
+{
+"origin" "296 -2616 440"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "232 -2616 440"
+"light" "100"
+"classname" "light"
+}
+{
+"target" "t160"
+"origin" "648 -2420 448"
+"classname" "ammo_shells"
+"spawnflags" "2048"
+}
+{
+"origin" "546 -2510 480"
+"classname" "weapon_grenadelauncher"
+"spawnflags" "1792"
+"team" "hidey1"
+}
+{
+"target" "t160"
+"origin" "532 -2420 448"
+"classname" "ammo_grenades"
+"spawnflags" "2048"
+"team" "hidey2"
+}
+{
+"target" "t160"
+"origin" "660 -2568 448"
+"classname" "item_armor_body"
+"spawnflags" "2048"
+}
+{
+"origin" "632 -2616 436"
+"targetname" "t157"
+"classname" "info_null"
+}
+{
+"origin" "632 -2552 436"
+"targetname" "t156"
+"classname" "info_null"
+}
+{
+"origin" "600 -2520 436"
+"targetname" "t155"
+"classname" "info_null"
+}
+{
+"origin" "520 -2520 436"
+"targetname" "t154"
+"classname" "info_null"
+}
+{
+"origin" "632 -2680 436"
+"targetname" "t158"
+"classname" "info_null"
+}
+{
+"origin" "632 -2616 504"
+"target" "t157"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "632 -2552 504"
+"target" "t156"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "600 -2520 504"
+"target" "t155"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "520 -2520 504"
+"target" "t154"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "632 -2680 504"
+"target" "t158"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*52"
+"_minlight" "0.1"
+"targetname" "big_secret"
+"wait" "-1"
+"angle" "-2"
+"classname" "func_door"
+"spawnflags" "2048"
+}
+{
+"targetname" "t152"
+"classname" "target_splash"
+"angle" "270"
+"sounds" "1"
+"origin" "328 -2364 320"
+}
+{
+"targetname" "t174"
+"origin" "312 -2388 312"
+"target" "t152"
+"delay" ".5"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t175"
+"origin" "340 -2388 312"
+"delay" ".2"
+"target" "t151"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t175"
+"target" "t153"
+"origin" "296 -2304 312"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t175"
+"origin" "356 -2312 312"
+"target" "t150"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t151"
+"origin" "360 -2384 320"
+"classname" "target_splash"
+"angle" "225"
+"sounds" "1"
+}
+{
+"targetname" "t153"
+"origin" "336 -2308 328"
+"sounds" "1"
+"angle" "180"
+"classname" "target_splash"
+}
+{
+"targetname" "t175"
+"target" "t150"
+"origin" "364 -2336 352"
+"delay" ".2"
+"classname" "trigger_relay"
+}
+{
+"target" "t174"
+"spawnflags" "1"
+"origin" "308 -2352 312"
+"wait" "10"
+"random" "5"
+"classname" "func_timer"
+}
+{
+"style" "34"
+"light" "500"
+"targetname" "t150"
+"origin" "364 -2340 312"
+"spawnflags" "1"
+"classname" "light"
+}
+{
+"origin" "196 -2520 332"
+"Wait" "3"
+"random" ".5"
+"target" "t148"
+"classname" "func_timer"
+}
+{
+"style" "35"
+"targetname" "t148"
+"origin" "151 -2524 316"
+"_style" "1"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-648 -840 80"
+"classname" "ammo_rockets"
+"spawnflags" "2048"
+}
+{
+"origin" "-568 -1068 80"
+"classname" "ammo_shells"
+"spawnflags" "0"
+}
+{
+"origin" "-328 -2144 320"
+"classname" "ammo_bullets"
+"spawnflags" "2560"
+}
+{
+"model" "*53"
+"spawnflags" "2048"
+"speed" "50"
+"angle" "135"
+"classname" "trigger_push"
+}
+{
+"model" "*54"
+"spawnflags" "2048"
+"angle" "180"
+"speed" "50"
+"classname" "trigger_push"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1352 -1552 88"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1464 -1584 184"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1528 -1584 184"
+}
+{
+"light" "100"
+"origin" "-1208 752 248"
+"classname" "light"
+"_color" "1.000000 0.933333 0.549020"
+}
+{
+"light" "100"
+"origin" "-1320 752 312"
+"classname" "light"
+"_color" "1.000000 0.933333 0.549020"
+}
+{
+"light" "100"
+"origin" "-1440 752 312"
+"classname" "light"
+"_color" "1.000000 0.933333 0.549020"
+}
+{
+"light" "100"
+"origin" "-1080 752 248"
+"_color" "1.000000 0.933333 0.549020"
+"classname" "light"
+}
+{
+"origin" "-2664 328 468"
+"spawnflags" "1792"
+"classname" "weapon_bfg"
+}
+{
+"origin" "-2533 336 473"
+"angle" "225"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-2720 -352 32"
+"angle" "45"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1858 -601 -56"
+"angle" "225"
+"classname" "info_player_deathmatch"
+}
+{
+"angle" "270"
+"origin" "-2064 -24 72"
+"classname" "info_player_deathmatch"
+}
+{
+"model" "*55"
+"spawnflags" "2048"
+"speed" "125"
+"angle" "270"
+"classname" "trigger_push"
+}
+{
+"model" "*56"
+"spawnflags" "2048"
+"classname" "trigger_push"
+"angle" "0"
+"speed" "200"
+}
+{
+"model" "*57"
+"target" "t249"
+"classname" "trigger_once"
+"message" "You have found a secret area."
+"spawnflags" "2048"
+}
+{
+"classname" "target_explosion"
+"delay" ".1.25"
+"targetname" "t146"
+"origin" "-452 -784 74"
+"spawnflags" "2048"
+"dmg" "1"
+}
+{
+"classname" "target_explosion"
+"delay" "1"
+"targetname" "t146"
+"origin" "-484 -786 160"
+"spawnflags" "2048"
+"dmg" "1"
+}
+{
+"classname" "target_explosion"
+"delay" ".5"
+"targetname" "t146"
+"origin" "-456 -784 130"
+"spawnflags" "2048"
+"dmg" "1"
+}
+{
+"model" "*58"
+"classname" "func_explosive"
+"spawnflags" "2048"
+"dmg" "0"
+"mass" "800"
+"target" "t146"
+"health" "50"
+}
+{
+"delay" "10"
+"origin" "-1249 719 444"
+"classname" "trigger_relay"
+"targetname" "brdswit2"
+"target" "t143"
+"spawnflags" "2048"
+}
+{
+"model" "*59"
+"classname" "trigger_counter"
+"count" "2"
+"targetname" "brdswit"
+"spawnflags" "2049"
+"target" "t144"
+}
+{
+"targetname" "t242"
+"classname" "monster_gladiator"
+"angle" "180"
+"item" "ammo_slugs"
+"origin" "-34 -1930 112"
+"spawnflags" "770"
+}
+{
+"classname" "target_secret"
+"targetname" "t141"
+"origin" "-1320 758 438"
+"spawnflags" "2048"
+}
+{
+"model" "*60"
+"classname" "trigger_once"
+"target" "t141"
+"message" "You have found a secret area."
+"spawnflags" "2048"
+}
+{
+"model" "*61"
+"wait" "-1"
+"classname" "func_button"
+"angle" "0"
+"lip" "3"
+"target" "brdswit2"
+"spawnflags" "2048"
+}
+{
+"classname" "target_secret"
+"targetname" "t140"
+"origin" "-2320 160 -328"
+}
+{
+"model" "*62"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t140"
+"message" "You have found a secret area."
+}
+{
+"classname" "target_help"
+"targetname" "t139"
+"message" "Neutralize Strogg Leader's\n Communication System."
+"origin" "160 -2260 336"
+"spawnflags" "2049"
+}
+{
+"model" "*63"
+"classname" "trigger_once"
+"target" "t139"
+"spawnflags" "2048"
+}
+{
+"origin" "184 -2540 680"
+"delay" "30"
+"classname" "trigger_relay"
+"targetname" "medguy1"
+"target" "t122"
+"spawnflags" "2048"
+}
+{
+"origin" "-280 -2580 320"
+"classname" "ammo_bullets"
+}
+{
+"targetname" "t138"
+"origin" "-2032 72 68"
+"classname" "info_null"
+}
+{
+"target" "t138"
+"classname" "light"
+"light" "400"
+"origin" "-2032 72 298"
+"_cone" "15"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2032 72 314"
+}
+{
+"targetname" "t136"
+"classname" "info_null"
+"origin" "-2032 16 68"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2032 184 314"
+}
+{
+"target" "t137"
+"classname" "light"
+"light" "400"
+"origin" "-2032 184 298"
+"_cone" "15"
+}
+{
+"targetname" "t137"
+"classname" "info_null"
+"origin" "-2032 184 68"
+}
+{
+"origin" "-2032 0 294"
+"classname" "light"
+"light" "100"
+}
+{
+"_cone" "15"
+"target" "t136"
+"origin" "-2032 0 278"
+"light" "400"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-832 -2608 400"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "item_health"
+"origin" "-885 -2697 327"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-600 -2344 336"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "512"
+"origin" "-636 -2316 328"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-1192 172 4"
+"classname" "ammo_shells"
+}
+{
+"origin" "-1252 356 -12"
+"spawnflags" "2057"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-1352 568 108"
+"classname" "ammo_slugs"
+"spawnflags" "1792"
+}
+{
+"origin" "-1152 788 460"
+"classname" "ammo_cells"
+"spawnflags" "1792"
+}
+{
+"origin" "-1852 476 316"
+"classname" "ammo_shells"
+"spawnflags" "1024"
+}
+{
+"origin" "-1804 60 300"
+"classname" "item_health"
+"spawnflags" "3072"
+}
+{
+"origin" "-1608 -160 212"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"origin" "-1784 0 -8"
+"angle" "90"
+"spawnflags" "2049"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-1768 -252 60"
+"classname" "ammo_rockets"
+"spawnflags" "2048"
+}
+{
+"origin" "-1864 -220 28"
+"classname" "item_health"
+}
+{
+"origin" "-1860 -92 60"
+"classname" "weapon_supershotgun"
+"spawnflags" "1792"
+}
+{
+"_minlight" "0.2"
+"origin" "-2540 -680 -72"
+"angle" "45"
+"spawnflags" "2056"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-2480 220 -288"
+"classname" "ammo_cells"
+"spawnflags" "2048"
+}
+{
+"origin" "-2520 220 -288"
+"classname" "ammo_grenades"
+"spawnflags" "2048"
+}
+{
+"origin" "-2516 184 -288"
+"classname" "ammo_slugs"
+"spawnflags" "2048"
+}
+{
+"origin" "-2480 148 -288"
+"classname" "ammo_rockets"
+"spawnflags" "0"
+}
+{
+"origin" "-2520 192 -231"
+"classname" "weapon_chaingun"
+"spawnflags" "1792"
+}
+{
+"origin" "-2520 144 -288"
+"classname" "item_health_large"
+"spawnflags" "0"
+}
+{
+"origin" "-2520 152 -240"
+"classname" "item_power_shield"
+"spawnflags" "2048"
+}
+{
+"target" "t172"
+"origin" "-2384 220 -296"
+"spawnflags" "2049"
+"classname" "target_crosslevel_target"
+}
+{
+"origin" "-2400 208 -288"
+"classname" "item_health_large"
+"spawnflags" "2048"
+}
+{
+"origin" "-2800 208 -24"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"origin" "-2920 -136 40"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"origin" "-2312 -1496 80"
+"classname" "ammo_shells"
+"spawnflags" "0"
+}
+{
+"origin" "-2272 -1512 80"
+"classname" "ammo_shells"
+"spawnflags" "2048"
+}
+{
+"origin" "-704 -832 72"
+"classname" "info_player_deathmatch"
+}
+{
+"spawnflags" "0"
+"origin" "-1624 -1624 112"
+"classname" "ammo_rockets"
+}
+{
+"model" "*64"
+"classname" "trigger_hurt"
+}
+{
+"origin" "-976 -2024 544"
+"classname" "item_health"
+}
+{
+"origin" "-1360 -1920 96"
+"classname" "ammo_bullets"
+}
+{
+"classname" "item_health"
+"origin" "-2016 -688 -64"
+"spawnflags" "2048"
+}
+{
+"origin" "-984 -1920 544"
+"classname" "item_armor_combat"
+"spawnflags" "1792"
+}
+{
+"origin" "-408 -1848 104"
+"classname" "item_health"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_bullets"
+"origin" "-600 -840 80"
+}
+{
+"classname" "item_health"
+"origin" "-528 -1148 80"
+"spawnflags" "2048"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2896 48 -384"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2872 120 -384"
+"light" "80"
+"classname" "light"
+}
+{
+"style" "1"
+"classname" "func_areaportal"
+"targetname" "t124"
+}
+{
+"model" "*65"
+"team" "redportal3"
+"lip" "8"
+"wait" "6"
+"sounds" "4"
+"speed" "75"
+"angle" "270"
+"classname" "func_door"
+"target" "t124"
+"_minlight" "0.2"
+}
+{
+"model" "*66"
+"team" "redportal3"
+"lip" "8"
+"wait" "6"
+"sounds" "4"
+"speed" "75"
+"classname" "func_door"
+"angle" "90"
+"target" "t124"
+"_minlight" "0.2"
+}
+{
+"item" "ammo_cells"
+"origin" "269 -2460 665"
+"spawnflags" "257"
+"classname" "monster_medic"
+"targetname" "t123"
+"angle" "180"
+"target" "t286"
+}
+{
+"classname" "trigger_relay"
+"targetname" "medguy1"
+"delay" "15"
+"target" "t123"
+"origin" "184 -2516 680"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_medic"
+"spawnflags" "769"
+"origin" "273 -2525 669"
+"targetname" "t122"
+"target" "t180"
+"angle" "180"
+}
+{
+"item" "ammo_cells"
+"origin" "-788 -2524 1084"
+"spawnflags" "2"
+"classname" "monster_hover"
+"targetname" "t223"
+}
+{
+"style" "2"
+"classname" "func_areaportal"
+"targetname" "t120"
+}
+{
+"style" "3"
+"classname" "func_areaportal"
+"targetname" "t119"
+}
+{
+"model" "*67"
+"_minlight" "0.2"
+"angle" "180"
+"classname" "func_door"
+"target" "t119"
+"speed" "75"
+"sounds" "4"
+"wait" "4"
+"lip" "24"
+"team" "redportal1"
+}
+{
+"model" "*68"
+"_minlight" "0.2"
+"classname" "func_door"
+"angle" "0"
+"speed" "75"
+"sounds" "4"
+"wait" "4"
+"lip" "24"
+"team" "redportal1"
+}
+{
+"model" "*69"
+"_minlight" "0.2"
+"classname" "func_door"
+"angle" "0"
+"speed" "75"
+"team" "big red"
+}
+{
+"model" "*70"
+"_minlight" "0.2"
+"team" "big red"
+"speed" "75"
+"angle" "180"
+"classname" "func_door"
+}
+{
+"classname" "point_combat"
+"targetname" "t117"
+"origin" "-2712 -96 24"
+"spawnflags" "2048"
+}
+{
+"model" "*71"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t106"
+}
+{
+"model" "*72"
+"classname" "func_wall"
+"targetname" "t106"
+"spawnflags" "6"
+}
+{
+"light" "150"
+"origin" "-980 446 456"
+"_color" "0.862348 1.000000 0.085020"
+"classname" "light"
+}
+{
+"target" "bigbridge"
+"targetname" "brdswit2"
+"origin" "-1247 771 476"
+"classname" "trigger_relay"
+"delay" "3"
+"spawnflags" "2048"
+}
+{
+"model" "*73"
+"target" "t111"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"light" "200"
+"_style" "10"
+"_color" "1.000000 1.000000 0.509804"
+"origin" "-1426 608 478"
+"classname" "light"
+}
+{
+"classname" "trigger_relay"
+"targetname" "brdswit2"
+"target" "brdswit"
+"origin" "-1271 711 444"
+"delay" "5"
+"spawnflags" "2048"
+}
+{
+"classname" "item_health"
+"origin" "-712 -1692 592"
+}
+{
+"origin" "-440 -1748 88"
+"targetname" "t108"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"origin" "-428 -1740 88"
+"target" "t108"
+"targetname" "t107"
+"classname" "point_combat"
+"pathtarget" "killme"
+"spawnflags" "2048"
+}
+{
+"targetname" "t178"
+"target" "t107"
+"origin" "-252 -1440 104"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"model" "*74"
+"targetname" "red2"
+"spawnflags" "2055"
+"classname" "func_wall"
+}
+{
+"origin" "-904 -2064 1000"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-220 -2252 584"
+"classname" "info_player_deathmatch"
+}
+{
+"item" "ammo_cells"
+"origin" "209 -2472 657"
+"targetname" "medguy1"
+"spawnflags" "1"
+"classname" "monster_medic"
+"angle" "180"
+"target" "t285"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-596 -2288 328"
+"spawnflags" "2048"
+}
+{
+"item" "item_armor_shard"
+"classname" "monster_soldier_ss"
+"angle" "270"
+"origin" "-888 -1544 608"
+"spawnflags" "257"
+"targetname" "m2"
+}
+{
+"origin" "-760 -1832 552"
+"classname" "trigger_relay"
+"killtarget" "g6"
+"targetname" "g6"
+"delay" ".4"
+"spawnflags" "2048"
+}
+{
+"model" "*75"
+"target" "t101"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "-1382 188 340"
+"targetname" "t93"
+"classname" "point_combat"
+}
+{
+"origin" "-1248 120 344"
+"targetname" "t94"
+"classname" "point_combat"
+}
+{
+"spawnflags" "2049"
+"origin" "-1060 592 428"
+"targetname" "t98"
+"classname" "point_combat"
+}
+{
+"model" "*76"
+"target" "t91"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"angle" "0"
+"item" "item_armor_shard"
+"origin" "-1615 -154 260"
+"spawnflags" "768"
+"targetname" "t91"
+"classname" "monster_hover"
+}
+{
+"origin" "-1122 415 431"
+"spawnflags" "257"
+"classname" "monster_soldier_ss"
+"targetname" "t111"
+}
+{
+"target" "t98"
+"origin" "-970 622 424"
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+"targetname" "t111"
+}
+{
+"item" "ammo_bullets"
+"target" "t93"
+"origin" "-1004 132 422"
+"spawnflags" "257"
+"classname" "monster_soldier_ss"
+"targetname" "t111"
+}
+{
+"target" "t94"
+"origin" "-1108 104 406"
+"spawnflags" "257"
+"classname" "monster_soldier_ss"
+"targetname" "t111"
+}
+{
+"item" "item_armor_shard"
+"origin" "-964 290 424"
+"angle" "270"
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+"targetname" "t111"
+}
+{
+"item" "item_armor_shard"
+"angle" "180"
+"origin" "-876 -1992 1016"
+"classname" "monster_hover"
+"spawnflags" "258"
+"targetname" "t230"
+}
+{
+"item" "ammo_rockets"
+"classname" "monster_tank_commander"
+"spawnflags" "257"
+"targetname" "t1"
+"origin" "-2024 -392 -8"
+"angle" "270"
+}
+{
+"spawnflags" "258"
+"targetname" "t1"
+"classname" "monster_hover"
+"origin" "-860 -1956 636"
+}
+{
+"item" "ammo_cells"
+"spawnflags" "258"
+"targetname" "t1"
+"classname" "monster_hover"
+"origin" "-812 -1876 620"
+}
+{
+"classname" "point_combat"
+"origin" "-2216 -1520 40"
+"targetname" "t77"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"origin" "-2128 -1512 24"
+"targetname" "t78"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"origin" "-1960 -1488 40"
+"targetname" "t79"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"origin" "-1840 -1584 40"
+"targetname" "t80"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"origin" "-1768 -1496 64"
+"targetname" "t81"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"origin" "-2288 -1512 56"
+"targetname" "t77"
+"spawnflags" "2048"
+}
+{
+"targetname" "t186"
+"item" "ammo_bullets"
+"origin" "-2036 -1908 380"
+"classname" "monster_soldier_ss"
+"target" "t79"
+"spawnflags" "2"
+}
+{
+"targetname" "t189"
+"origin" "-2036 -1948 380"
+"classname" "monster_soldier_ss"
+"target" "t78"
+"spawnflags" "258"
+}
+{
+"targetname" "t185"
+"classname" "monster_soldier_ss"
+"origin" "-2076 -1908 380"
+"target" "t77"
+"spawnflags" "258"
+}
+{
+"targetname" "t189"
+"item" "ammo_bullets"
+"classname" "monster_soldier_ss"
+"origin" "-1988 -1948 380"
+"target" "t80"
+"spawnflags" "514"
+}
+{
+"targetname" "t185"
+"classname" "monster_soldier_ss"
+"origin" "-1988 -1908 380"
+"target" "t81"
+"spawnflags" "770"
+}
+{
+"targetname" "t186"
+"item" "ammo_bullets"
+"angle" "180"
+"classname" "monster_soldier_ss"
+"origin" "-2076 -1948 380"
+"spawnflags" "2"
+}
+{
+"item" "item_armor_shard"
+"targetname" "t101"
+"classname" "monster_gladiator"
+"spawnflags" "770"
+"origin" "-3020 -136 -270"
+"angle" "0"
+}
+{
+"model" "*77"
+"classname" "trigger_once"
+"target" "t76"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"target" "t74"
+"delay" "0.3"
+"targetname" "t76"
+"origin" "-2728 -136 -296"
+}
+{
+"classname" "monster_soldier"
+"origin" "-2568 -144 -280"
+"targetname" "t74"
+"angle" "180"
+"spawnflags" "769"
+}
+{
+"item" "ammo_shells"
+"classname" "monster_soldier"
+"origin" "-2608 -120 -280"
+"targetname" "t76"
+"angle" "180"
+"spawnflags" "1"
+}
+{
+"item" "item_power_shield"
+"targetname" "t76"
+"classname" "monster_gladiator"
+"origin" "-2112 -240 -168"
+"angle" "270"
+"spawnflags" "1"
+}
+{
+"targetname" "t58"
+"spawnflags" "2"
+"angle" "180"
+"classname" "monster_hover"
+"origin" "-2534 84 484"
+"deathtarget" "hv4"
+}
+{
+"spawnflags" "258"
+"classname" "monster_hover"
+"origin" "-2536 264 504"
+"targetname" "t265"
+}
+{
+"angle" "270"
+"classname" "info_player_start"
+"targetname" "city1XH"
+"origin" "-2040 80 72"
+}
+{
+"classname" "info_player_start"
+"angle" "270"
+"targetname" "city1XL"
+"origin" "-2040 48 -168"
+}
+{
+"classname" "point_combat"
+"targetname" "t68"
+"origin" "-1368 -1864 88"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"targetname" "t67"
+"origin" "-1432 -1912 88"
+"spawnflags" "2048"
+}
+{
+"targetname" "t303"
+"deathtarget" "t121"
+"target" "t259"
+"classname" "monster_hover"
+"origin" "-160 -2600 504"
+"angle" "225"
+"spawnflags" "1"
+}
+{
+"target" "g6"
+"targetname" "g2"
+"origin" "-792 -1832 552"
+"classname" "trigger_relay"
+"delay" "0.1"
+"spawnflags" "2048"
+}
+{
+"target" "gate1"
+"origin" "-792 -1800 552"
+"classname" "trigger_relay"
+"targetname" "g6"
+"delay" "0.1"
+"spawnflags" "2048"
+}
+{
+"targetname" "g4"
+"target" "gate1"
+"classname" "trigger_relay"
+"origin" "-792 -1872 552"
+"spawnflags" "2048"
+}
+{
+"target" "gate1"
+"targetname" "g1"
+"origin" "-808 -1760 288"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2"
+"origin" "-1388 -1796 120"
+"targetname" "m1"
+"classname" "monster_soldier_ss"
+"target" "t67"
+}
+{
+"item" "ammo_bullets"
+"spawnflags" "258"
+"origin" "-1436 -1796 128"
+"angle" "270"
+"targetname" "m1"
+"classname" "monster_soldier_ss"
+"target" "t68"
+}
+{
+"item" "item_armor_shard"
+"targetname" "m2"
+"spawnflags" "257"
+"origin" "-936 -1568 596"
+"angle" "135"
+"classname" "monster_soldier_ss"
+}
+{
+"targetname" "g4"
+"killtarget" "gatetrig1"
+"classname" "trigger_relay"
+"origin" "-792 -1912 552"
+"spawnflags" "2048"
+}
+{
+"model" "*78"
+"lip" "12"
+"wait" "-1"
+"sounds" "3"
+"target" "g2"
+"angle" "-2"
+"classname" "func_button"
+"spawnflags" "2048"
+}
+{
+"model" "*79"
+"target" "g4"
+"targetname" "gatetrig2"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "-800 -1728 288"
+"killtarget" "gatetrig2"
+"targetname" "g1"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"model" "*80"
+"targetname" "gatetrig1"
+"target" "g1"
+"classname" "trigger_once"
+}
+{
+"model" "*81"
+"_minlight" "0.1"
+"message" "ACCESS DENIED.\nThis gate is opened elsewhere."
+"sounds" "4"
+"lip" "64"
+"dmg" "25"
+"speed" "50"
+"targetname" "gate1"
+"spawnflags" "2093"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"classname" "light"
+"light" "70"
+"origin" "-1272 -1936 184"
+}
+{
+"item" "ammo_slugs"
+"angle" "180"
+"classname" "monster_gladiator"
+"targetname" "t58"
+"origin" "-2544 -120 32"
+"target" "t117"
+"spawnflags" "257"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-264 -2792 488"
+"spawnflags" "2048"
+}
+{
+"classname" "item_health"
+"origin" "-856 -2616 704"
+}
+{
+"classname" "item_health"
+"origin" "-856 -2560 704"
+}
+{
+"model" "*82"
+"classname" "trigger_once"
+"spawnflags" "2308"
+"targetname" "t40"
+"target" "t62"
+}
+{
+"item" "item_armor_shard"
+"targetname" "t106"
+"angle" "270"
+"classname" "monster_soldier_ss"
+"origin" "-1248 792 422"
+"spawnflags" "257"
+}
+{
+"targetname" "t106"
+"classname" "monster_soldier_ss"
+"angle" "180"
+"origin" "-1320 604 430"
+"spawnflags" "1"
+}
+{
+"targetname" "bigbridge"
+"spawnflags" "1"
+"classname" "monster_gladiator"
+"origin" "-1015 366 436"
+"angle" "225"
+}
+{
+"deathtarget" "t121"
+"item" "ammo_cells"
+"classname" "monster_hover"
+"spawnflags" "2"
+"origin" "-900 -2160 1044"
+"targetname" "t226"
+}
+{
+"deathtarget" "t61"
+"classname" "monster_hover"
+"spawnflags" "258"
+"origin" "-788 -2628 1092"
+"targetname" "t222"
+}
+{
+"classname" "monster_hover"
+"spawnflags" "258"
+"origin" "-904 -2104 1016"
+"targetname" "t228"
+}
+{
+"targetname" "t242"
+"item" "ammo_slugs"
+"classname" "monster_gladiator"
+"spawnflags" "1"
+"origin" "-108 -1880 108"
+"deathtarget" "t243"
+}
+{
+"targetname" "t243"
+"classname" "monster_gladiator"
+"spawnflags" "257"
+"origin" "-704 -1048 102"
+"angle" "0"
+}
+{
+"model" "*83"
+"origin" "-964 -1840 72"
+"classname" "func_door_rotating"
+"spawnflags" "2124"
+"angle" "-2"
+"distance" "90"
+"speed" "100"
+"team" "drtrp"
+"targetname" "drtrp1"
+"wait" "6"
+}
+{
+"model" "*84"
+"classname" "func_plat"
+"speed" "75"
+"_minlight" "0.1"
+}
+{
+"model" "*85"
+"spawnflags" "2048"
+"classname" "trigger_multiple"
+"target" "t58"
+}
+{
+"classname" "path_corner"
+"target" "t54"
+"targetname" "t57"
+"origin" "-2192 -832 -56"
+}
+{
+"classname" "item_health"
+"origin" "-288 -2104 320"
+}
+{
+"model" "*86"
+"spawnflags" "4"
+"angle" "-1"
+"classname" "func_door"
+"team" "dent1"
+"_minlight" "0.1"
+}
+{
+"model" "*87"
+"spawnflags" "4"
+"angle" "270"
+"classname" "func_door"
+"team" "dent1"
+"_minlight" "0.1"
+}
+{
+"model" "*88"
+"spawnflags" "4"
+"angle" "90"
+"classname" "func_door"
+"team" "dent1"
+"_minlight" "0.1"
+"target" "t120"
+}
+{
+"classname" "light"
+"origin" "-128 -2288 344"
+"light" "150"
+"_color" "0.650980 1.000000 0.650980"
+}
+{
+"_color" "0.650980 1.000000 0.650980"
+"light" "150"
+"origin" "-128 -2400 344"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-128 -2400 400"
+"light" "150"
+"_color" "0.650980 1.000000 0.650980"
+}
+{
+"_color" "0.650980 1.000000 0.650980"
+"light" "150"
+"origin" "-128 -2288 400"
+"classname" "light"
+}
+{
+"origin" "-2000 -48 64"
+"classname" "item_health_large"
+"spawnflags" "2048"
+}
+{
+"origin" "-2504 -288 24"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-2056 -688 -64"
+"classname" "item_health"
+}
+{
+"origin" "-2496 -680 -8"
+"classname" "item_armor_jacket"
+"spawnflags" "1792"
+}
+{
+"angle" "270"
+"origin" "-2664 312 520"
+"classname" "monster_hover"
+"targetname" "t58"
+"deathtarget" "hv1"
+"spawnflags" "257"
+}
+{
+"targetname" "t263"
+"origin" "-2536 144 488"
+"classname" "monster_hover"
+"spawnflags" "2"
+}
+{
+"targetname" "t267"
+"origin" "-2534 10 484"
+"classname" "monster_hover"
+"angle" "180"
+"spawnflags" "2"
+}
+{
+"origin" "-2768 312 512"
+"angle" "270"
+"classname" "monster_hover"
+"targetname" "t58"
+"deathtarget" "hv3"
+"spawnflags" "1"
+}
+{
+"model" "*89"
+"classname" "func_plat"
+"speed" "200"
+"lip" "0"
+"sounds" "2"
+"_minlight" "0.1"
+}
+{
+"deathtarget" "t171"
+"item" "ammo_bullets"
+"origin" "-2032 -120 72"
+"angle" "270"
+"classname" "monster_tank_commander"
+"spawnflags" "1"
+}
+{
+"angle" "45"
+"deathtarget" "t46"
+"target" "t251"
+"spawnflags" "257"
+"classname" "monster_hover"
+"origin" "-568 -1880 264"
+"targetname" "t246"
+}
+{
+"target" "t255"
+"deathtarget" "t240"
+"targetname" "t64"
+"origin" "-720 -2180 1040"
+"classname" "monster_hover"
+"spawnflags" "1"
+"angle" "45"
+}
+{
+"model" "*90"
+"target" "drtrp1"
+"delay" "0.1"
+"wait" "6"
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+}
+{
+"target" "t242"
+"origin" "-336 -1856 104"
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+}
+{
+"origin" "-560 -1108 80"
+"classname" "item_health"
+"spawnflags" "1024"
+}
+{
+"origin" "-488 -736 104"
+"classname" "item_health_large"
+"spawnflags" "0"
+}
+{
+"model" "*91"
+"spawnflags" "2048"
+"angle" "270"
+"speed" "75"
+"classname" "trigger_push"
+}
+{
+"origin" "-1608 -1640 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1592 -1640 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1576 -1640 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1608 -1528 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1592 -1528 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1576 -1528 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1544 -1528 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1528 -1528 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1512 -1528 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1480 -1528 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1464 -1528 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1448 -1528 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1416 -1528 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1400 -1528 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1384 -1528 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1352 -1600 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1352 -1568 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1352 -1536 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1352 -1664 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1352 -1632 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1352 -1616 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1352 -1696 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1352 -1680 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1352 -1744 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1352 -1840 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1352 -1824 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1352 -1808 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1464 -1888 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1464 -1872 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1464 -1856 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1464 -1744 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1512 -1640 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1528 -1640 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1544 -1640 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1464 -1952 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1464 -1936 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1464 -1920 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1464 -1792 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1464 -1808 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1464 -1824 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1440 -1976 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1424 -1976 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1408 -1976 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1280 -1976 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1296 -1976 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1312 -1976 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1344 -1976 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1360 -1976 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1376 -1976 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1280 -1872 88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1296 -1872 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1312 -1872 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1464 -1680 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1464 -1696 88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1464 -1664 88"
+"light" "64"
+"classname" "light"
+}
+{
+"model" "*92"
+"target" "t40"
+"classname" "trigger_multiple"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-448 -2288 448"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-472 -2344 360"
+"light" "90"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.448000 0.208000"
+"classname" "light"
+"origin" "-496 -920 40"
+"light" "100"
+}
+{
+"_color" "1.000000 0.448000 0.208000"
+"classname" "light"
+"origin" "-544 -928 40"
+"light" "100"
+}
+{
+"_color" "1.000000 0.448000 0.208000"
+"classname" "light"
+"origin" "-536 -928 64"
+"light" "100"
+}
+{
+"light" "100"
+"origin" "-616 -928 64"
+"classname" "light"
+"_color" "1.000000 0.448000 0.208000"
+}
+{
+"light" "150"
+"origin" "-440 -712 40"
+"classname" "light"
+"_color" "1.000000 0.448000 0.208000"
+}
+{
+"_color" "1.000000 0.448000 0.208000"
+"classname" "light"
+"origin" "-472 -696 40"
+"light" "150"
+}
+{
+"light" "100"
+"origin" "-440 -712 88"
+"classname" "light"
+"_color" "1.000000 0.448000 0.208000"
+}
+{
+"light" "100"
+"origin" "-632 -888 40"
+"classname" "light"
+"_color" "1.000000 0.448000 0.208000"
+}
+{
+"light" "100"
+"origin" "-576 -872 64"
+"classname" "light"
+"_color" "1.000000 0.448000 0.208000"
+}
+{
+"_color" "1.000000 0.448000 0.208000"
+"classname" "light"
+"origin" "-568 -984 88"
+"light" "100"
+}
+{
+"_color" "1.000000 0.448000 0.208000"
+"classname" "light"
+"origin" "-440 -744 40"
+"light" "150"
+}
+{
+"_color" "1.000000 0.448000 0.208000"
+"classname" "light"
+"origin" "-440 -808 32"
+"light" "150"
+}
+{
+"_color" "1.000000 0.448000 0.208000"
+"classname" "light"
+"origin" "-624 -928 40"
+"light" "100"
+}
+{
+"classname" "light"
+"_color" "1.000000 0.448000 0.208000"
+"origin" "-552 -1056 120"
+"light" "150"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-712 -2736 752"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-584 -2800 688"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-456 -2800 624"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-360 -2816 544"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-760 -2472 304"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-784 -2480 352"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-720 -2576 384"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-880 -2480 352"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-800 -2368 336"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-864 -2208 240"
+"light" "175"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-800 -2208 240"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-816 -2064 176"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-280 -2736 488"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-800 -2648 784"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1656 -1584 168"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1592 -1584 168"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1400 -1584 184"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1400 -1664 184"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1400 -1792 184"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1400 -1856 184"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1400 -1920 184"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1336 -1920 184"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1272 -1904 184"
+"light" "100"
+"classname" "light"
+}
+{
+"angle" "270"
+"origin" "-1584 -1160 960"
+"targetname" "t10"
+"spawnflags" "258"
+"classname" "monster_hover"
+}
+{
+"item" "ammo_cells"
+"origin" "-2432 -1704 656"
+"targetname" "t10"
+"spawnflags" "2"
+"classname" "monster_hover"
+}
+{
+"angle" "270"
+"origin" "-2072 -944 1032"
+"targetname" "t10"
+"spawnflags" "2"
+"classname" "monster_hover"
+}
+{
+"model" "*93"
+"classname" "func_button"
+"angle" "-2"
+"target" "t20"
+"lip" "12"
+"sounds" "3"
+}
+{
+"origin" "-2848 -64 -168"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2832 -80 -168"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2832 -192 -168"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2848 -208 -168"
+}
+{
+"spawnflags" "258"
+"origin" "-1992 -944 1032"
+"classname" "monster_hover"
+"targetname" "t183"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-318 -2066 448"
+"light" "175"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-446 -2066 512"
+"light" "175"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-512 -2512 512"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-512 -2192 512"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-512 -2384 512"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"spawnflags" "80"
+"classname" "light"
+"light" "200"
+"origin" "-576 -2480 512"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-240 -2672 456"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-312 -2552 368"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-448 -2480 448"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-464 -2248 400"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-576 -2288 512"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "0.000000 1.000000 1.000000"
+"origin" "-2960 232 -216"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.000000 1.000000 1.000000"
+"origin" "-2960 280 -216"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "70"
+"origin" "-2904 232 -216"
+}
+{
+"light" "70"
+"classname" "light"
+"origin" "-2904 280 -216"
+}
+{
+"_color" "0.000000 1.000000 1.000000"
+"origin" "-2960 232 -280"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.000000 1.000000 1.000000"
+"origin" "-2960 280 -280"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "0.000000 1.000000 1.000000"
+"classname" "light"
+"light" "70"
+"origin" "-2904 232 -280"
+}
+{
+"_color" "0.000000 1.000000 1.000000"
+"light" "70"
+"classname" "light"
+"origin" "-2904 280 -280"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2960 232 -336"
+"light" "70"
+"classname" "light"
+}
+{
+"origin" "-2960 280 -336"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2904 232 -336"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "70"
+"classname" "light"
+"origin" "-2904 280 -336"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2968 224 -384"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2968 272 -384"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2912 224 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "70"
+"classname" "light"
+"origin" "-2912 272 -384"
+}
+{
+"origin" "-2904 232 -152"
+"light" "70"
+"classname" "light"
+}
+{
+"origin" "-2904 280 -152"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2872 184 -384"
+"light" "80"
+"classname" "light"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2872 232 -384"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1664 -1568 233"
+"_color" "1.000000 0.853755 0.268775"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2184 -752 53"
+"_color" "1.000000 0.853755 0.268775"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.853755 0.268775"
+"origin" "-2184 -720 53"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.853755 0.268775"
+"origin" "-1664 -1600 233"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.853755 0.268775"
+"origin" "-1880 -720 53"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.853755 0.268775"
+"origin" "-2256 -640 53"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.853755 0.268775"
+"origin" "-2288 -640 53"
+}
+{
+"classname" "light"
+"light" "125"
+"_color" "1.000000 0.853755 0.268775"
+"origin" "-2496 -632 21"
+}
+{
+"item" "ammo_rockets"
+"spawnflags" "257"
+"origin" "-1880 -650 -54"
+"angle" "270"
+"target" "t55"
+"targetname" "t9"
+"classname" "monster_tank_commander"
+}
+{
+"classname" "light"
+"light" "175"
+"_color" "1.000000 0.853755 0.268775"
+"origin" "-2440 -456 79"
+}
+{
+"classname" "light"
+"light" "175"
+"_color" "1.000000 0.853755 0.268775"
+"origin" "-2552 -456 79"
+}
+{
+"classname" "light"
+"light" "175"
+"_color" "1.000000 0.853755 0.268775"
+"origin" "-2496 -376 167"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.853755 0.268775"
+"origin" "-2688 -240 167"
+}
+{
+"model" "*94"
+"classname" "trigger_once"
+"target" "bigbridge"
+"delay" "1"
+"spawnflags" "2048"
+}
+{
+"model" "*95"
+"spawnflags" "32"
+"classname" "func_door"
+"angle" "0"
+"speed" "35"
+"targetname" "bigbridge"
+"lip" "390"
+}
+{
+"model" "*96"
+"_minlight" "0.1"
+"wait" "-1"
+"classname" "func_door"
+"angle" "-1"
+"lip" "8"
+"speed" "75"
+"spawnflags" "8"
+"sounds" "2"
+"targetname" "t20"
+"delay" "10"
+}
+{
+"classname" "key_data_spinner"
+"origin" "-1428 608 448"
+"target" "t184"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-1024 792 440"
+}
+{
+"origin" "-2072 152 -184"
+"targetname" "exit_low"
+"classname" "target_changelevel"
+"map" "city2$city2NL"
+}
+{
+"model" "*97"
+"target" "exit_low"
+"classname" "trigger_multiple"
+"angle" "90"
+}
+{
+"origin" "-2072 104 88"
+"map" "city2$city2NH"
+"targetname" "exit_high"
+"classname" "target_changelevel"
+}
+{
+"model" "*98"
+"target" "exit_high"
+"classname" "trigger_multiple"
+"angle" "90"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-2040 -376 120"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-2040 -504 120"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-2040 -632 120"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-2024 -248 120"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1896 -832 32"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1952 -632 56"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-2112 -632 32"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-2160 -824 32"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-832 -1920 176"
+"light" "175"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-720 -2000 176"
+"light" "175"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-768 -2112 240"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-864 -2336 304"
+"light" "175"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-656 -2576 384"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-872 -2536 400"
+"light" "175"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-784 -2568 368"
+"light" "175"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-320 -2736 480"
+"light" "175"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-448 -2608 448"
+"light" "200"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-640 -2384 512"
+"light" "200"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"origin" "-1816 -144 288"
+"light" "100"
+}
+{
+"_color" "1.000000 0.709804 0.658824"
+"classname" "light"
+"origin" "-1785 -69 72"
+"light" "150"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"origin" "-1800 -144 168"
+"light" "150"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"origin" "-1800 -144 -272"
+"light" "200"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"origin" "-1800 -144 -56"
+"light" "150"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-1952 -168 -384"
+"classname" "light"
+"light" "90"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2016 -168 -384"
+"classname" "light"
+"light" "90"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2080 -168 -384"
+"classname" "light"
+"light" "90"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2144 -168 -384"
+"classname" "light"
+"light" "90"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2208 -168 -384"
+"classname" "light"
+"light" "90"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2272 -136 -384"
+"classname" "light"
+"light" "90"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2272 -72 -384"
+"classname" "light"
+"light" "90"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2272 -8 -384"
+"classname" "light"
+"light" "90"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "90"
+"classname" "light"
+"origin" "-1888 -168 -384"
+}
+{
+"origin" "-1636 -162 -434"
+"_style" "5"
+"light" "300"
+"_color" "0.000000 1.000000 0.000000"
+"classname" "light"
+}
+{
+"model" "*99"
+"origin" "-1718 -214 -327"
+"message" "The gate is blocked by debris."
+"speed" "60"
+"angle" "180"
+"targetname" "pumpdoor"
+"classname" "func_door_rotating"
+"distance" "90"
+"wait" "-1"
+}
+{
+"model" "*100"
+"spawnflags" "2048"
+"mass" "200"
+"health" "20"
+"target" "pumpdoor"
+"classname" "func_explosive"
+"dmg" "1"
+}
+{
+"item" "ammo_bullets"
+"spawnflags" "1"
+"targetname" "t9"
+"target" "t1"
+"classname" "monster_tank_commander"
+"angle" "0"
+"origin" "-2032 -1560 32"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2696 -192 -152"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2712 -176 -152"
+}
+{
+"origin" "-2712 -96 -152"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2696 -80 -152"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-1832 -1400 312"
+"light" "200"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "300"
+"origin" "-1832 -1400 504"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "200"
+"origin" "-1832 -1400 696"
+}
+{
+"_color" "1.000000 0.576471 0.501961"
+"origin" "-2216 -1400 312"
+"light" "200"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "300"
+"origin" "-2216 -1400 504"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "200"
+"origin" "-2216 -1400 696"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2216 -1528 312"
+"light" "200"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "300"
+"origin" "-2216 -1528 504"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "300"
+"origin" "-2216 -1528 696"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2088 -1400 312"
+"classname" "light"
+"light" "200"
+}
+{
+"_color" "1.000000 0.576471 0.501961"
+"origin" "-1960 -1400 312"
+"classname" "light"
+"light" "200"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "300"
+"classname" "light"
+"origin" "-2088 -1400 504"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "300"
+"classname" "light"
+"origin" "-1960 -1400 504"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "200"
+"classname" "light"
+"origin" "-1960 -1400 696"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "200"
+"classname" "light"
+"origin" "-2088 -1400 696"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2168 -1264 1248"
+"light" "200"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2088 -1528 312"
+"classname" "light"
+"light" "200"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-1960 -1528 312"
+"classname" "light"
+"light" "200"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "300"
+"classname" "light"
+"origin" "-2088 -1528 504"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "300"
+"classname" "light"
+"origin" "-1960 -1528 504"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "300"
+"classname" "light"
+"origin" "-1960 -1528 696"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "300"
+"classname" "light"
+"origin" "-2088 -1528 696"
+}
+{
+"origin" "-2472 -1528 504"
+"light" "300"
+"classname" "light"
+"_color" "1.000000 0.576471 0.501961"
+}
+{
+"origin" "-2344 -1528 504"
+"light" "300"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-2088 -1272 504"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-1960 -1272 504"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-1832 -1528 504"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-1704 -1528 504"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-1576 -1528 520"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-2472 -1528 696"
+"light" "300"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-2344 -1528 696"
+"light" "300"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-2088 -1272 696"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-1960 -1272 696"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-1832 -1528 696"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-1704 -1528 696"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-1576 -1528 696"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-1816 -1272 1008"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2128 -1272 1008"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-1872 -1264 1144"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "300"
+"origin" "-1848 -1264 1024"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "300"
+"classname" "light"
+"origin" "-1576 -1528 376"
+"_color" "1.000000 0.576471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1704 -1528 312"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-2328 -1528 312"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1832 -1528 312"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1960 -1272 376"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-2088 -1272 344"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-1880 -752 53"
+"_color" "1.000000 0.853755 0.268775"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2688 -176 167"
+"_color" "1.000000 0.853755 0.268775"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-1912 -72 -384"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "70"
+"origin" "-1848 -72 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2272 72 -384"
+"classname" "light"
+"light" "90"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2232 120 -384"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2232 184 -384"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2296 120 -384"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"origin" "-2296 184 -384"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "0.826772 0.539370 1.000000"
+"origin" "-2520 -104 56"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "100"
+"classname" "light"
+"origin" "-2584 -104 56"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "100"
+"classname" "light"
+"origin" "-2648 -104 56"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2712 -104 56"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "100"
+"classname" "light"
+"origin" "-2776 -104 56"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2840 -104 56"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "0.826772 0.539370 1.000000"
+"origin" "-2904 -104 56"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2904 -40 56"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2904 24 56"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2904 88 56"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2904 152 56"
+"classname" "light"
+"light" "64"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "64"
+"classname" "light"
+"origin" "-2584 -104 216"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "64"
+"classname" "light"
+"origin" "-2648 -104 216"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2712 -104 216"
+"classname" "light"
+"light" "64"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "64"
+"classname" "light"
+"origin" "-2776 -104 216"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2840 -104 216"
+"classname" "light"
+"light" "64"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2904 -104 216"
+"classname" "light"
+"light" "64"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2904 -40 216"
+"classname" "light"
+"light" "64"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2904 24 216"
+"classname" "light"
+"light" "64"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2904 88 188"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2904 152 188"
+"classname" "light"
+"light" "100"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2708 136 -128"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2836 136 -128"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2708 104 8"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2580 104 8"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2900 104 8"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2708 104 64"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2580 104 64"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2836 104 64"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2900 104 64"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2708 104 160"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2580 104 160"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2836 104 160"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-2900 104 160"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2580 168 -224"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.620553 0.529644"
+"classname" "light"
+"light" "150"
+"origin" "-2324 168 -224"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2708 168 -224"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2836 168 -224"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2900 168 -224"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2580 104 224"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2708 104 224"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2836 104 224"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2900 104 196"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.620553 0.529644"
+"origin" "-2580 104 288"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2708 104 288"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2708 104 352"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.620553 0.529644"
+"origin" "-2900 104 352"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2636 104 504"
+"light" "200"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2708 104 448"
+"light" "200"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2796 104 448"
+"light" "200"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2580 104 512"
+"light" "300"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2708 104 512"
+"light" "300"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2836 104 512"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-2584 -104 152"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-2648 -104 152"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2712 -104 152"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-2776 -104 152"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "150"
+"classname" "light"
+"origin" "-2712 32 504"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2648 32 504"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-2584 32 504"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-2520 32 504"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2776 32 504"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2840 32 504"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2840 56 504"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2840 120 504"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2840 184 504"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2840 248 504"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-2872 312 504"
+"classname" "light"
+"light" "200"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-2840 568 376"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-2864 504 376"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-2880 504 376"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-2968 568 376"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-3032 504 376"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-2904 152 152"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2904 88 152"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2904 24 152"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2904 -40 152"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2904 -104 152"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2840 -104 152"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "70"
+"origin" "-2896 48 -352"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "70"
+"origin" "-2960 232 -152"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"light" "70"
+"classname" "light"
+"origin" "-2960 280 -152"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2808 120 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2808 184 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2808 232 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2360 184 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2424 184 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2488 184 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2616 184 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2552 184 -384"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2680 184 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2744 184 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "70"
+"origin" "-2296 232 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2360 232 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2360 120 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2424 232 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2424 120 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2488 232 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2488 120 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2552 232 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2552 120 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2616 232 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2616 120 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2680 232 -384"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2680 120 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"classname" "light"
+"light" "80"
+"origin" "-2744 232 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "80"
+"classname" "light"
+"origin" "-2744 120 -384"
+}
+{
+"_color" "0.615686 1.000000 0.894118"
+"light" "70"
+"classname" "light"
+"origin" "-2232 232 -384"
+}
+{
+"_color" "1.000000 0.733333 0.733333"
+"origin" "-2144 96 136"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-2144 160 136"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1920 96 136"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"_color" "1.000000 0.733333 0.733333"
+"origin" "-1920 160 136"
+"light" "100"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.733333 0.733333"
+"classname" "light"
+"light" "150"
+"origin" "-1880 288 248"
+}
+{
+"model" "*101"
+"_minlight" "0.2"
+"lip" "8"
+"wait" "4"
+"speed" "75"
+"angle" "180"
+"classname" "func_door"
+"team" "b"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.920949 0.343874"
+"origin" "-2032 32 -74"
+}
+{
+"target" "t278"
+"_cone" "20"
+"origin" "-2032 176 -78"
+"_color" "1.000000 0.920949 0.343874"
+"light" "200"
+"classname" "light"
+}
+{
+"_cone" "20"
+"target" "t277"
+"origin" "-2032 32 -78"
+"_color" "1.000000 0.920949 0.343874"
+"light" "200"
+"classname" "light"
+}
+{
+"model" "*102"
+"_minlight" "0.2"
+"team" "b"
+"lip" "8"
+"wait" "4"
+"sounds" "3"
+"speed" "75"
+"angle" "0"
+"classname" "func_door"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2464 -192 -152"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2448 -176 -152"
+}
+{
+"origin" "-2832 -24 -200"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2920 -208 -168"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2936 -192 -168"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2936 -80 -168"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2920 -64 -168"
+}
+{
+"origin" "-2464 -80 -152"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2448 -96 -152"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1360 688 440"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "180 -2332 336"
+"classname" "info_player_start"
+"angle" "180"
+"targetname" "unitstart"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-504 -1771 192"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "-624 -1889 192"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-382 -2130 512"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "-327 -1948 448"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-752 -1808 208"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "-744 -2288 448"
+"_color" "1.000000 0.976471 0.501961"
+}

--- a/stuff/mapfixes/baseq2/city2.ent
+++ b/stuff/mapfixes/baseq2/city2.ent
@@ -1,0 +1,6737 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Fixed an unreachable monster_floater (3908)
+//
+// His targetname, t54, is never targeted. I changed it to t295 instead, which
+// is targeted by target_crosslevel_target (680).
+// That way he is triggered by picking up the Data CD in Upper Palace (city3).
+//
+// 2. Fixed unused target_splash (4090)
+//
+// This splash was in the level but had no targetname. Gave it what I
+// believe is the one intended by the level creator ("py1").
+//
+// 3. Fixed inactive trigger_multiple (613) without a targetname
+//
+// Changed spawnflags from 2052 to 2048 to remove triggered flag.
+//
+// 4. Removed useless trigger_relay (3174, 3272)
+//
+// Set their spawnflags to 3840 so that they never spawn.
+{
+"nextmap" "city3"
+"sounds" "6"
+"sky" "unit9_"
+"spawnflags" "1792"
+"classname" "worldspawn"
+"message" "Lower Palace"
+}
+{
+"model" "*1"
+"classname" "func_wall"
+"spawnflags" "2048"
+"_minlight" "0.2"
+}
+{
+"model" "*2"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"origin" "216 -248 -680"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "216 -296 -680"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "-168 -440 -808"
+"spawnflags" "0"
+"classname" "item_pack"
+}
+{
+"origin" "40 -448 -808"
+"spawnflags" "1792"
+"classname" "item_armor_jacket"
+}
+{
+"origin" "-856 184 -568"
+"spawnflags" "1024"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-856 232 -568"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-856 136 -568"
+"spawnflags" "1536"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-688 24 -560"
+"spawnflags" "1792"
+"classname" "weapon_chaingun"
+}
+{
+"origin" "-720 -208 -592"
+"spawnflags" "1792"
+"classname" "item_armor_jacket"
+}
+{
+"origin" "360 -992 -928"
+"spawnflags" "1792"
+"classname" "ammo_cells"
+}
+{
+"origin" "360 -1040 -928"
+"spawnflags" "1792"
+"classname" "ammo_cells"
+}
+{
+"origin" "-480 -552 -936"
+"spawnflags" "1792"
+"classname" "weapon_shotgun"
+}
+{
+"origin" "-264 -880 -936"
+"classname" "weapon_hyperblaster"
+"spawnflags" "1792"
+}
+{
+"origin" "-208 -880 -936"
+"spawnflags" "1792"
+"classname" "ammo_cells"
+}
+{
+"classname" "ammo_grenades"
+"origin" "-70 -1014 -944"
+}
+{
+"origin" "-480 -1248 -688"
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+}
+{
+"origin" "-424 -1248 -688"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-864 -1240 -760"
+"spawnflags" "1792"
+"classname" "weapon_grenadelauncher"
+}
+{
+"origin" "160 -152 -816"
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+}
+{
+"origin" "-64 -144 -744"
+"spawnflags" "1792"
+"classname" "weapon_chaingun"
+}
+{
+"origin" "368 -1416 -944"
+"classname" "ammo_shells"
+}
+{
+"origin" "272 -1472 -944"
+"classname" "ammo_shells"
+}
+{
+"spawnflags" "1792"
+"origin" "360 -1472 -928"
+"classname" "weapon_shotgun"
+}
+{
+"classname" "item_health"
+"origin" "41 -1067 -944"
+"spawnflags" "2048"
+}
+{
+"origin" "376 -1184 -700"
+"classname" "ammo_cells"
+"spawnflags" "2048"
+}
+{
+"origin" "368 -1240 -696"
+"spawnflags" "1792"
+"classname" "weapon_chaingun"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-286 394 -464"
+"spawnflags" "2048"
+}
+{
+"origin" "-352 360 -472"
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+}
+{
+"classname" "target_speaker"
+"targetname" "t303"
+"noise" "world/spark7.wav"
+"attenuation" "3"
+"volume" "0.4"
+"origin" "168 -200 -728"
+}
+{
+"classname" "func_timer"
+"random" "1"
+"wait" "1.5"
+"target" "t303"
+"origin" "200 -216 -728"
+"spawnflags" "1"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "232 -328 -736"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "168 -328 -736"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-280 -328 -736"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-344 -328 -736"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-344 -424 -736"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-280 -424 -736"
+"classname" "light"
+"light" "32"
+}
+{
+"origin" "-544 16 -640"
+"spawnflags" "1792"
+"light" "80"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-896 -32 -380"
+"classname" "light"
+"light" "32"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-896 416 -380"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-896 352 -380"
+"classname" "light"
+"light" "32"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-896 224 -380"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-896 160 -380"
+"classname" "light"
+"light" "32"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-728 -16 -380"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-896 96 -400"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"targetname" "t82"
+"classname" "trigger_relay"
+"origin" "-924 0 -564"
+"spawnflags" "2304"
+"killtarget" "guntrigger"
+}
+{
+"model" "*3"
+"wait" "3"
+"targetname" "t4"
+"speed" "100"
+"angle" "-2"
+"_minlight" "0.2"
+"classname" "func_door"
+"lip" "16"
+}
+{
+"origin" "-416 -288 -816"
+"classname" "item_health_large"
+}
+{
+"origin" "-416 -224 -816"
+"spawnflags" "2048"
+"classname" "item_health_large"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-376 -296 -736"
+"classname" "light"
+"light" "32"
+}
+{
+"style" "32"
+"_color" "1.000000 0.948819 0.755906"
+"origin" "168 -200 -736"
+"classname" "light"
+"light" "150"
+"targetname" "t303"
+"spawnflags" "1"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "232 -200 -736"
+"classname" "light"
+"light" "32"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-376 -216 -736"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-280 -184 -736"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-344 -184 -736"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-280 -40 -752"
+"classname" "light"
+"light" "32"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-344 -40 -752"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"classname" "monster_soldier_ss"
+"spawnflags" "1536"
+"angle" "180"
+"origin" "-289 -984 -924"
+}
+{
+"classname" "monster_soldier_ss"
+"spawnflags" "1536"
+"targetname" "t13"
+"angle" "135"
+"origin" "-185 -529 -928"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+"origin" "280 -552 -832"
+}
+{
+"origin" "282 -656 -832"
+"classname" "ammo_rockets"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1792"
+"classname" "light"
+"light" "100"
+"origin" "-864 532 -532"
+}
+{
+"spawnflags" "769"
+"angle" "270"
+"classname" "monster_floater"
+"origin" "-16 124 -334"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "-172 -452 -328"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "-172 -500 -328"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "-168 -140 -328"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "-168 -92 -328"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "180 -736 -574"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "224 -736 -574"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "268 -736 -574"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_large"
+"origin" "268 -752 -614"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1024"
+"origin" "-20 -876 -620"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1536"
+"origin" "-64 -876 -620"
+}
+{
+"classname" "misc_deadsoldier"
+"origin" "-120 -864 -640"
+"spawnflags" "2052"
+"angle" "45"
+}
+{
+"spawnflags" "1024"
+"classname" "ammo_grenades"
+"origin" "-664 -864 -920"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1536"
+"origin" "-552 -856 -688"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+"origin" "160 -152 -800"
+}
+{
+"origin" "160 -192 -816"
+"classname" "ammo_bullets"
+}
+{
+"classname" "ammo_bullets"
+"origin" "160 -240 -816"
+"spawnflags" "3072"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "576 56 -872"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+"origin" "-408 -994 -696"
+}
+{
+"origin" "-24 -152 -712"
+"message" "Access Central Computer\nkeyboard to return\ndata spinner."
+"targetname" "t186"
+"classname" "target_help"
+}
+{
+"model" "*4"
+"wait" "3"
+"classname" "trigger_multiple"
+"target" "t301"
+}
+{
+"classname" "trigger_relay"
+"target" "t301"
+"targetname" "t46"
+"origin" "-480 -1432 -1064"
+}
+{
+"spawnflags" "3328"
+"speed" "1000"
+"origin" "-388 -1424 -1064"
+"angle" "180"
+"dmg" "20"
+"classname" "target_blaster"
+"targetname" "t46"
+}
+{
+"spawnflags" "2816"
+"speed" "1000"
+"origin" "-388 -1424 -1064"
+"angle" "180"
+"dmg" "25"
+"classname" "target_blaster"
+"targetname" "t46"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t279"
+"killtarget" "reminder"
+"origin" "0 -808 -536"
+}
+{
+"model" "*5"
+"classname" "trigger_multiple"
+"target" "t300"
+"targetname" "reminder"
+}
+{
+"origin" "0 632 -88"
+"targetname" "city2XH"
+"angle" "225"
+"classname" "info_player_coop"
+}
+{
+"origin" "-128 632 -88"
+"targetname" "city2XH"
+"angle" "315"
+"classname" "info_player_coop"
+}
+{
+"origin" "-64 488 -88"
+"targetname" "city2XH"
+"angle" "270"
+"classname" "info_player_coop"
+}
+{
+"origin" "304 160 -880"
+"targetname" "city2XL"
+"angle" "0"
+"classname" "info_player_coop"
+}
+{
+"origin" "304 224 -880"
+"targetname" "city2XL"
+"angle" "0"
+"classname" "info_player_coop"
+}
+{
+"origin" "248 192 -888"
+"targetname" "city2XL"
+"angle" "0"
+"classname" "info_player_coop"
+}
+{
+"targetname" "city2NL"
+"angle" "90"
+"origin" "-96 -1808 -1064"
+"classname" "info_player_coop"
+}
+{
+"targetname" "city2NL"
+"angle" "90"
+"origin" "-64 -1944 -1056"
+"classname" "info_player_coop"
+}
+{
+"targetname" "city2NL"
+"classname" "info_player_coop"
+"origin" "-32 -1808 -1064"
+"angle" "90"
+}
+{
+"targetname" "city2NH"
+"angle" "90"
+"origin" "-120 -1702 -808"
+"classname" "info_player_coop"
+}
+{
+"targetname" "city2NH"
+"angle" "90"
+"origin" "-96 -1918 -816"
+"classname" "info_player_coop"
+}
+{
+"targetname" "city2NH"
+"angle" "90"
+"origin" "-64 -1862 -800"
+"classname" "info_player_start"
+}
+{
+"model" "*6"
+"classname" "trigger_multiple"
+"spawnflags" "4"
+"target" "t302"
+"targetname" "reminder"
+}
+{
+"classname" "target_speaker"
+"noise" "world/v_cit1.wav"
+"origin" "-64 -1696 -1008"
+"attenuation" "-1"
+"targetname" "t302"
+}
+{
+"model" "*7"
+"spawnflags" "2048"
+"classname" "trigger_multiple"
+"target" "t5"
+}
+{
+"classname" "target_speaker"
+"targetname" "t298"
+"origin" "-384 -400 -592"
+"spawnflags" "2048"
+"noise" "world/voice5.wav"
+"attenuation" "-1"
+"volume" "0.7"
+}
+{
+"classname" "func_timer"
+"target" "t298"
+"attenuation" "-1"
+"random" "34"
+"wait" "120"
+"targetname" "t89"
+"origin" "-384 -368 -592"
+"spawnflags" "2049"
+}
+{
+"classname" "target_speaker"
+"targetname" "t297"
+"origin" "-352 -400 -592"
+"spawnflags" "2048"
+"noise" "world/v_fac3.wav"
+"attenuation" "-1"
+"volume" "0.7"
+}
+{
+"delay" "3"
+"classname" "func_timer"
+"target" "t297"
+"attenuation" "-1"
+"random" "100"
+"wait" "400"
+"targetname" "t89"
+"origin" "-352 -368 -592"
+"spawnflags" "2049"
+}
+{
+"model" "*8"
+"classname" "trigger_multiple"
+"wait" "30"
+"target" "t296"
+"spawnflags" "2048"
+}
+{
+"classname" "target_speaker"
+"noise" "world/v_cit2.wav"
+"attenuation" "-1"
+"targetname" "t296"
+"spawnflags" "2052"
+"origin" "-24 -456 -544"
+}
+{
+"targetname" "t228"
+"origin" "-256 24 -752"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"noise" "world/klaxon1.wav"
+}
+{
+"origin" "480 136 -896"
+"target" "t295"
+"spawnflags" "8"
+"classname" "target_crosslevel_target"
+}
+{
+"model" "*9"
+"targetname" "t295"
+"target" "t294"
+"spawnflags" "4"
+"classname" "trigger_once"
+}
+{
+"targetname" "t294"
+"origin" "520 -192 -816"
+"angle" "90"
+"classname" "target_spawner"
+"target" "monster_berserk"
+"spawnflags" "768"
+}
+{
+"targetname" "t294"
+"origin" "576 -176 -816"
+"angle" "90"
+"classname" "target_spawner"
+"target" "monster_berserk"
+"spawnflags" "256"
+}
+{
+"targetname" "t292"
+"deathtarget" "t57"
+"origin" "-94 -416 -416"
+"spawnflags" "3"
+"angle" "270"
+"classname" "monster_floater"
+}
+{
+"targetname" "t292"
+"classname" "monster_floater"
+"angle" "270"
+"spawnflags" "3"
+"origin" "-16 -416 -416"
+"deathtarget" "t57"
+}
+{
+"origin" "-904 264 -568"
+"targetname" "t292"
+"spawnflags" "259"
+"angle" "45"
+"classname" "monster_berserk"
+}
+{
+"origin" "-872 0 -568"
+"targetname" "t292"
+"spawnflags" "3"
+"angle" "45"
+"classname" "monster_berserk"
+}
+{
+"origin" "-56 -8 -376"
+"angle" "90"
+"targetname" "t292"
+"spawnflags" "3"
+"classname" "monster_tank_commander"
+}
+{
+"origin" "0 -200 -784"
+"targetname" "t293"
+"spawnflags" "1"
+"classname" "point_combat"
+}
+{
+"spawnflags" "2056"
+"origin" "32 -168 -672"
+"target" "t292"
+"classname" "target_crosslevel_target"
+}
+{
+"target" "t293"
+"origin" "32 -168 -768"
+"angle" "270"
+"targetname" "t292"
+"spawnflags" "3"
+"classname" "monster_tank_commander"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t290"
+"target" "t291"
+"delay" "2"
+"origin" "480 -144 -816"
+}
+{
+"volume" "0.8"
+"classname" "target_speaker"
+"spawnflags" "4"
+"attenuation" "-1"
+"noise" "world/deactivated.wav"
+"origin" "484 -144 -832"
+"targetname" "yfld"
+}
+{
+"model" "*10"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"model" "*11"
+"classname" "func_button"
+"angle" "90"
+"sounds" "4"
+"_minlight" "0.8"
+"target" "redfieldbutton"
+"lip" "4"
+"wait" "-1"
+"spawnflags" "2048"
+}
+{
+"model" "*12"
+"classname" "func_button"
+"angle" "180"
+"sounds" "4"
+"wait" "-1"
+"spawnflags" "2048"
+"_minlight" "0.8"
+"target" "yfld"
+}
+{
+"model" "*13"
+"classname" "func_wall"
+"spawnflags" "2048"
+"_minlight" "0.2"
+"target" "t290"
+}
+{
+"targetname" "rfld"
+"killtarget" "redmsg"
+"origin" "-177 -814 -924"
+"classname" "trigger_relay"
+}
+{
+"classname" "monster_brain"
+"angle" "315"
+"targetname" "brainguy"
+"origin" "480 -156 -848"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "45"
+"origin" "504 -48 -856"
+"item" "ammo_bullets"
+"spawnflags" "256"
+}
+{
+"classname" "point_combat"
+"origin" "304 -792 -624"
+"spawnflags" "2048"
+"targetname" "t289"
+}
+{
+"origin" "-184 -778 -846"
+"targetname" "redfieldbutton"
+"killtarget" "redforfld"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t148"
+"killtarget" "t182"
+"origin" "-32 -256 -768"
+"spawnflags" "2064"
+"classname" "target_crosslevel_trigger"
+}
+{
+"targetname" "t187"
+"classname" "trigger_relay"
+"origin" "-176 -192 -744"
+"killtarget" "t190"
+"spawnflags" "2048"
+}
+{
+"classname" "weapon_machinegun"
+"spawnflags" "1792"
+"origin" "-68 403 -66"
+}
+{
+"origin" "-280 -1024 -896"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-152 -840 -848"
+"targetname" "redfieldbutton"
+"target" "t288"
+"delay" "2"
+"classname" "trigger_relay"
+}
+{
+"classname" "info_player_intermission"
+"angles" "20 68 0"
+"origin" "-120 -456 -528"
+}
+{
+"model" "*14"
+"spawnflags" "2048"
+"targetname" "redmsg"
+"message" "This force field is\ndeactivated elsewhere."
+"classname" "trigger_multiple"
+"wait" "3"
+}
+{
+"spawnflags" "1792"
+"origin" "-64 -240 -920"
+"target" "t286"
+"angle" "90"
+"classname" "misc_teleporter"
+}
+{
+"model" "*15"
+"wait" "-1"
+"classname" "func_door"
+"angle" "90"
+"sounds" "2"
+"speed" "50"
+"_minlight" "0.1"
+"spawnflags" "2048"
+"targetname" "spg1"
+}
+{
+"spawnflags" "1792"
+"targetname" "t286"
+"origin" "-288 -744 -696"
+"angle" "225"
+"classname" "misc_teleporter_dest"
+}
+{
+"origin" "112 -1424 -874"
+"_color" "1.000000 0.796078 0.003922"
+"light" "48"
+"classname" "light"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "-8 -1784 -590"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-120 -1784 -590"
+"classname" "light"
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"_color" "1.000000 0.796078 0.003922"
+"light" "48"
+"classname" "light"
+"origin" "-120 -1480 -590"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-64 -1784 -590"
+}
+{
+"classname" "misc_teleporter_dest"
+"targetname" "t285"
+"spawnflags" "1792"
+"origin" "-144 -288 -328"
+"angle" "0"
+}
+{
+"model" "*16"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"model" "*17"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"classname" "misc_teleporter"
+"spawnflags" "1792"
+"origin" "-56 -1776 -920"
+"target" "t285"
+"angle" "180"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "128 -800 -880"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "192 -800 -880"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "256 -800 -880"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "320 -800 -880"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "320 -1184 -880"
+"classname" "light"
+"light" "64"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "320 -1120 -880"
+"classname" "light"
+"light" "64"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "320 -864 -880"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "320 -928 -880"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "320 -992 -880"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "320 -1056 -880"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "320 -1248 -880"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "320 -1120 -816"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"classname" "misc_teleporter"
+"target" "t283"
+"origin" "0 480 -88"
+"spawnflags" "1792"
+}
+{
+"classname" "misc_teleporter_dest"
+"spawnflags" "1792"
+"origin" "-480 472 -472"
+"targetname" "t284"
+"angle" "315"
+}
+{
+"classname" "misc_teleporter_dest"
+"angle" "135"
+"spawnflags" "1792"
+"origin" "360 -1248 -696"
+"targetname" "t283"
+}
+{
+"classname" "misc_teleporter"
+"spawnflags" "1792"
+"origin" "-64 -1096 -760"
+"target" "t284"
+}
+{
+"spawnflags" "1792"
+"classname" "misc_teleporter_dest"
+"targetname" "t282"
+"origin" "-420 -1668 -920"
+"angle" "135"
+}
+{
+"classname" "misc_teleporter"
+"angle" "0"
+"target" "t282"
+"origin" "480 -144 -864"
+"spawnflags" "1792"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"origin" "-938 -34 -568"
+}
+{
+"model" "*18"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_shells"
+"origin" "360 -656 -832"
+}
+{
+"classname" "item_health_large"
+"spawnflags" "2048"
+"origin" "320 -656 -816"
+}
+{
+"model" "*19"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"classname" "item_health_mega"
+"spawnflags" "1792"
+"origin" "-544 16 -672"
+}
+{
+"model" "*20"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*21"
+"classname" "func_door"
+"health" "5"
+"angle" "90"
+"spawnflags" "1792"
+}
+{
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+"origin" "-66 -426 -636"
+}
+{
+"classname" "item_armor_combat"
+"spawnflags" "1536"
+"origin" "-108 -846 -612"
+}
+{
+"classname" "item_armor_body"
+"spawnflags" "1792"
+"origin" "544 352 -826"
+}
+{
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.578740 0.003937"
+"origin" "544 352 -776"
+}
+{
+"model" "*22"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*23"
+"spawnflags" "1792"
+"angle" "-1"
+"health" "5"
+"classname" "func_door"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_shells"
+"origin" "632 -194 -872"
+}
+{
+"classname" "item_armor_jacket"
+"spawnflags" "1792"
+"origin" "70 -846 -938"
+}
+{
+"spawnflags" "2048"
+"origin" "-279 -1023 -944"
+"classname" "item_health"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_bullets"
+"origin" "-277 -1065 -944"
+}
+{
+"model" "*24"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*25"
+"lip" "8"
+"sounds" "2"
+"speed" "200"
+"wait" "3"
+"angle" "0"
+"classname" "func_door"
+"team" "traphider"
+"spawnflags" "1792"
+"health" "5"
+}
+{
+"model" "*26"
+"lip" "8"
+"classname" "func_door"
+"angle" "180"
+"wait" "3"
+"speed" "200"
+"sounds" "0"
+"team" "traphider"
+"spawnflags" "1792"
+"health" "5"
+}
+{
+"classname" "item_armor_combat"
+"spawnflags" "1792"
+"origin" "-898 520 -566"
+}
+{
+"model" "*27"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*28"
+"classname" "func_wall"
+"spawnflags" "1536"
+}
+{
+"model" "*29"
+"classname" "func_wall"
+"spawnflags" "1536"
+}
+{
+"classname" "ammo_grenades"
+"origin" "152 -32 -808"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_bullets"
+"origin" "-328 -576 -944"
+}
+{
+"classname" "weapon_railgun"
+"spawnflags" "1792"
+"origin" "-64 -1216 -800"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "1792"
+"origin" "-168 -1480 -968"
+}
+{
+"classname" "weapon_rocketlauncher"
+"spawnflags" "1792"
+"origin" "-56 -1416 -928"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1536"
+"origin" "-656 -728 -704"
+}
+{
+"classname" "item_health"
+"origin" "-408 -1038 -696"
+}
+{
+"classname" "weapon_hyperblaster"
+"origin" "-536 -728 -248"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_bullets"
+"origin" "-48 -864 -352"
+}
+{
+"spawnflags" "2048"
+"origin" "-92 -864 -352"
+"classname" "ammo_rockets"
+}
+{
+"classname" "ammo_rockets"
+"origin" "-92 -864 -304"
+"spawnflags" "1792"
+"team" "ammo1"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_grenadelauncher"
+"origin" "-112 -8 -384"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-16 -8 -384"
+}
+{
+"classname" "item_health"
+"spawnflags" "3584"
+"origin" "-140 468 -88"
+}
+{
+"classname" "item_health"
+"spawnflags" "3072"
+"origin" "12 468 -92"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb15.wav"
+"origin" "-48 688 120"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-104 696 126"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-24 696 126"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-24 584 126"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-104 584 126"
+}
+{
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.677165 0.003937"
+"origin" "-408 8 -330"
+}
+{
+"classname" "trigger_always"
+"target" "t14"
+"origin" "102 -636 -830"
+"spawnflags" "1792"
+}
+{
+"targetname" "t288"
+"spawnflags" "2052"
+"origin" "-167 -860 -849"
+"attenuation" "-1"
+"noise" "world/redforce.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "item_quad"
+"team" "q2best"
+"origin" "56 -280 -336"
+"spawnflags" "1792"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "232 -456 -808"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "0"
+"origin" "-416 -224 -808"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "225"
+"origin" "224 48 -680"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "0"
+"origin" "-208 -1200 -936"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "225"
+"origin" "-296 -136 -664"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "225"
+"origin" "352 -744 -616"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "24 -1728 -808"
+}
+{
+"spawnflags" "2052"
+"attenuation" "-1"
+"origin" "-72 -128 -696"
+"targetname" "spg2"
+"noise" "world/dataspin.wav"
+"classname" "target_speaker"
+}
+{
+"noise" "world/force1.wav"
+"origin" "320 -936 -568"
+"spawnflags" "2049"
+"targetname" "rfld"
+"classname" "target_speaker"
+}
+{
+"model" "*30"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-316 -856 -460"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-316 -856 -396"
+}
+{
+"origin" "-316 -856 -588"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-316 -856 -524"
+}
+{
+"model" "*31"
+"target" "t281"
+"targetname" "rfld"
+"spawnflags" "2052"
+"classname" "trigger_once"
+}
+{
+"spawnflags" "2048"
+"origin" "320 -784 -624"
+"targetname" "t280"
+"classname" "point_combat"
+}
+{
+"model" "*32"
+"spawnflags" "2054"
+"targetname" "redforfld"
+"classname" "func_wall"
+}
+{
+"model" "*33"
+"spawnflags" "2048"
+"message" "This force field is\ndeactivated elsewhere."
+"targetname" "redmsg"
+"classname" "trigger_multiple"
+"wait" "3"
+}
+{
+"origin" "0 -784 -584"
+"target" "t279"
+"spawnflags" "4"
+"classname" "target_crosslevel_target"
+}
+{
+"attenuation" "2"
+"noise" "world/spark5.wav"
+"origin" "-280 -824 -264"
+"classname" "target_speaker"
+"targetname" "t108"
+}
+{
+"origin" "-424 -808 -600"
+"wait" "1"
+"random" ".9"
+"spawnflags" "1"
+"classname" "func_timer"
+"target" "t108"
+}
+{
+"classname" "target_speaker"
+"origin" "-616 -824 -600"
+"noise" "world/spark5.wav"
+"attenuation" "2"
+"targetname" "t194"
+}
+{
+"classname" "func_timer"
+"target" "t194"
+"spawnflags" "1"
+"random" ".9"
+"wait" "1"
+"origin" "-616 -808 -600"
+}
+{
+"classname" "func_timer"
+"spawnflags" "2049"
+"wait" "2"
+"target" "t16"
+"origin" "222 -1219 -881"
+}
+{
+"origin" "-64 -1528 -862"
+"_color" "1.000000 0.799213 0.003937"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-64 -1464 -862"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.799213 0.003937"
+}
+{
+"origin" "-64 -1592 -862"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.799213 0.003937"
+}
+{
+"origin" "-64 -1400 -862"
+"_color" "1.000000 0.799213 0.003937"
+"light" "64"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "320 -1288 -808"
+"classname" "light"
+"light" "64"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "64 -800 -880"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "322 -536 -774"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "322 -608 -774"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-320 -800 -824"
+"classname" "light"
+"_color" "1.000000 0.384921 0.011905"
+"light" "64"
+}
+{
+"origin" "-312 -744 -824"
+"classname" "light"
+"_color" "1.000000 0.384921 0.011905"
+"light" "64"
+}
+{
+"origin" "-248 -744 -824"
+"classname" "light"
+"_color" "1.000000 0.384921 0.011905"
+"light" "64"
+}
+{
+"origin" "-168 -744 -824"
+"classname" "light"
+"_color" "1.000000 0.384921 0.011905"
+"light" "64"
+}
+{
+"origin" "-104 -744 -824"
+"classname" "light"
+"_color" "1.000000 0.384921 0.011905"
+"light" "64"
+}
+{
+"origin" "-320 -864 -824"
+"light" "64"
+"_color" "1.000000 0.384921 0.011905"
+"classname" "light"
+}
+{
+"origin" "-724 -848 -808"
+"classname" "light"
+"_color" "1.000000 0.250980 0.000000"
+"light" "64"
+}
+{
+"origin" "-722 -930 -806"
+"classname" "light"
+"_color" "1.000000 0.250980 0.000000"
+"light" "64"
+}
+{
+"origin" "-724 -1078 -816"
+"classname" "light"
+"_color" "1.000000 0.250980 0.000000"
+"light" "64"
+}
+{
+"origin" "-852 -1078 -816"
+"classname" "light"
+"_color" "1.000000 0.250980 0.000000"
+"light" "64"
+}
+{
+"origin" "-878 -996 -816"
+"classname" "light"
+"_color" "1.000000 0.250980 0.000000"
+"light" "64"
+}
+{
+"origin" "-878 -908 -816"
+"classname" "light"
+"_color" "1.000000 0.250980 0.000000"
+"light" "64"
+}
+{
+"origin" "-852 -778 -816"
+"classname" "light"
+"_color" "1.000000 0.250980 0.000000"
+"light" "64"
+}
+{
+"origin" "-724 -778 -816"
+"classname" "light"
+"_color" "1.000000 0.250980 0.000000"
+"light" "64"
+}
+{
+"origin" "-818 -894 -808"
+"light" "64"
+"_color" "1.000000 0.250980 0.000000"
+"classname" "light"
+}
+{
+"origin" "-448 -832 -546"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.850980 0.000000"
+}
+{
+"origin" "-448 -896 -546"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.850980 0.000000"
+}
+{
+"origin" "-448 -960 -546"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.850980 0.000000"
+}
+{
+"origin" "-448 -1024 -546"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.850980 0.000000"
+}
+{
+"origin" "-448 -768 -546"
+"_color" "1.000000 0.850980 0.000000"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-544 288 -456"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-544 488 -456"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-272 488 -330"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-272 384 -330"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-272 200 -330"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-272 280 -330"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-432 280 -330"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-376 120 -330"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-248 120 -330"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-432 488 -330"
+"light" "64"
+"classname" "light"
+}
+{
+"classname" "monster_floater"
+"angle" "0"
+"spawnflags" "257"
+"origin" "-310 -560 -630"
+"deathtarget" "t57"
+}
+{
+"spawnflags" "2048"
+"classname" "target_secret"
+"targetname" "py1"
+"message" "You have found a secret."
+"origin" "34 -1114 -618"
+}
+{
+"model" "*34"
+"classname" "trigger_once"
+"target" "t155"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"classname" "target_help"
+"targetname" "t148"
+"origin" "-16 -312 -792"
+"message" "Shut down communication\nlaser in Upper Palace."
+}
+{
+"classname" "misc_explobox"
+"origin" "-36 -1484 -976"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-304 -68 -784"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-304 -132 -784"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-304 -196 -784"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-304 -260 -784"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-304 -324 -784"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-304 -388 -784"
+"classname" "light"
+"light" "70"
+}
+{
+"light" "70"
+"classname" "light"
+"origin" "-304 -4 -784"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"origin" "-260 -384 -824"
+"targetname" "t273"
+"classname" "info_null"
+}
+{
+"spawnflags" "2048"
+"targetname" "t265"
+"origin" "24 -360 -808"
+"classname" "point_combat"
+}
+{
+"spawnflags" "2048"
+"target" "t265"
+"origin" "168 -392 -808"
+"targetname" "t264"
+"classname" "point_combat"
+}
+{
+"spawnflags" "2048"
+"origin" "-72 -488 -456"
+"target" "t263"
+"targetname" "t262"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "-152 -280 -456"
+"target" "t262"
+"targetname" "t261"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "-56 -152 -456"
+"target" "t261"
+"targetname" "t260"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "40 -232 -456"
+"targetname" "t263"
+"target" "t260"
+"classname" "path_corner"
+}
+{
+"origin" "264 -808 -536"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"light" "80"
+"classname" "light"
+"origin" "212 -808 -536"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"light" "80"
+"classname" "light"
+"origin" "264 -764 -536"
+}
+{
+"origin" "368 -792 -536"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"light" "80"
+"classname" "light"
+"origin" "212 -764 -536"
+}
+{
+"origin" "316 -836 -536"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "100"
+"origin" "-184 -288 -616"
+"classname" "light"
+"_color" "1.000000 0.255906 0.003937"
+}
+{
+"light" "100"
+"origin" "-184 -288 -752"
+"classname" "light"
+"_color" "1.000000 0.255906 0.003937"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-64 -392 -752"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-64 -392 -792"
+}
+{
+"model" "*35"
+"_minlight" "0.3"
+"target" "t4"
+"classname" "func_button"
+"angle" "270"
+"lip" "3"
+}
+{
+"model" "*36"
+"wait" "5"
+"target" "t4"
+"delay" "1"
+"classname" "trigger_multiple"
+"spawnflags" "0"
+}
+{
+"origin" "-64 -360 -720"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-64 -432 -816"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-64 -348 -368"
+"light" "125"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "85"
+"origin" "-136 -348 -304"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-88 -348 -256"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-40 -348 -256"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "8 -348 -304"
+"light" "85"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-40 -356 -368"
+"light" "125"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "85"
+"origin" "8 -156 -304"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "125"
+"origin" "-40 -164 -368"
+}
+{
+"_color" "1.000000 0.658824 0.576471"
+"origin" "-136 -156 -304"
+"light" "85"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "125"
+"origin" "-64 -156 -368"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-40 -220 -256"
+"light" "125"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "85"
+"origin" "8 -220 -304"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "100"
+"origin" "-40 -228 -368"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-88 -220 -256"
+"light" "125"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-136 -220 -304"
+"light" "85"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "125"
+"origin" "-64 -220 -368"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "85"
+"origin" "8 -412 -304"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "125"
+"origin" "-40 -420 -368"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-136 -412 -304"
+"light" "85"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "125"
+"origin" "-64 -412 -368"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-40 -284 -256"
+"light" "125"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.658824 0.576471"
+"classname" "light"
+"light" "85"
+"origin" "8 -284 -304"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "125"
+"origin" "-40 -292 -368"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-88 -284 -256"
+"light" "125"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.658824 0.576471"
+"origin" "-136 -284 -304"
+"light" "85"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "125"
+"origin" "-64 -284 -368"
+}
+{
+"spawnflags" "2048"
+"target" "t253"
+"targetname" "t214"
+"origin" "-476 -1208 -600"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"target" "t252"
+"targetname" "t214"
+"classname" "trigger_relay"
+"origin" "-476 -1164 -600"
+}
+{
+"model" "*37"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t251"
+}
+{
+"origin" "-277 -1065 -912"
+"classname" "ammo_shells"
+"spawnflags" "1792"
+}
+{
+"model" "*38"
+"classname" "trigger_once"
+"delay" "0.5"
+"target" "t250"
+}
+{
+"target" "t247"
+"origin" "48 -528 -528"
+"wait" "7"
+"random" "5"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"targetname" "t247"
+"origin" "48 -492 -528"
+"volume" "0.12"
+"attenuation" "1"
+"noise" "world/battle5.wav"
+"classname" "target_speaker"
+}
+{
+"target" "t248"
+"origin" "32 -528 -528"
+"wait" "20"
+"random" "10"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"targetname" "t248"
+"origin" "32 -492 -528"
+"volume" "0.2"
+"attenuation" "1"
+"noise" "world/battle5.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-4 -576 -528"
+"target" "t244"
+"wait" "12"
+"random" "10"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"origin" "-4 -540 -528"
+"targetname" "t244"
+"volume" "0.35"
+"attenuation" "1"
+"noise" "world/battle5.wav"
+"classname" "target_speaker"
+}
+{
+"target" "t249"
+"origin" "16 -528 -528"
+"classname" "func_timer"
+"spawnflags" "1"
+"random" "12"
+"wait" "35"
+}
+{
+"targetname" "t249"
+"origin" "16 -492 -528"
+"classname" "target_speaker"
+"noise" "world/battle5.wav"
+"attenuation" "1"
+"volume" "0.35"
+}
+{
+"origin" "-76 -452 -420"
+"target" "t245"
+"classname" "func_timer"
+"spawnflags" "1"
+"random" "8"
+"wait" "16"
+}
+{
+"origin" "-76 -416 -420"
+"targetname" "t245"
+"classname" "target_speaker"
+"noise" "world/battle5.wav"
+"attenuation" "1"
+"volume" "0.6"
+}
+{
+"origin" "-128 -528 -528"
+"volume" "0.4"
+"attenuation" "1"
+"noise" "world/battle5.wav"
+"targetname" "t243"
+"classname" "target_speaker"
+}
+{
+"origin" "-128 -564 -528"
+"wait" "15"
+"random" "10"
+"spawnflags" "1"
+"target" "t243"
+"classname" "func_timer"
+}
+{
+"model" "*39"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"origin" "-64 -640 -388"
+"targetname" "t241"
+"classname" "info_notnull"
+}
+{
+"style" "33"
+"light" "175"
+"targetname" "t242"
+"_cone" "25"
+"origin" "-64 -640 -308"
+"target" "t241"
+"classname" "light"
+}
+{
+"spawnflags" "0"
+"target" "t242"
+"origin" "-64 -640 -368"
+"classname" "item_invulnerability"
+"team" "q2best"
+}
+{
+"origin" "-144 -744 -904"
+"delay" "1"
+"dmg" "1"
+"targetname" "rfld"
+"classname" "target_explosion"
+}
+{
+"classname" "weapon_shotgun"
+"origin" "-279 -1023 -912"
+"spawnflags" "1792"
+}
+{
+"model" "*40"
+"targetname" "guntrigger"
+"spawnflags" "2304"
+"target" "trap_gun"
+"delay" ".5"
+"wait" ".8"
+"classname" "trigger_multiple"
+}
+{
+"origin" "-108 -116 -684"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2"
+}
+{
+"origin" "-12 -116 -684"
+"noise" "world/comp_hum2"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"model" "*41"
+"_minlight" "0.5"
+"classname" "func_wall"
+}
+{
+"model" "*42"
+"spawnflags" "2048"
+"_minlight" "0.6"
+"targetname" "py1"
+"dmg" "1"
+"mass" "100"
+"classname" "func_explosive"
+}
+{
+"model" "*43"
+"target" "t240"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "-832 -1024 -936"
+"targetname" "t239"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"origin" "-736 -816 -920"
+"targetname" "t240"
+"spawnflags" "1025"
+"angle" "180"
+"classname" "monster_soldier"
+}
+{
+"origin" "-608 -856 -920"
+"targetname" "t240"
+"spawnflags" "769"
+"angle" "180"
+"classname" "monster_soldier"
+}
+{
+"origin" "-840 -840 -920"
+"spawnflags" "1"
+"target" "t239"
+"targetname" "t238"
+"angle" "270"
+"classname" "monster_soldier"
+}
+{
+"angle" "270"
+"spawnflags" "257"
+"origin" "-288 -984 -936"
+"classname" "monster_berserk"
+}
+{
+"origin" "-56 -1424 -960"
+"classname" "monster_soldier_light"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "1536"
+"origin" "-86 -1248 -936"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "1024"
+"origin" "-126 -1248 -936"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "0"
+"origin" "-166 -1248 -936"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "0"
+"origin" "-206 -1248 -936"
+}
+{
+"light" "80"
+"classname" "light"
+"_color" "1.000000 0.920949 0.343874"
+"origin" "-92 -1678 -938"
+}
+{
+"spawnflags" "2048"
+"classname" "target_goal"
+"targetname" "t189"
+"origin" "56 -160 -752"
+}
+{
+"spawnflags" "2048"
+"classname" "target_goal"
+"targetname" "t187"
+"origin" "-184 -160 -752"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "328 -1000 -560"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "328 -1056 -560"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "320 -1120 -536"
+"classname" "light"
+"light" "150"
+}
+{
+"model" "*44"
+"_minlight" "0.2"
+"speed" "35"
+"classname" "func_door"
+"spawnflags" "2049"
+"angle" "-2"
+"sounds" "1"
+"targetname" "spg2"
+"wait" "-1"
+}
+{
+"style" "1"
+"targetname" "t79"
+"classname" "func_areaportal"
+}
+{
+"origin" "-64 -1208 -936"
+"angle" "135"
+"spawnflags" "257"
+"classname" "monster_soldier"
+"targetname" "t251"
+}
+{
+"target" "t5"
+"origin" "-16 -1224 -928"
+"angle" "0"
+"spawnflags" "1"
+"classname" "monster_soldier"
+"targetname" "t251"
+}
+{
+"classname" "misc_explobox"
+"origin" "-108 -1516 -976"
+}
+{
+"origin" "-144 -744 -920"
+"volume" "1"
+"attenuation" "1"
+"noise" "world/explod2.wav"
+"targetname" "rfld"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2048"
+"target" "t228"
+"targetname" "t222"
+"classname" "trigger_relay"
+"killtarget" "t224"
+"origin" "288 200 -848"
+}
+{
+"spawnflags" "2048"
+"origin" "-8 608 -56"
+"target" "t228"
+"targetname" "t225"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"origin" "-64 600 32"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"origin" "-64 -24 -320"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"classname" "target_speaker"
+"origin" "-80 264 -424"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"origin" "-408 360 -424"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"origin" "-856 368 -512"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"origin" "-896 -8 -512"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"classname" "target_speaker"
+"origin" "-680 -184 -544"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"classname" "target_speaker"
+"origin" "-328 -192 -624"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"classname" "target_speaker"
+"origin" "-320 -488 -624"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"classname" "target_speaker"
+"origin" "-48 -464 -576"
+}
+{
+"targetname" "t228"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"origin" "-64 -312 -728"
+}
+{
+"spawnflags" "2048"
+"origin" "-112 584 -72"
+"killtarget" "t222"
+"targetname" "t225"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "312 224 -848"
+"killtarget" "t224"
+"targetname" "t222"
+"classname" "trigger_relay"
+}
+{
+"origin" "0 576 -40"
+"target" "t224"
+"classname" "target_crosslevel_target"
+"spawnflags" "2056"
+"delay" "0.1"
+}
+{
+"model" "*45"
+"target" "t225"
+"targetname" "t224"
+"classname" "trigger_once"
+"spawnflags" "2052"
+}
+{
+"target" "t221"
+"classname" "target_crosslevel_target"
+"spawnflags" "2056"
+"delay" "0.1"
+"origin" "344 216 -840"
+}
+{
+"model" "*46"
+"target" "t222"
+"targetname" "t221"
+"spawnflags" "2052"
+"classname" "trigger_once"
+}
+{
+"targetname" "t228"
+"origin" "-64 216 -272"
+"classname" "target_speaker"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+}
+{
+"targetname" "t228"
+"origin" "208 -256 -792"
+"classname" "target_speaker"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+}
+{
+"targetname" "t228"
+"origin" "352 -96 -792"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"noise" "world/klaxon1.wav"
+}
+{
+"targetname" "t228"
+"origin" "616 168 -840"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"noise" "world/klaxon1.wav"
+}
+{
+"targetname" "t228"
+"origin" "-64 -160 -712"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"model" "*47"
+"target" "t218"
+"targetname" "t214"
+"classname" "trigger_counter"
+"spawnflags" "2049"
+"count" "2"
+}
+{
+"targetname" "t218"
+"origin" "350 -1014 -640"
+"spawnflags" "257"
+"angle" "270"
+"classname" "monster_berserk"
+}
+{
+"origin" "-800 -1534 -848"
+"targetname" "t216"
+"target" "t215"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-784 -1552 -848"
+"targetname" "t217"
+"target" "t215"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-840 -1544 -848"
+"targetname" "t215"
+"classname" "monster_berserk"
+"spawnflags" "256"
+}
+{
+"model" "*48"
+"targetname" "t252"
+"target" "t216"
+"count" "4"
+"spawnflags" "2049"
+"classname" "trigger_counter"
+}
+{
+"spawnflags" "2048"
+"origin" "-392 -1212 -640"
+"target" "t214"
+"targetname" "t70"
+"classname" "trigger_relay"
+}
+{
+"style" "2"
+"classname" "func_areaportal"
+"targetname" "t213"
+}
+{
+"style" "3"
+"classname" "func_areaportal"
+"targetname" "t212"
+}
+{
+"style" "4"
+"classname" "func_areaportal"
+"targetname" "t211"
+}
+{
+"style" "5"
+"classname" "func_areaportal"
+"targetname" "t210"
+}
+{
+"style" "6"
+"classname" "func_areaportal"
+"targetname" "t209"
+}
+{
+"model" "*49"
+"classname" "func_door"
+"angle" "180"
+"team" "comp3"
+"_minlight" "0.2"
+}
+{
+"model" "*50"
+"classname" "func_door"
+"angle" "0"
+"team" "comp3"
+"_minlight" "0.2"
+"target" "t211"
+}
+{
+"model" "*51"
+"classname" "func_door"
+"angle" "270"
+"team" "comp1"
+"_minlight" "0.2"
+}
+{
+"model" "*52"
+"classname" "func_door"
+"angle" "90"
+"team" "comp1"
+"_minlight" "0.2"
+"target" "t210"
+}
+{
+"model" "*53"
+"team" "comp4"
+"angle" "0"
+"classname" "func_door"
+"_minlight" "0.2"
+"target" "t213"
+}
+{
+"model" "*54"
+"team" "comp4"
+"angle" "180"
+"classname" "func_door"
+"_minlight" "0.2"
+}
+{
+"model" "*55"
+"classname" "func_door"
+"angle" "90"
+"team" "comp2"
+"_minlight" "0.2"
+}
+{
+"model" "*56"
+"classname" "func_door"
+"angle" "270"
+"team" "comp2"
+"_minlight" "0.2"
+"target" "t209"
+}
+{
+"spawnflags" "2048"
+"targetname" "t206"
+"origin" "320 -1092 -696"
+"classname" "point_combat"
+}
+{
+"origin" "352 -1048 -664"
+"targetname" "t205"
+"target" "t146"
+"delay" "3"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"model" "*57"
+"spawnflags" "2048"
+"target" "t205"
+"classname" "trigger_once"
+}
+{
+"target" "t206"
+"targetname" "t205"
+"origin" "298 -1014 -644"
+"angle" "270"
+"spawnflags" "1"
+"classname" "monster_berserk"
+}
+{
+"model" "*58"
+"target" "t21"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"wait" "3"
+"origin" "-56 -1196 -808"
+"target" "t202"
+"targetname" "t201"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"wait" "3"
+"origin" "-56 -1252 -808"
+"target" "t199"
+"targetname" "t198"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "324 -1192 -712"
+"target" "t203"
+"targetname" "t202"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "324 -1248 -712"
+"target" "t200"
+"targetname" "t199"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"wait" "3"
+"origin" "-24 -1196 -808"
+"target" "t204"
+"targetname" "t203"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"wait" "3"
+"origin" "-24 -1252 -808"
+"target" "t197"
+"targetname" "t200"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "-380 -1192 -712"
+"targetname" "t204"
+"target" "t201"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "-380 -1248 -712"
+"target" "t198"
+"targetname" "t197"
+"classname" "path_corner"
+}
+{
+"origin" "-420 -1240 -676"
+"angle" "0"
+"target" "t197"
+"classname" "monster_soldier"
+}
+{
+"origin" "-420 -1196 -676"
+"angle" "0"
+"target" "t204"
+"classname" "monster_soldier"
+"spawnflags" "256"
+}
+{
+"target" "t214"
+"targetname" "t70"
+"origin" "-692 -1180 -760"
+"angle" "0"
+"classname" "monster_soldier_ss"
+"spawnflags" "1"
+}
+{
+"target" "t214"
+"targetname" "t70"
+"origin" "-692 -1244 -752"
+"angle" "0"
+"classname" "monster_soldier_ss"
+"spawnflags" "1"
+}
+{
+"target" "t214"
+"targetname" "t70"
+"spawnflags" "257"
+"classname" "monster_soldier_ss"
+"angle" "0"
+"origin" "-728 -1188 -772"
+}
+{
+"target" "t214"
+"targetname" "t70"
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+"angle" "0"
+"origin" "-728 -1240 -772"
+}
+{
+"origin" "-448 -928 -872"
+"targetname" "rfld"
+"classname" "target_speaker"
+"noise" "world/force2.wav"
+"spawnflags" "0"
+}
+{
+"origin" "-608 -1208 -1064"
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "769"
+"targetname" "rfld"
+"origin" "-452 -1480 -928"
+"angle" "270"
+"classname" "monster_tank_commander"
+}
+{
+"origin" "-136 -848 -928"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_soldier"
+}
+{
+"origin" "-233 -761 -944"
+"classname" "item_health_large"
+}
+{
+"origin" "-336 -536 -944"
+"classname" "item_health"
+}
+{
+"origin" "-416 -568 -936"
+"classname" "ammo_shells"
+"spawnflags" "1792"
+}
+{
+"origin" "-296 -536 -944"
+"classname" "item_health"
+}
+{
+"origin" "232 -1400 -914"
+"_color" "1.000000 0.920949 0.343874"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "136 -1400 -914"
+"_color" "1.000000 0.920949 0.343874"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "24 -1400 -914"
+"_color" "1.000000 0.920949 0.343874"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-64 -1400 -914"
+"_color" "1.000000 0.920949 0.343874"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-64 -1464 -914"
+"_color" "1.000000 0.920949 0.343874"
+"classname" "light"
+"light" "150"
+}
+{
+"classname" "target_speaker"
+"noise" "world/klaxon1.wav"
+"attenuation" "3"
+"volume" "0.5"
+"origin" "-488 -1416 -1064"
+"spawnflags" "2048"
+"targetname" "t301"
+}
+{
+"origin" "-364 466 -464"
+"classname" "item_health"
+}
+{
+"origin" "-424 468 -464"
+"classname" "item_health"
+}
+{
+"origin" "-296 478 -464"
+"classname" "item_armor_jacket"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1792"
+"origin" "-286 394 -424"
+"classname" "ammo_shells"
+}
+{
+"origin" "-374 -800 -312"
+"targetname" "t181"
+"spawnflags" "2049"
+"noise" "world/force1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "220 -60 -752"
+"target" "t192"
+"targetname" "sd2"
+"classname" "trigger_relay"
+}
+{
+"origin" "238 -60 -752"
+"target" "t191"
+"delay" "8.5"
+"targetname" "sd2"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t192"
+"origin" "198 12 -752"
+"attenuation" "1"
+"volume" "0.9"
+"noise" "world/lite_on1.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t191"
+"volume" "0.9"
+"noise" "world/lite_out.wav"
+"origin" "198 -16 -750"
+"attenuation" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "item_health"
+"origin" "632 -232 -872"
+}
+{
+"origin" "40 -1568 -816"
+"classname" "item_health"
+}
+{
+"spawnflags" "3584"
+"origin" "48 -1696 -816"
+"classname" "item_health"
+}
+{
+"origin" "-168 -1568 -816"
+"classname" "ammo_shells"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-100 -92 -384"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-28 -92 -384"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-100 -92 -448"
+"light" "100"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-28 -92 -448"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-100 -284 -384"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-100 -284 -448"
+"light" "125"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-28 -284 -384"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-28 -284 -448"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-100 -476 -384"
+"light" "100"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "100"
+"origin" "-100 -476 -448"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-28 -476 -448"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-28 -476 -384"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-28 -92 -320"
+"light" "125"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-28 -284 -320"
+"light" "100"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "100"
+"origin" "-100 -476 -320"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-28 -476 -320"
+"light" "100"
+"classname" "light"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-316 -856 -332"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-316 -856 -652"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "180"
+"origin" "-540 -1232 -1048"
+}
+{
+"classname" "item_adrenaline"
+"origin" "-328 -1368 -1056"
+"spawnflags" "2048"
+}
+{
+"classname" "item_armor_shard"
+"origin" "232 -336 -816"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "2048"
+"classname" "target_goal"
+"targetname" "t148"
+"origin" "-16 -280 -788"
+}
+{
+"origin" "-152 -776 -888"
+"targetname" "redfieldbutton"
+"volume" "0.3"
+"attenuation" "3"
+"noise" "world/comp_hum1"
+"spawnflags" "2049"
+"classname" "target_speaker"
+}
+{
+"origin" "440 -200 -824"
+"targetname" "yfld"
+"noise" "world/l_hum1.wav"
+"spawnflags" "2049"
+"classname" "target_speaker"
+}
+{
+"origin" "232 -296 -816"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "232 -384 -816"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"classname" "ammo_shells"
+"origin" "-336 -368 -816"
+}
+{
+"spawnflags" "2048"
+"target" "t184"
+"targetname" "t187"
+"classname" "trigger_relay"
+"origin" "-144 -192 -744"
+}
+{
+"spawnflags" "3840"
+"targetname" "t187"
+"classname" "trigger_relay"
+"origin" "-136 -216 -744"
+}
+{
+"origin" "56 -200 -744"
+"target" "t184"
+"targetname" "t189"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"target" "t190"
+"origin" "24 -200 -744"
+"targetname" "t189"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"killtarget" "t188"
+"origin" "40 -232 -744"
+"targetname" "t189"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"target" "t188"
+"origin" "-160 -200 -744"
+"targetname" "t187"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-160 -240 -728"
+"message" "Obtain the Data CD\nfrom the Upper Palace."
+"targetname" "t188"
+"classname" "target_help"
+}
+{
+"message" "Insert Data Spinner\nin next console."
+"targetname" "t190"
+"origin" "-16 -160 -608"
+"classname" "target_help"
+"spawnflags" "2048"
+}
+{
+"origin" "-88 -176 -752"
+"target" "spg1"
+"delay" "2"
+"targetname" "spg"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-72 -168 -744"
+"target" "spg2"
+"delay" "3"
+"targetname" "spg"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"model" "*59"
+"targetname" "t186"
+"lip" "4"
+"sounds" "1"
+"angle" "90"
+"wait" "-1"
+"spawnflags" "2056"
+"classname" "func_door"
+}
+{
+"spawnflags" "2048"
+"targetname" "2nd message"
+"classname" "trigger_relay"
+"origin" "-4 -92 -724"
+"message" "Access keyboard\nto return Data Spinner."
+"delay" "3"
+}
+{
+"spawnflags" "2048"
+"target" "2nd message"
+"delay" "3"
+"message" "Data Spinner\n is now reprogrammed."
+"origin" "-24 -92 -700"
+"targetname" "t186"
+"classname" "trigger_relay"
+}
+{
+"model" "*60"
+"target" "t186"
+"targetname" "t184"
+"count" "2"
+"classname" "trigger_counter"
+"spawnflags" "2049"
+}
+{
+"origin" "-84 -224 -680"
+"target" "t185"
+"classname" "trigger_relay"
+"spawnflags" "3840"
+}
+{
+"origin" "-44 -224 -680"
+"target" "t185"
+"targetname" "t148"
+"classname" "trigger_relay"
+}
+{
+"origin" "-60 -132 -748"
+"targetname" "t148"
+"killtarget" "t182"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"target" "t187"
+"message" "Data Spinner inserted for reprogramming."
+"item" "key_data_spinner"
+"origin" "-132 -156 -740"
+"targetname" "t182"
+"classname" "trigger_key"
+}
+{
+"spawnflags" "2048"
+"target" "t189"
+"message" "New program accepted."
+"item" "key_data_cd"
+"origin" "36 -176 -756"
+"targetname" "t183"
+"classname" "trigger_key"
+}
+{
+"model" "*61"
+"spawnflags" "2048"
+"target" "t182"
+"classname" "trigger_multiple"
+}
+{
+"model" "*62"
+"spawnflags" "2048"
+"target" "t183"
+"classname" "trigger_multiple"
+}
+{
+"model" "*63"
+"health" "5"
+"spawnflags" "3840"
+"_minlight" "0.1"
+"speed" "50"
+"sounds" "2"
+"angle" "90"
+"classname" "func_door"
+"wait" "3"
+}
+{
+"origin" "-874 -1170 -778"
+"classname" "item_health"
+}
+{
+"classname" "target_crosslevel_target"
+"target" "t181"
+"spawnflags" "2050"
+"origin" "-320 -784 -328"
+}
+{
+"classname" "target_crosslevel_trigger"
+"spawnflags" "2064"
+"targetname" "t148"
+"origin" "-8 -256 -768"
+}
+{
+"model" "*64"
+"classname" "trigger_once"
+"target" "t180"
+"spawnflags" "2048"
+}
+{
+"model" "*65"
+"classname" "trigger_once"
+"target" "t180"
+"spawnflags" "2048"
+}
+{
+"origin" "-834 -1170 -778"
+"classname" "item_health"
+}
+{
+"origin" "-848 -806 -926"
+"angle" "315"
+"classname" "info_player_deathmatch"
+}
+{
+"classname" "monster_tank_commander"
+"angle" "270"
+"spawnflags" "257"
+"item" "ammo_bullets"
+"origin" "-712 0 -584"
+}
+{
+"classname" "monster_tank_commander"
+"angle" "270"
+"item" "ammo_rockets"
+"spawnflags" "257"
+"origin" "216 24 -680"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "1.000000 1.000000 0.874510"
+"origin" "-64 504 120"
+}
+{
+"origin" "-64 504 112"
+"_color" "1.000000 1.000000 1.000000"
+"light" "300"
+"classname" "light"
+"_cone" "20"
+"target" "t164"
+}
+{
+"origin" "-64 504 -100"
+"classname" "info_notnull"
+"targetname" "t164"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "1.000000 1.000000 0.874510"
+"origin" "-64 584 120"
+}
+{
+"origin" "-64 584 112"
+"_color" "1.000000 1.000000 1.000000"
+"light" "300"
+"classname" "light"
+"_cone" "20"
+"target" "t163"
+}
+{
+"origin" "-64 584 -100"
+"classname" "info_notnull"
+"targetname" "t163"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "1.000000 1.000000 0.874510"
+"origin" "-64 696 120"
+}
+{
+"origin" "-64 696 112"
+"_color" "1.000000 1.000000 1.000000"
+"light" "300"
+"classname" "light"
+"_cone" "20"
+"target" "t162"
+}
+{
+"origin" "-64 696 -100"
+"classname" "info_notnull"
+"targetname" "t162"
+}
+{
+"origin" "-68 355 -82"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-84 -60 -384"
+"classname" "item_health_large"
+"spawnflags" "2048"
+}
+{
+"target" "t214"
+"targetname" "t70"
+"item" "ammo_bullets"
+"origin" "-792 -1188 -772"
+"angle" "0"
+"classname" "monster_soldier_ss"
+"spawnflags" "513"
+}
+{
+"target" "t214"
+"targetname" "t70"
+"origin" "-792 -1240 -772"
+"angle" "0"
+"classname" "monster_soldier_ss"
+"spawnflags" "257"
+}
+{
+"origin" "-64 -1432 -824"
+"targetname" "t160"
+"classname" "info_notnull"
+}
+{
+"origin" "-64 -1432 -612"
+"target" "t160"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "616 80 -872"
+"classname" "item_health"
+}
+{
+"origin" "496 72 -864"
+"classname" "ammo_bullets"
+"spawnflags" "1536"
+}
+{
+"origin" "-862 -1630 -856"
+"angle" "45"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-132 -888 -936"
+"angle" "135"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-204 -1194 -936"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "-46 -1248 -936"
+"spawnflags" "1536"
+"classname" "item_health_small"
+}
+{
+"origin" "-62 -1810 -1064"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "372 -632 -920"
+"angle" "180"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "14 -1026 -944"
+"classname" "item_health"
+}
+{
+"spawnflags" "1792"
+"origin" "-158 -1078 -928"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "42 -1647 -958"
+"classname" "item_health_small"
+}
+{
+"origin" "-216 -1720 -936"
+"targetname" "t159"
+"dmg" "0"
+"classname" "target_explosion"
+}
+{
+"origin" "60 -1572 -992"
+"classname" "misc_explobox"
+}
+{
+"targetname" "t13"
+"item" "ammo_cells"
+"classname" "monster_brain"
+"angle" "270"
+"origin" "-175 -530 -930"
+"spawnflags" "257"
+}
+{
+"item" "ammo_cells"
+"classname" "monster_brain"
+"angle" "270"
+"origin" "-295 -770 -930"
+"spawnflags" "1"
+}
+{
+"origin" "-560 -1232 -1056"
+"classname" "ammo_bullets"
+"spawnflags" "3072"
+}
+{
+"origin" "-528 -1200 -1056"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"origin" "-136 -816 -344"
+"angle" "180"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-128 480 -88"
+"angle" "0"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-288 472 -472"
+"angle" "225"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-224 0 -664"
+"angle" "0"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "30 136 -392"
+"angle" "225"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "464 -240 -864"
+"angle" "45"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "546 222 -884"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"spawnflags" "0"
+"classname" "ammo_rockets"
+"origin" "120 16 -808"
+}
+{
+"spawnflags" "2048"
+"classname" "item_armor_jacket"
+"origin" "168 16 -808"
+}
+{
+"origin" "-344 32 -816"
+"classname" "item_health"
+}
+{
+"origin" "-288 -416 -832"
+"angle" "90"
+"spawnflags" "2050"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "136 -736 -574"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "2048"
+"origin" "-464 -798 -328"
+"targetname" "t156"
+"classname" "target_secret"
+}
+{
+"model" "*66"
+"spawnflags" "2048"
+"message" "You have found a secret area."
+"target" "t156"
+"classname" "trigger_once"
+}
+{
+"model" "*67"
+"spawnflags" "2055"
+"classname" "func_wall"
+"targetname" "t181"
+}
+{
+"origin" "-60 -792 -368"
+"targetname" "t154"
+"classname" "point_combat"
+}
+{
+"targetname" "t155"
+"origin" "-64 -708 -362"
+"angle" "270"
+"target" "t154"
+"classname" "monster_soldier_light"
+"spawnflags" "1"
+}
+{
+"classname" "ammo_cells"
+"origin" "-452 -720 -702"
+}
+{
+"origin" "-408 -954 -640"
+"classname" "ammo_rockets"
+"spawnflags" "3584"
+}
+{
+"origin" "-504 -724 -352"
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+}
+{
+"origin" "-508 -828 -352"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"origin" "-472 -828 -352"
+"classname" "item_health"
+"spawnflags" "1024"
+}
+{
+"origin" "-508 -764 -352"
+"classname" "ammo_shells"
+"spawnflags" "0"
+}
+{
+"origin" "-508 -868 -352"
+"classname" "item_health_large"
+"spawnflags" "2048"
+}
+{
+"origin" "-472 -868 -352"
+"classname" "item_health"
+"spawnflags" "0"
+}
+{
+"origin" "-548 -868 -288"
+"classname" "ammo_rockets"
+"spawnflags" "2048"
+}
+{
+"origin" "-548 -796 -288"
+"classname" "ammo_cells"
+"spawnflags" "0"
+}
+{
+"origin" "-548 -760 -288"
+"classname" "ammo_slugs"
+"spawnflags" "2048"
+}
+{
+"origin" "-548 -724 -288"
+"classname" "ammo_rockets"
+"spawnflags" "2048"
+}
+{
+"origin" "-548 -760 -352"
+"classname" "ammo_grenades"
+"spawnflags" "2048"
+}
+{
+"origin" "-548 -832 -352"
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+}
+{
+"origin" "-548 -868 -352"
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+}
+{
+"origin" "-132 -864 -352"
+"classname" "ammo_rockets"
+"team" "ammo1"
+}
+{
+"origin" "-48 -864 -304"
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"team" "ammo1"
+}
+{
+"origin" "-48 -828 -352"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"origin" "-320 -1384 -1064"
+"targetname" "t153"
+"classname" "target_secret"
+}
+{
+"spawnflags" "2048"
+"origin" "-280 -1408 -1064"
+"target" "t153"
+"targetname" "t152"
+"message" "You have found a secret area."
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "208 -32 -808"
+"targetname" "t149"
+"classname" "target_secret"
+}
+{
+"model" "*68"
+"spawnflags" "2048"
+"message" "You have found a secret area."
+"target" "t149"
+"classname" "trigger_once"
+}
+{
+"target" "t280"
+"targetname" "t281"
+"classname" "monster_berserk"
+"spawnflags" "769"
+"angle" "270"
+"origin" "220 -752 -612"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+"origin" "376 -1184 -652"
+}
+{
+"classname" "monster_berserk"
+"angle" "270"
+"origin" "16 -712 -612"
+"spawnflags" "1"
+}
+{
+"classname" "monster_berserk"
+"angle" "270"
+"origin" "-144 -712 -612"
+"spawnflags" "257"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2"
+"angle" "135"
+"origin" "-112 -1568 -832"
+}
+{
+"targetname" "city2NH"
+"angle" "90"
+"origin" "-64 -1862 -800"
+"classname" "info_player_start"
+}
+{
+"classname" "target_crosslevel_trigger"
+"spawnflags" "2049"
+"targetname" "rfld"
+"origin" "-116 -872 -809"
+}
+{
+"target" "t217"
+"spawnflags" "256"
+"origin" "-448 -1184 -936"
+"angle" "270"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-480 -1248 -936"
+"angle" "225"
+"classname" "monster_soldier_ss"
+}
+{
+"killtarget" "redfieldbutton"
+"origin" "-155 -795 -822"
+"targetname" "rfld"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"model" "*69"
+"spawnflags" "2048"
+"targetname" "pylon"
+"classname" "func_wall"
+}
+{
+"origin" "-696 -1252 -776"
+"target" "t137"
+"targetname" "t136"
+"classname" "trigger_relay"
+}
+{
+"angle" "0"
+"spawnflags" "1"
+"origin" "-492 -1204 -680"
+"target" "t70"
+"classname" "monster_soldier_ss"
+"item" "ammo_bullets"
+}
+{
+"origin" "-64 -1864 -590"
+"classname" "light"
+"light" "100"
+}
+{
+"_cone" "15"
+"origin" "-64 -1864 -598"
+"target" "t133"
+"classname" "light"
+"light" "300"
+}
+{
+"origin" "-64 -1864 -808"
+"targetname" "t133"
+"classname" "info_notnull"
+}
+{
+"_color" "1.000000 0.796078 0.003922"
+"origin" "-8 -1480 -590"
+"classname" "light"
+"light" "48"
+}
+{
+"_cone" "15"
+"origin" "-64 -1784 -598"
+"target" "t134"
+"classname" "light"
+"light" "300"
+}
+{
+"origin" "-64 -1784 -808"
+"targetname" "t134"
+"classname" "info_notnull"
+}
+{
+"origin" "-64 -1976 -808"
+"targetname" "t132"
+"classname" "info_notnull"
+}
+{
+"origin" "-64 -1976 -590"
+"light" "100"
+"classname" "light"
+}
+{
+"_cone" "15"
+"origin" "-64 -1976 -598"
+"light" "300"
+"target" "t132"
+"classname" "light"
+}
+{
+"origin" "192 -216 -616"
+"angle" "270"
+"spawnflags" "259"
+"targetname" "t295"
+"classname" "monster_floater"
+}
+{
+"origin" "-16 -1104 -632"
+"targetname" "t57"
+"spawnflags" "3"
+"classname" "monster_floater"
+}
+{
+"spawnflags" "2048"
+"origin" "-288 64 -672"
+"classname" "item_health"
+}
+{
+"spawnflags" "2048"
+"origin" "-248 64 -672"
+"classname" "item_health"
+}
+{
+"origin" "-328 64 -664"
+"classname" "ammo_rockets"
+"spawnflags" "0"
+}
+{
+"origin" "632 -170 -824"
+"classname" "item_armor_jacket"
+"spawnflags" "1792"
+}
+{
+"origin" "592 -232 -872"
+"classname" "item_health"
+}
+{
+"spawnflags" "2048"
+"origin" "192 -48 -808"
+"classname" "item_health_mega"
+}
+{
+"spawnflags" "1792"
+"origin" "152 -32 -776"
+"classname" "weapon_rocketlauncher"
+}
+{
+"item" "ammo_bullets"
+"origin" "464 -8 -856"
+"angle" "45"
+"classname" "monster_soldier_ss"
+"deathtarget" "brainguy"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-320 -804 -396"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-316 -792 -524"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-632 -832 -772"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-632 -832 -836"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-632 -832 -900"
+}
+{
+"classname" "info_null"
+"targetname" "t130"
+"origin" "-72 -832 -360"
+}
+{
+"style" "34"
+"classname" "light"
+"target" "t130"
+"light" "350"
+"_color" "1.000000 0.945098 0.643137"
+"origin" "-72 -832 -238"
+"spawnflags" "1"
+"targetname" "t155"
+"_cone" "25"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-127 -798 -515"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-81 -787 -532"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-43 -793 -511"
+}
+{
+"origin" "-64 -1880 -982"
+"_color" "1.000000 0.920900 0.343800"
+"light" "90"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.920900 0.343800"
+"origin" "-64 -1880 -973"
+"target" "t129"
+"_cone" "20"
+}
+{
+"origin" "-64 -1872 -1080"
+"classname" "info_notnull"
+"targetname" "t129"
+}
+{
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.920900 0.343800"
+"origin" "-64 -2032 -976"
+"target" "t128"
+"_cone" "20"
+}
+{
+"classname" "info_notnull"
+"origin" "-64 -2032 -1080"
+"targetname" "t128"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.920900 0.343800"
+"origin" "-64 -2032 -974"
+}
+{
+"classname" "info_notnull"
+"targetname" "t127"
+"origin" "-64 -1808 -1080"
+}
+{
+"target" "t264"
+"spawnflags" "1"
+"item" "item_armor_shard"
+"classname" "monster_brain"
+"angle" "270"
+"origin" "194 -222 -804"
+}
+{
+"spawnflags" "1"
+"item" "Ammo_cells"
+"classname" "monster_brain"
+"angle" "225"
+"origin" "238 -184 -804"
+}
+{
+"classname" "info_notnull"
+"targetname" "t126"
+"origin" "-64 -1096 -620"
+}
+{
+"classname" "trigger_relay"
+"delay" "0.1"
+"targetname" "py1"
+"angle" "45"
+"killtarget" "support_hose"
+"origin" "-68 -1174 -632"
+"target" "supporthose"
+}
+{
+"sounds" "2"
+"origin" "-64 -1096 -748"
+"angle" "-2"
+"classname" "target_splash"
+"targetname" "py1"
+}
+{
+"sounds" "2"
+"origin" "-64 -1096 -684"
+"classname" "target_splash"
+"angle" "225"
+"targetname" "py1"
+}
+{
+"sounds" "2"
+"origin" "-64 -1096 -638"
+"classname" "target_splash"
+"angle" "-1"
+"targetname" "py1"
+}
+{
+"model" "*70"
+"classname" "func_door"
+"angle" "0"
+"Team" "door1"
+"lip" "8"
+"speed" "50"
+"sounds" "4"
+}
+{
+"targetname" "rfld"
+"killtarget" "ran3"
+"origin" "-242 -826 -924"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"target" "t287"
+"targetname" "ran4"
+"random" ".8"
+"wait" ".95"
+"spawnflags" "2049"
+"classname" "func_timer"
+"origin" "-229 -901 -924"
+}
+{
+"targetname" "rfld"
+"classname" "trigger_relay"
+"origin" "-270 -820 -924"
+"killtarget" "ran2"
+"spawnflags" "2048"
+}
+{
+"targetname" "rfld"
+"classname" "trigger_relay"
+"origin" "-217 -826 -924"
+"killtarget" "ran4"
+}
+{
+"targetname" "rfld"
+"killtarget" "ran1"
+"origin" "-288 -787 -924"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-262 -797 -924"
+"targetname" "ran2"
+"target" "t124"
+"random" ".8"
+"wait" "1"
+"spawnflags" "2049"
+"classname" "func_timer"
+}
+{
+"origin" "-238 -804 -924"
+"targetname" "ran3"
+"target" "t125"
+"classname" "func_timer"
+"spawnflags" "2049"
+"wait" "3"
+"random" "2.333333333"
+}
+{
+"origin" "-266 -764 -924"
+"targetname" "ran1"
+"target" "t118"
+"random" ".9"
+"wait" "4"
+"spawnflags" "2049"
+"classname" "func_timer"
+}
+{
+"targetname" "t121"
+"noise" "world/spark1.wav"
+"classname" "target_speaker"
+"origin" "-106 -812 -883"
+"spawnflags" "2048"
+}
+{
+"targetname" "t123"
+"noise" "world/spark5.wav"
+"classname" "target_speaker"
+"origin" "-110 -791 -896"
+"spawnflags" "2048"
+}
+{
+"targetname" "t122"
+"origin" "-102 -771 -896"
+"classname" "target_speaker"
+"noise" "world/spark1.wav"
+"spawnflags" "2048"
+}
+{
+"targetname" "t125"
+"origin" "-232 -771 -941"
+"target" "t123"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t124"
+"origin" "-221 -761 -940"
+"target" "t122"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t118"
+"origin" "-241 -763 -940"
+"target" "t121"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-148 -835 -864"
+"_color" "1.000000 0.853175 0.011905"
+"light" "100"
+"classname" "light"
+}
+{
+"targetname" "rfld"
+"classname" "trigger_relay"
+"origin" "-177 -798 -924"
+"killtarget" "t119"
+}
+{
+"model" "*71"
+"_minlight" "0.9"
+"targetname" "rfld"
+"delay" ".25"
+"spawnflags" "2054"
+"classname" "func_wall"
+}
+{
+"model" "*72"
+"_minlight" "0.8"
+"targetname" "rfld"
+"spawnflags" "2049"
+"classname" "func_wall"
+}
+{
+"targetname" "t287"
+"origin" "-100 -826 -847"
+"target" "t119"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"style" "35"
+"light" "200"
+"targetname" "t119"
+"origin" "-142 -744 -896"
+"_color" "1.000000 0.391304 0.185771"
+"classname" "light"
+}
+{
+"targetname" "t122"
+"origin" "-154 -754 -938"
+"classname" "target_splash"
+"angle" "225"
+"sounds" "1"
+}
+{
+"targetname" "t121"
+"origin" "-130 -748 -924"
+"classname" "target_splash"
+"angle" "-1"
+"sounds" "1"
+}
+{
+"targetname" "t123"
+"origin" "-148 -754 -938"
+"sounds" "1"
+"angle" "315"
+"classname" "target_splash"
+"spawnflags" "2048"
+}
+{
+"model" "*73"
+"message" "Red force fields deactivated."
+"delay" ".5"
+"target" "rfld"
+"targetname" "redfieldbutton"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "-256 254 -460"
+"angle" "180"
+"classname" "monster_tank_commander"
+"item" "ammo_bullets"
+"spawnflags" "1"
+}
+{
+"model" "*74"
+"spawnflags" "2048"
+"target" "t116"
+"classname" "trigger_once"
+}
+{
+"targetname" "t116"
+"origin" "-384 112 -440"
+"angle" "90"
+"classname" "monster_berserk"
+}
+{
+"origin" "-488 472 -488"
+"targetname" "t112"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "256"
+"origin" "-368 352 -472"
+"classname" "monster_soldier_ss"
+"angle" "180"
+}
+{
+"item" "ammo_bullets"
+"origin" "-416 384 -472"
+"target" "t112"
+"classname" "monster_soldier_ss"
+"angle" "180"
+}
+{
+"origin" "-288 432 -472"
+"angle" "180"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-316 -792 -588"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-320 -804 -332"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-316 -792 -652"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-628 -884 -808"
+"_color" "1.000000 0.172549 0.023529"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-464 -1072 -680"
+"angle" "90"
+"classname" "monster_berserk"
+"item" "item_armor_shard"
+"spawnflags" "1"
+"targetname" "t250"
+}
+{
+"style" "36"
+"targetname" "t194"
+"target" "t111"
+"_color" "1.000000 0.996078 0.768627"
+"classname" "light"
+"_cone" "20"
+"origin" "-632 -832 -600"
+"light" "450"
+"spawnflags" "1"
+}
+{
+"targetname" "t111"
+"classname" "info_notnull"
+"origin" "-633 -832 -936"
+}
+{
+"origin" "-281 -832 -712"
+"targetname" "t106"
+"classname" "info_notnull"
+}
+{
+"style" "37"
+"targetname" "t108"
+"spawnflags" "1"
+"light" "900"
+"origin" "-280 -832 -248"
+"_cone" "20"
+"target" "t106"
+"classname" "light"
+}
+{
+"model" "*75"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*76"
+"spawnflags" "2056"
+"lip" "8"
+"wait" "-1"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*77"
+"target" "t238"
+"lip" "8"
+"spawnflags" "8"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*78"
+"target" "sec2"
+"classname" "trigger_multiple"
+}
+{
+"model" "*79"
+"wait" "4"
+"lip" "64"
+"_minlight" "0.1"
+"targetname" "sec2"
+"speed" "100"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"target" "t102"
+"classname" "light"
+"_cone" "10"
+"light" "200"
+"origin" "0 -712 -486"
+}
+{
+"target" "t103"
+"light" "200"
+"_cone" "10"
+"classname" "light"
+"origin" "-48 -712 -486"
+}
+{
+"target" "t104"
+"light" "200"
+"_cone" "10"
+"classname" "light"
+"origin" "-80 -712 -486"
+}
+{
+"target" "t105"
+"light" "200"
+"_cone" "10"
+"classname" "light"
+"origin" "-128 -712 -486"
+}
+{
+"targetname" "t105"
+"classname" "info_notnull"
+"origin" "-128 -712 -636"
+}
+{
+"targetname" "t104"
+"classname" "info_notnull"
+"origin" "-80 -712 -636"
+}
+{
+"targetname" "t103"
+"classname" "info_notnull"
+"origin" "-48 -712 -636"
+}
+{
+"targetname" "t102"
+"classname" "info_notnull"
+"origin" "-4 -712 -636"
+}
+{
+"classname" "func_group"
+}
+{
+"model" "*80"
+"target" "t100"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"model" "*81"
+"spawnflags" "2304"
+"target" "t82"
+"targetname" "t81"
+"classname" "trigger_once"
+}
+{
+"targetname" "t97"
+"origin" "-48 -632 -636"
+"classname" "info_null"
+}
+{
+"target" "t97"
+"origin" "-48 -632 -486"
+"classname" "light"
+"_cone" "10"
+"light" "200"
+}
+{
+"targetname" "t98"
+"origin" "-80 -632 -636"
+"classname" "info_null"
+}
+{
+"target" "t98"
+"origin" "-80 -632 -486"
+"classname" "light"
+"_cone" "10"
+"light" "200"
+}
+{
+"targetname" "t99"
+"origin" "-128 -632 -636"
+"classname" "info_null"
+}
+{
+"target" "t99"
+"origin" "-128 -632 -486"
+"classname" "light"
+"_cone" "10"
+"light" "200"
+}
+{
+"origin" "-4 -632 -636"
+"targetname" "t96"
+"classname" "info_null"
+}
+{
+"origin" "-4 -632 -486"
+"target" "t96"
+"light" "200"
+"_cone" "10"
+"classname" "light"
+}
+{
+"target" "t95"
+"classname" "light"
+"light" "300"
+"_cone" "20"
+"origin" "84 -384 -504"
+}
+{
+"targetname" "t95"
+"classname" "info_null"
+"origin" "84 -384 -664"
+}
+{
+"target" "t94"
+"_cone" "20"
+"light" "300"
+"classname" "light"
+"origin" "-216 -384 -504"
+}
+{
+"targetname" "t94"
+"classname" "info_null"
+"origin" "-216 -384 -664"
+}
+{
+"targetname" "t93"
+"classname" "info_null"
+"origin" "-216 -576 -664"
+}
+{
+"target" "t93"
+"_cone" "20"
+"light" "300"
+"classname" "light"
+"origin" "-216 -576 -504"
+}
+{
+"targetname" "t92"
+"classname" "info_null"
+"origin" "88 -576 -664"
+}
+{
+"target" "t92"
+"classname" "light"
+"light" "300"
+"_cone" "20"
+"origin" "88 -576 -504"
+}
+{
+"targetname" "t91"
+"origin" "-216 -192 -664"
+"classname" "info_null"
+}
+{
+"target" "t91"
+"origin" "-216 -192 -504"
+"classname" "light"
+"light" "300"
+"_cone" "20"
+}
+{
+"origin" "84 -192 -664"
+"targetname" "t90"
+"classname" "info_null"
+}
+{
+"origin" "84 -192 -504"
+"target" "t90"
+"_cone" "20"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-320 -292 -668"
+"targetname" "t86"
+"target" "t85"
+"classname" "path_corner"
+}
+{
+"origin" "212 -592 -700"
+"targetname" "t84"
+"target" "t83"
+"classname" "path_corner"
+}
+{
+"killtarget" "trap_gun"
+"spawnflags" "2304"
+"origin" "-924 -16 -564"
+"targetname" "t82"
+"classname" "trigger_relay"
+}
+{
+"origin" "-936 456 -492"
+"target" "t1"
+"targetname" "t80"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"targetname" "t100"
+"origin" "-408 120 -408"
+"message" "You have found a secret passage."
+"classname" "target_secret"
+}
+{
+"spawnflags" "2304"
+"targetname" "t82"
+"origin" "-928 32 -560"
+"message" "You have found a secret.\nGun trap is deactivated."
+"classname" "target_secret"
+}
+{
+"item" "item_armor_shard"
+"targetname" "t89"
+"origin" "195 -34 -673"
+"spawnflags" "1"
+"classname" "monster_berserk"
+}
+{
+"model" "*82"
+"spawnflags" "2048"
+"target" "t89"
+"classname" "trigger_once"
+}
+{
+"item" "item_armor_shard"
+"targetname" "t89"
+"origin" "-717 -77 -576"
+"spawnflags" "2"
+"angle" "270"
+"classname" "monster_berserk"
+}
+{
+"model" "*83"
+"target" "t81"
+"_minlight" "0.1"
+"classname" "func_button"
+"angle" "180"
+"health" "1"
+"lip" "4"
+"spawnflags" "2304"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-28 -156 -512"
+"light" "100"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-100 -156 -512"
+"light" "100"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-28 -284 -512"
+"light" "100"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-100 -284 -512"
+"light" "100"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"origin" "-28 -476 -512"
+"light" "100"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.976471 0.501961"
+"classname" "light"
+"light" "100"
+"origin" "-100 -476 -512"
+}
+{
+"model" "*84"
+"spawnflags" "8"
+"target" "t79"
+"classname" "func_door"
+"angle" "180"
+"_minlight" "0.1"
+"team" "sdr1"
+"health" "80"
+}
+{
+"model" "*85"
+"angle" "0"
+"classname" "func_door"
+"team" "bigredx"
+"speed" "50"
+"sounds" "4"
+"wait" "4"
+"_minlight" "0.2"
+}
+{
+"model" "*86"
+"classname" "func_door"
+"angle" "180"
+"team" "bigredx"
+"speed" "50"
+"sounds" "4"
+"wait" "4"
+"_minlight" "0.2"
+}
+{
+"origin" "-924 532 -532"
+"light" "100"
+"classname" "light"
+"spawnflags" "1792"
+}
+{
+"model" "*87"
+"targetname" "t279"
+"target" "bigredoor"
+"spawnflags" "4"
+"classname" "trigger_once"
+}
+{
+"model" "*88"
+"spawnflags" "2080"
+"message" "This door is opened elsewhere."
+"sounds" "4"
+"_minlight" "0.3"
+"lip" "32"
+"team" "bigred"
+"targetname" "bigredoor"
+"speed" "25"
+"angle" "180"
+"classname" "func_door"
+}
+{
+"model" "*89"
+"spawnflags" "2080"
+"message" "This door is opened elsewhere."
+"sounds" "2"
+"_minlight" "0.3"
+"lip" "32"
+"team" "bigred"
+"speed" "25"
+"targetname" "bigredoor"
+"angle" "0"
+"classname" "func_door"
+}
+{
+"model" "*90"
+"spawnflags" "2080"
+"message" "This door is opened elsewhere."
+"sounds" "2"
+"_minlight" "0.3"
+"lip" "8"
+"targetname" "bigredoor"
+"speed" "25"
+"team" "bigred"
+"angle" "180"
+"classname" "func_door"
+}
+{
+"model" "*91"
+"spawnflags" "2080"
+"message" "This door is opened elsewhere."
+"sounds" "2"
+"_minlight" "0.3"
+"lip" "8"
+"targetname" "bigredoor"
+"team" "bigred"
+"speed" "25"
+"angle" "0"
+"classname" "func_door"
+}
+{
+"dmg" "200"
+"health" "50"
+"classname" "misc_explobox"
+"origin" "-36 -1824 -936"
+"spawnflags" "2048"
+}
+{
+"model" "*92"
+"spawnflags" "2048"
+"classname" "func_explosive"
+"target" "rly2"
+"health" "5"
+"dmg" "50"
+"mass" "100"
+"_minlight" "0.6"
+}
+{
+"model" "*93"
+"wait" "-1"
+"_minlight" "0.2"
+"angle" "180"
+"classname" "func_door"
+"spawnflags" "2048"
+"team" "Greendoor"
+"targetname" "yfld"
+"sounds" "3"
+"message" "This door is opened elsewhere."
+}
+{
+"model" "*94"
+"wait" "-1"
+"_minlight" "0.2"
+"classname" "func_door"
+"angle" "0"
+"spawnflags" "2048"
+"message" "This door is opened elsewhere."
+"team" "Greendoor"
+"targetname" "yfld"
+}
+{
+"classname" "info_notnull"
+"targetname" "t50"
+"origin" "-64 -224 -812"
+}
+{
+"style" "38"
+"targetname" "t185"
+"classname" "light"
+"light" "400"
+"target" "t50"
+"spawnflags" "1"
+"_color" "1.000000 0.894118 0.290196"
+"origin" "-64 -224 -680"
+"_cone" "25"
+}
+{
+"target" "t57"
+"item" "ammo_cells"
+"targetname" "t56"
+"origin" "-80 124 -334"
+"classname" "monster_floater"
+"angle" "270"
+"spawnflags" "1"
+}
+{
+"model" "*95"
+"sounds" "4"
+"lip" "3"
+"angle" "270"
+"classname" "func_button"
+"_minlight" "0.6"
+"target" "sd2"
+}
+{
+"target" "t152"
+"classname" "item_power_shield"
+"origin" "-288 -1368 -1056"
+"spawnflags" "0"
+}
+{
+"delay" "0"
+"classname" "trigger_relay"
+"targetname" "t46"
+"target" "t47"
+"origin" "-392 -1400 -1064"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"delay" "0.2"
+"targetname" "t46"
+"target" "t47"
+"origin" "-392 -1440 -1064"
+"spawnflags" "2048"
+}
+{
+"style" "39"
+"classname" "light"
+"light" "1000"
+"_color" "1.000000 0.873016 0.154762"
+"origin" "-393 -1424 -1064"
+"spawnflags" "2049"
+"targetname" "t47"
+}
+{
+"classname" "target_splash"
+"angle" "180"
+"sounds" "5"
+"origin" "-382 -1424 -1064"
+"targetname" "t46"
+}
+{
+"model" "*96"
+"classname" "trigger_multiple"
+"wait" "3"
+"delay" ".5"
+"target" "t46"
+"spawnflags" "2048"
+}
+{
+"classname" "target_blaster"
+"dmg" "15"
+"angle" "180"
+"origin" "-388 -1424 -1064"
+"speed" "1000"
+"targetname" "t46"
+"spawnflags" "3584"
+}
+{
+"classname" "point_combat"
+"targetname" "t44"
+"origin" "-472 -1000 -952"
+}
+{
+"classname" "monster_brain"
+"angle" "225"
+"origin" "-68 -118 -742"
+}
+{
+"dmg" "10000"
+"origin" "432 -218 -808"
+"classname" "target_laser"
+"angle" "90"
+"spawnflags" "2053"
+"targetname" "yfld"
+}
+{
+"sounds" "5"
+"dmg" "10000"
+"origin" "432 -218 -840"
+"classname" "target_laser"
+"spawnflags" "2053"
+"angle" "90"
+"targetname" "yfld"
+}
+{
+"model" "*97"
+"spawnflags" "2048"
+"target" "spg"
+"classname" "func_button"
+"angle" "90"
+"lip" "6"
+"speed" "50"
+"wait" "-1"
+"sounds" "5"
+}
+{
+"classname" "light"
+"light" "135"
+"origin" "-64 -232 -896"
+}
+{
+"target" "t148"
+"classname" "key_data_spinner"
+"origin" "-64 -224 -876"
+"spawnflags" "2048"
+}
+{
+"angle" "90"
+"classname" "target_splash"
+"targetname" "py1"
+"origin" "-64 -1096 -716"
+"sounds" "2"
+}
+{
+"angle" "315"
+"classname" "target_splash"
+"targetname" "py1"
+"origin" "-64 -1096 -658"
+"sounds" "2"
+}
+{
+"spawnflags" "2048"
+"origin" "-20 -1124 -612"
+"killtarget" "pylon"
+"classname" "trigger_relay"
+"targetname" "py1"
+}
+{
+"model" "*98"
+"spawnflags" "2048"
+"classname" "func_wall"
+"_minlight" "0.9"
+"targetname" "pylon"
+}
+{
+"classname" "light"
+"light" "200"
+"_color" "0.145098 0.466667 1.000000"
+"origin" "-64 -1095 -783"
+}
+{
+"origin" "-408 8 -376"
+"light" "100"
+"classname" "light"
+}
+{
+"model" "*99"
+"spawnflags" "8"
+"target" "t79"
+"_minlight" "0.9"
+"angle" "180"
+"team" "sdr1"
+"classname" "func_door"
+"health" "2"
+}
+{
+"model" "*100"
+"team" "condoor"
+"classname" "func_door"
+"angle" "90"
+"speed" "100"
+"sounds" "2"
+"lip" "8"
+"wait" "4"
+"_minlight" "0.1"
+}
+{
+"deathtarget" "t57"
+"target" "t261"
+"origin" "-72 -352 -416"
+"spawnflags" "1"
+"angle" "270"
+"classname" "monster_floater"
+}
+{
+"deathtarget" "t57"
+"origin" "210 -576 -630"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_floater"
+}
+{
+"spawnflags" "1792"
+"origin" "41 -1067 -904"
+"classname" "ammo_slugs"
+}
+{
+"origin" "-161 -1701 -816"
+"classname" "ammo_grenades"
+"spawnflags" "2048"
+}
+{
+"origin" "43 -1501 -816"
+"classname" "ammo_rockets"
+}
+{
+"targetname" "t281"
+"spawnflags" "1"
+"origin" "124 -796 -616"
+"classname" "monster_tank_commander"
+"angle" "360"
+"item" "ammo_rockets"
+"target" "t289"
+}
+{
+"targetname" "t70"
+"spawnflags" "1"
+"origin" "-839 -1609 -860"
+"angle" "90"
+"classname" "monster_tank_commander"
+"item" "ammo_rockets"
+}
+{
+"model" "*101"
+"dmg" "25"
+"targetname" "f1"
+"mass" "300"
+"classname" "func_explosive"
+"spawnflags" "2048"
+}
+{
+"style" "40"
+"spawnflags" "2048"
+"_cone" "20"
+"classname" "light"
+"light" "250"
+"targetname" "pylon"
+"origin" "-64 -1096 -508"
+"target" "t126"
+}
+{
+"spawnflags" "1024"
+"classname" "item_health_small"
+"origin" "42 -1689 -934"
+}
+{
+"model" "*102"
+"spawnflags" "2048"
+"dmg" "20"
+"health" "200"
+"classname" "func_explosive"
+}
+{
+"spawnflags" "2048"
+"classname" "misc_explobox"
+"health" "15"
+"dmg" "55"
+"origin" "336 -764 -944"
+}
+{
+"spawnflags" "1"
+"classname" "monster_floater"
+"targetname" "t17"
+"origin" "-72 -654 -892"
+}
+{
+"targetname" "t16"
+"classname" "target_laser"
+"origin" "224 -1240 -956"
+"spawnflags" "2057"
+"angle" "-1"
+"dmg" "25"
+}
+{
+"targetname" "t16"
+"angle" "-1"
+"classname" "target_laser"
+"origin" "224 -1192 -956"
+"spawnflags" "2057"
+"dmg" "25"
+}
+{
+"targetname" "t16"
+"spawnflags" "2056"
+"angle" "90"
+"origin" "224 -1280 -920"
+"classname" "target_laser"
+"dmg" "45"
+}
+{
+"targetname" "t16"
+"spawnflags" "2056"
+"origin" "224 -1280 -872"
+"classname" "target_laser"
+"angle" "90"
+"dmg" "45"
+}
+{
+"spawnflags" "2048"
+"origin" "336 -902 -944"
+"dmg" "55"
+"health" "15"
+"classname" "misc_explobox"
+}
+{
+"target" "t15"
+"origin" "-464 -612 -930"
+"targetname" "t13"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"delay" ".5"
+"targetname" "t15"
+"origin" "96 -652 -872"
+"classname" "target_explosion"
+"spawnflags" "2048"
+}
+{
+"targetname" "t15"
+"delay" "1.25"
+"origin" "96 -652 -896"
+"classname" "target_explosion"
+"spawnflags" "2048"
+}
+{
+"origin" "96 -656 -1048"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-488 -656 -936"
+"targetname" "t13"
+"delay" "0.5"
+"target" "f1"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-472 -632 -944"
+"delay" "2"
+"target" "t14"
+"targetname" "t13"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"model" "*103"
+"target" "t13"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "88 -656 -1056"
+"classname" "item_health_large"
+"spawnflags" "2048"
+}
+{
+"item" "ammo_cells"
+"angle" "180"
+"origin" "56 -648 -984"
+"targetname" "t14"
+"spawnflags" "2"
+"classname" "monster_floater"
+}
+{
+"origin" "120 -664 -984"
+"targetname" "t14"
+"spawnflags" "258"
+"classname" "monster_floater"
+}
+{
+"model" "*104"
+"lip" "16"
+"targetname" "t14"
+"classname" "func_door"
+"angle" "-2"
+"spawnflags" "1"
+"speed" "75"
+"wait" "-1"
+}
+{
+"origin" "-416 -624 -936"
+"targetname" "t12"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"origin" "-310 -852 -950"
+"targetname" "t11"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"origin" "-462 -674 -938"
+"targetname" "t10"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "769"
+"origin" "-215 -802 -930"
+"angle" "270"
+"classname" "monster_brain"
+"target" "t11"
+}
+{
+"origin" "-72 -1804 -912"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"origin" "-112 -1800 -904"
+"classname" "ammo_rockets"
+"spawnflags" "2048"
+}
+{
+"origin" "-48 -1752 -936"
+"targetname" "t8"
+"classname" "point_combat"
+"spawnflags" "1"
+}
+{
+"origin" "-80 -1752 -936"
+"targetname" "t9"
+"classname" "point_combat"
+"spawnflags" "1"
+"killtarget" "t9"
+}
+{
+"model" "*105"
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+"wait" "15"
+"target" "t302"
+"targetname" "reminder"
+}
+{
+"spawnflags" "1"
+"targetname" "t28"
+"target" "t8"
+"origin" "-36 -1768 -920"
+"classname" "monster_soldier_ss"
+"angle" "90"
+}
+{
+"spawnflags" "1"
+"targetname" "t28"
+"target" "t9"
+"origin" "-76 -1768 -920"
+"angle" "90"
+"classname" "monster_soldier_ss"
+}
+{
+"target" "t17"
+"spawnflags" "1"
+"targetname" "t5"
+"origin" "36 -1748 -920"
+"classname" "monster_berserk"
+"angle" "90"
+}
+{
+"spawnflags" "768"
+"targetname" "t6"
+"origin" "-120 -1752 -920"
+"angle" "315"
+"classname" "monster_berserk"
+}
+{
+"model" "*106"
+"spawnflags" "2054"
+"classname" "func_wall"
+"targetname" "redforfld"
+}
+{
+"origin" "-56 -96 -760"
+"classname" "light"
+"light" "32"
+"_color" "0.215686 0.784314 1.000000"
+}
+{
+"origin" "-72 -96 -760"
+"classname" "light"
+"light" "32"
+"_color" "0.215686 0.784314 1.000000"
+}
+{
+"origin" "-104 -112 -760"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-168 -112 -632"
+"classname" "light"
+"light" "32"
+"_color" "0.215686 0.784314 1.000000"
+}
+{
+"origin" "-160 -128 -712"
+"_color" "0.220472 0.590551 1.000000"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "40 -136 -772"
+"classname" "light"
+"light" "64"
+"_color" "0.220472 0.590551 1.000000"
+}
+{
+"origin" "-168 -136 -760"
+"classname" "light"
+"light" "64"
+"_color" "0.215686 0.784314 1.000000"
+}
+{
+"origin" "32 -112 -632"
+"_color" "0.215686 0.784314 1.000000"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "32 -136 -696"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-24 -112 -760"
+"_color" "1.000000 0.976471 0.501961"
+"light" "64"
+"classname" "light"
+}
+{
+"model" "*107"
+"spawnflags" "2048"
+"health" "5"
+"_minlight" "0.6"
+"classname" "func_explosive"
+"target" "t3"
+"dmg" "50"
+}
+{
+"origin" "-107 -1331 -538"
+"classname" "trigger_relay"
+"targetname" "t3"
+"target" "cntr1"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"targetname" "rly2"
+"target" "cntr1"
+"origin" "-109 -1025 -526"
+}
+{
+"model" "*108"
+"spawnflags" "2048"
+"classname" "trigger_counter"
+"count" "2"
+"targetname" "cntr1"
+"target" "py1"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-368 -648 -828"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"spawnflags" "2048"
+"target" "pylon"
+"classname" "item_quad"
+"origin" "-64 -1096 -562"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-100 -284 -576"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-152 -92 -368"
+"light" "125"
+"classname" "light"
+"_color" "1.000000 0.603922 0.533333"
+}
+{
+"classname" "light"
+"light" "85"
+"origin" "-136 -92 -304"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-100 -156 -576"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-28 -156 -576"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-28 -284 -576"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-40 -100 -368"
+"light" "125"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-28 -476 -576"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "36 -476 -368"
+"light" "125"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-164 -476 -368"
+"_color" "1.000000 0.603922 0.533333"
+}
+{
+"origin" "-100 -476 -576"
+"light" "100"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "8 -92 -304"
+"light" "85"
+"classname" "light"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "trigger_relay"
+"target" "sdlight"
+"targetname" "sd2"
+"delay" "8.5"
+"origin" "246 -20 -752"
+}
+{
+"classname" "trigger_relay"
+"targetname" "sd2"
+"target" "sdlight"
+"origin" "228 24 -752"
+}
+{
+"model" "*109"
+"spawnflags" "2048"
+"sounds" "3"
+"classname" "func_button"
+"angle" "270"
+"target" "sd2"
+}
+{
+"model" "*110"
+"classname" "func_door"
+"angle" "-2"
+"speed" "75"
+"spawnflags" "12"
+"targetname" "sd2"
+"sounds" "4"
+"wait" "10"
+"_minlight" "0.1"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "544 -145 -744"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "544 -49 -744"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "544 23 -744"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "544 119 -744"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "544 231 -744"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "544 -241 -744"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "232 -424 -736"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "168 -424 -736"
+"classname" "light"
+"light" "32"
+}
+{
+"model" "*111"
+"target" "t80"
+"_minlight" "0.6"
+"classname" "func_button"
+"angle" "90"
+"lip" "8"
+"speed" "50"
+"wait" "2"
+"health" "1"
+"spawnflags" "2304"
+}
+{
+"model" "*112"
+"classname" "func_door"
+"angle" "-2"
+"spawnflags" "2057"
+"wait" "4"
+"speed" "150"
+"targetname" "t1"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-448 -1312 -776"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-448 -1312 -824"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-448 -1120 -824"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-448 -1120 -776"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"origin" "-376 -800 -822"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.881423 0.217391"
+}
+{
+"origin" "-376 -864 -822"
+"_color" "1.000000 0.881423 0.217391"
+"light" "150"
+"classname" "light"
+}
+{
+"light" "100"
+"classname" "light"
+"_color" "1.000000 0.920949 0.343874"
+"origin" "-90 -1566 -938"
+}
+{
+"origin" "-28 -1566 -938"
+"_color" "1.000000 0.920949 0.343874"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "80"
+"classname" "light"
+"_color" "1.000000 0.920949 0.343874"
+"origin" "-80 -1632 -938"
+}
+{
+"origin" "-48 -1632 -938"
+"_color" "1.000000 0.920949 0.343874"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"_color" "1.000000 0.920949 0.343874"
+"origin" "-28 -1676 -938"
+}
+{
+"light" "120"
+"classname" "light"
+"_color" "1.000000 0.920949 0.343874"
+"origin" "-64 -1632 -874"
+}
+{
+"model" "*113"
+"team" "condoor"
+"_minlight" "0.1"
+"wait" "4"
+"lip" "8"
+"sounds" "2"
+"speed" "100"
+"angle" "270"
+"classname" "func_door"
+}
+{
+"model" "*114"
+"classname" "func_door"
+"angle" "-1"
+"team" "pal1"
+"_minlight" "0.2"
+}
+{
+"model" "*115"
+"classname" "func_door"
+"angle" "0"
+"team" "pal1"
+"sounds" "3"
+"_minlight" "0.1"
+"target" "t212"
+}
+{
+"model" "*116"
+"classname" "func_door"
+"angle" "180"
+"team" "pal1"
+"_minlight" "0.2"
+}
+{
+"classname" "info_player_start"
+"angle" "270"
+"targetname" "city2XH"
+"origin" "-65 592 -80"
+}
+{
+"classname" "target_changelevel"
+"targetname" "next_high"
+"map" "city3$city3NH"
+"origin" "-80 632 48"
+}
+{
+"model" "*117"
+"angle" "90"
+"classname" "trigger_multiple"
+"target" "next_high"
+}
+{
+"classname" "info_player_start"
+"angle" "0"
+"targetname" "city2XL"
+"origin" "356 176 -872"
+}
+{
+"classname" "target_changelevel"
+"targetname" "next_low"
+"map" "city3$city3NL"
+"origin" "224 144 -840"
+}
+{
+"model" "*118"
+"angle" "180"
+"classname" "trigger_multiple"
+"target" "next_low"
+}
+{
+"angle" "90"
+"origin" "-64 -1888 -1056"
+"classname" "info_player_start"
+"targetname" "city2NL"
+}
+{
+"classname" "target_changelevel"
+"targetname" "back_low"
+"map" "city1$city1XL"
+"origin" "-104 -1944 -1064"
+}
+{
+"model" "*119"
+"classname" "trigger_multiple"
+"target" "back_low"
+"angle" "270"
+}
+{
+"classname" "target_changelevel"
+"targetname" "back_high"
+"map" "city1$city1XH"
+"origin" "-24 -1944 -760"
+}
+{
+"model" "*120"
+"classname" "trigger_multiple"
+"target" "back_high"
+"angle" "270"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "16 -1888 -744"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"_color" "1.000000 0.733333 0.733333"
+"origin" "16 -1952 -744"
+"light" "100"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.255906 0.003937"
+"classname" "light"
+"origin" "-168 -1536 -728"
+"light" "100"
+}
+{
+"_color" "1.000000 0.255906 0.003937"
+"classname" "light"
+"origin" "56 -288 -616"
+"light" "100"
+}
+{
+"classname" "light"
+"_color" "1.000000 0.255906 0.003937"
+"origin" "-168 -1728 -728"
+"light" "100"
+}
+{
+"_color" "1.000000 0.255906 0.003937"
+"classname" "light"
+"origin" "56 -288 -752"
+"light" "100"
+}
+{
+"classname" "light"
+"_color" "1.000000 0.255906 0.003937"
+"origin" "-184 -488 -624"
+"light" "100"
+}
+{
+"item" "ammo_bullets"
+"spawnflags" "1"
+"targetname" "t13"
+"target" "t10"
+"angle" "270"
+"origin" "-474 -543 -928"
+"classname" "monster_soldier_ss"
+}
+{
+"_color" "1.000000 0.733333 0.733333"
+"origin" "416 -1184 -624"
+"light" "225"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "225"
+"origin" "416 -1248 -624"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"_color" "1.000000 0.733333 0.733333"
+"origin" "-144 -1888 -744"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-144 -1952 -744"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"_color" "1.000000 0.733333 0.733333"
+"origin" "-928 -1184 -704"
+"light" "225"
+"classname" "light"
+}
+{
+"angle" "270"
+"sounds" "1"
+"classname" "target_splash"
+"targetname" "gun3"
+"origin" "-880 488 -564"
+"spawnflags" "2048"
+}
+{
+"angle" "270"
+"sounds" "1"
+"classname" "target_splash"
+"targetname" "gun2"
+"origin" "-904 488 -564"
+"spawnflags" "2048"
+}
+{
+"angle" "270"
+"sounds" "1"
+"classname" "target_splash"
+"targetname" "gun1"
+"origin" "-928 488 -564"
+"spawnflags" "2048"
+}
+{
+"classname" "target_splash"
+"sounds" "1"
+"angle" "270"
+"targetname" "gun4"
+"origin" "-856 488 -564"
+"spawnflags" "2048"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "88 -384 -528"
+"_color" "1.000000 0.988189 0.724409"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-216 -384 -528"
+"_color" "1.000000 0.988189 0.724409"
+}
+{
+"item" "ammo_bullets"
+"spawnflags" "1"
+"targetname" "t13"
+"target" "t12"
+"classname" "monster_soldier_ss"
+"origin" "-415 -535 -930"
+"angle" "270"
+}
+{
+"origin" "-132 -1702 -914"
+"_color" "1.000000 0.920949 0.343874"
+"classname" "light"
+"light" "64"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-896 32 -380"
+"classname" "light"
+"light" "32"
+}
+{
+"model" "*121"
+"spawnflags" "2048"
+"delay" ".25"
+"angle" "90"
+"speed" "500"
+"wait" ".25"
+"lip" "6"
+"classname" "func_door"
+"targetname" "gun3"
+"sounds" "2"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-896 288 -416"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "88 -576 -528"
+"_color" "1.000000 0.988189 0.724409"
+}
+{
+"origin" "-64 -1808 -971"
+"_color" "1.000000 1.000000 1.000000"
+"light" "200"
+"classname" "light"
+"target" "t127"
+"_cone" "20"
+}
+{
+"origin" "-64 -1808 -975"
+"_color" "1.000000 1.000000 1.000000"
+"light" "90"
+"classname" "light"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-4 -1232 -912"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-132 -1232 -912"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"model" "*122"
+"team" "B"
+"lip" "8"
+"wait" "4"
+"sounds" "3"
+"speed" "75"
+"angle" "180"
+"classname" "func_door"
+}
+{
+"model" "*123"
+"team" "B"
+"classname" "func_door"
+"angle" "0"
+"speed" "75"
+"wait" "4"
+"lip" "8"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "300 -592 -848"
+}
+{
+"_color" "1.000000 0.920949 0.343874"
+"light" "120"
+"classname" "light"
+"origin" "-64 -1824 -874"
+}
+{
+"light" "100"
+"classname" "light"
+"_color" "1.000000 0.920949 0.343874"
+"origin" "344 -1400 -914"
+}
+{
+"light" "150"
+"classname" "light"
+"_color" "1.000000 0.920949 0.343874"
+"origin" "-64 -1528 -914"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.920900 0.343800"
+"origin" "-64 -1936 -982"
+}
+{
+"style" "41"
+"classname" "light"
+"light" "300"
+"origin" "200 0 -753"
+"spawnflags" "1"
+"targetname" "sdlight"
+}
+{
+"classname" "light"
+"_color" "1.000000 0.259843 0.220472"
+"origin" "-268 -1368 -1048"
+"light" "100"
+}
+{
+"model" "*124"
+"target" "t159"
+"classname" "func_explosive"
+"dmg" "15"
+"health" "50"
+"_minlight" "0.2"
+"spawnflags" "2048"
+}
+{
+"model" "*125"
+"Team" "door1"
+"classname" "func_door"
+"angle" "180"
+"speed" "50"
+"lip" "8"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "88 -1696 -648"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "88 -1760 -648"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"classname" "info_player_coop"
+"origin" "-8 -1702 -808"
+"angle" "90"
+"targetname" "city2NH"
+}
+{
+"_color" "1.000000 0.733333 0.733333"
+"classname" "light"
+"light" "150"
+"origin" "-216 -1760 -648"
+}
+{
+"_color" "1.000000 0.733333 0.733333"
+"classname" "light"
+"light" "150"
+"origin" "-216 -1696 -648"
+}
+{
+"model" "*126"
+"spawnflags" "2048"
+"wait" "-1"
+"_minlight" "0.3"
+"classname" "func_button"
+"target" "droop_gate"
+"angle" "270"
+"lip" "3"
+"sounds" "4"
+}
+{
+"model" "*127"
+"spawnflags" "2048"
+"classname" "func_door"
+"angle" "-2"
+"sounds" "1"
+"speed" "75"
+"wait" "-1"
+"targetname" "droop_gate"
+}
+{
+"origin" "-552 -1216 -536"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-736 -1216 -624"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-832 -1312 -624"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-640 -1136 -952"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-640 -1248 -952"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-624 -1408 -952"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-640 -1360 -952"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-544 -1600 -776"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-736 -1600 -712"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-832 -1504 -696"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "224 -1216 -536"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "320 -1208 -584"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "320 -1336 -808"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"light" "80"
+"classname" "light"
+"origin" "368 -836 -536"
+}
+{
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-216 -16 -720"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-64 152 -328"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*128"
+"classname" "func_door"
+"angle" "180"
+"speed" "75"
+"sounds" "3"
+"wait" "4"
+"lip" "8"
+"team" "C"
+}
+{
+"model" "*129"
+"lip" "8"
+"wait" "4"
+"speed" "75"
+"angle" "0"
+"classname" "func_door"
+"team" "C"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "128 -384 -736"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"_cone" "25"
+"target" "t273"
+"_color" "1.000000 0.948819 0.755906"
+"origin" "-260 -384 -740"
+"classname" "light"
+"light" "200"
+}
+{
+"_color" "1.000000 0.988189 0.724409"
+"origin" "88 -192 -528"
+"classname" "light"
+"light" "200"
+}
+{
+"model" "*130"
+"lip" "8"
+"Team" "door4"
+"angle" "270"
+"classname" "func_door"
+}
+{
+"model" "*131"
+"lip" "8"
+"Team" "door4"
+"sounds" "3"
+"angle" "90"
+"classname" "func_door"
+}
+{
+"_color" "1.000000 0.988189 0.724409"
+"origin" "-216 -192 -528"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-216 -576 -528"
+"_color" "1.000000 0.988189 0.724409"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-216 72 -720"
+"_color" "1.000000 0.948819 0.755906"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "200 0 -536"
+"_color" "1.000000 0.988189 0.724409"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-416 -192 -536"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-608 -192 -432"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-608 384 -368"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-704 -96 -432"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-800 0 -400"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-640 -1008 -952"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-448 -1504 -776"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-178 -1216 -912"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-124 -1016 -848"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "4 -1016 -848"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "320 -928 -816"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "88 -712 -828"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "8 -648 -828"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-144 -648 -832"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-448 -728 -828"
+"classname" "light"
+"light" "150"
+}
+{
+"model" "*132"
+"spawnflags" "2054"
+"classname" "func_wall"
+"targetname" "redforfld"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-448 -1504 -824"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.875537 0.004292"
+"origin" "-448 -1504 -776"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-800 384 -416"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"origin" "112 -1216 -640"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"origin" "-240 -1216 -624"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"origin" "-40 -784 -432"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"origin" "96 -800 -536"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-88 -784 -432"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"_color" "1.000000 1.000000 0.901961"
+"light" "150"
+"classname" "light"
+"origin" "-64 -1432 -632"
+}
+{
+"light" "225"
+"classname" "light"
+"origin" "-352 -1216 -536"
+"_color" "1.000000 0.875537 0.004292"
+}
+{
+"origin" "-96 -976 -488"
+"light" "150"
+"classname" "light"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"origin" "-32 -976 -488"
+"classname" "light"
+"light" "150"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-64 -976 -560"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-96 -976 -600"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"spawnflags" "2048"
+"classname" "light"
+"light" "150"
+"origin" "-32 -976 -600"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-64 -976 -640"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"origin" "-96 -976 -680"
+"light" "150"
+"classname" "light"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"origin" "-64 -976 -712"
+"classname" "light"
+"light" "150"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"origin" "-32 -976 -680"
+"light" "150"
+"classname" "light"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"origin" "-40 -1408 -544"
+"light" "150"
+"classname" "light"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"origin" "-88 -1408 -544"
+"classname" "light"
+"light" "150"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"origin" "-96 -1408 -600"
+"light" "200"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-96 -976 -744"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-32 -976 -744"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-32 -1408 -488"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-96 -1408 -488"
+"_color" "0.756863 0.807843 1.000000"
+}
+{
+"_color" "0.615686 0.615686 1.000000"
+"classname" "light"
+"light" "200"
+"origin" "-64 256 80"
+}
+{
+"origin" "88 -1568 -648"
+"light" "150"
+"classname" "light"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"origin" "88 -1504 -648"
+"light" "150"
+"classname" "light"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"classname" "light"
+"light" "225"
+"origin" "-928 -1248 -704"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-216 -1568 -648"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-216 -1504 -648"
+"_color" "1.000000 0.733333 0.733333"
+}
+{
+"classname" "target_blaster"
+"angle" "270"
+"targetname" "gun4"
+"origin" "-856 488 -564"
+"dmg" "15"
+"spawnflags" "2048"
+}
+{
+"origin" "-928 488 -564"
+"angle" "270"
+"targetname" "gun1"
+"classname" "target_blaster"
+"dmg" "15"
+"spawnflags" "2048"
+}
+{
+"angle" "270"
+"origin" "-904 488 -564"
+"targetname" "gun2"
+"classname" "target_blaster"
+"dmg" "15"
+"spawnflags" "2048"
+}
+{
+"origin" "-880 488 -564"
+"angle" "270"
+"targetname" "gun3"
+"classname" "target_blaster"
+"dmg" "15"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-832 528 -580"
+}
+{
+"model" "*133"
+"classname" "func_door"
+"lip" "6"
+"wait" ".25"
+"speed" "500"
+"angle" "90"
+"delay" ".25"
+"targetname" "gun4"
+"spawnflags" "2048"
+"sounds" "2"
+}
+{
+"model" "*134"
+"delay" ".25"
+"angle" "90"
+"speed" "500"
+"wait" ".25"
+"lip" "6"
+"classname" "func_door"
+"targetname" "gun2"
+"spawnflags" "2048"
+"sounds" "2"
+}
+{
+"model" "*135"
+"delay" ".25"
+"angle" "90"
+"speed" "500"
+"wait" ".25"
+"lip" "6"
+"classname" "func_door"
+"targetname" "gun1"
+"spawnflags" "2048"
+"sounds" "2"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-952 528 -580"
+}
+{
+"model" "*136"
+"team" "traphider"
+"sounds" "0"
+"speed" "200"
+"wait" "-1"
+"angle" "180"
+"classname" "func_door"
+"lip" "8"
+"targetname" "trap_gun"
+"spawnflags" "2048"
+}
+{
+"model" "*137"
+"team" "traphider"
+"classname" "func_door"
+"angle" "0"
+"targetname" "trap_gun"
+"wait" "-1"
+"speed" "200"
+"sounds" "2"
+"lip" "8"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"targetname" "trap_gun"
+"target" "gun1"
+"delay" ".2"
+"origin" "-776 400 -440"
+"spawnflags" "2304"
+}
+{
+"classname" "trigger_relay"
+"targetname" "trap_gun"
+"target" "gun2"
+"delay" ".4"
+"origin" "-752 400 -440"
+"spawnflags" "2304"
+}
+{
+"classname" "trigger_relay"
+"targetname" "trap_gun"
+"target" "gun3"
+"delay" ".6"
+"origin" "-728 400 -440"
+"spawnflags" "2304"
+}
+{
+"classname" "trigger_relay"
+"targetname" "trap_gun"
+"target" "gun4"
+"delay" ".8"
+"origin" "-704 400 -440"
+"spawnflags" "2304"
+}
+{
+"origin" "-64 408 96"
+"_color" "1.000000 1.000000 0.874510"
+"light" "80"
+"classname" "light"
+}
+{
+"_cone" "20"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 1.000000 1.000000"
+"origin" "-64 408 88"
+"target" "t161"
+}
+{
+"classname" "info_notnull"
+"origin" "-65 408 -104"
+"targetname" "t161"
+}

--- a/stuff/mapfixes/baseq2/city3.ent
+++ b/stuff/mapfixes/baseq2/city3.ent
@@ -1,0 +1,7243 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Fixed 2x monster_chick not activating (5016, 5023)
+//
+// Their targetname, t125, was never triggered. Set it to t257 instead,
+// which is activated by using the Data Spinner. Also set spawnflags of
+// one of them from 2051 to 3, as the 2048 flag is unnecessary for monsters.
+//
+// 2. Removed DM-only items from SP/co-op
+//
+// A Grenade Launcher and Grenades (99, 104) are located in a room
+// only accessible in DM. Set their spawnflags from 0 to 1792.
+{
+"nextmap" "boss1"
+"sky" "unit9_"
+"sounds" "4"
+"message" "Upper Palace"
+"spawnflags" "0"
+"classname" "worldspawn"
+}
+{
+"model" "*1"
+"classname" "func_wall"
+"spawnflags" "2048"
+"_minlight" "0.2"
+}
+{
+"model" "*2"
+"classname" "func_wall"
+"_minlight" "0.8"
+"spawnflags" "2048"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2052"
+"targetname" "t304"
+"noise" "world/x_alarm.wav"
+"volume" "1.0"
+"attenuation" "-1"
+"origin" "-1568 -416 -1016"
+}
+{
+"spawnflags" "1792"
+"classname" "misc_teleporter"
+"angle" "135"
+"target" "telly1"
+"origin" "368 -336 220"
+}
+{
+"spawnflags" "1792"
+"origin" "-408 -664 -88"
+"targetname" "telly1"
+"angle" "90"
+"classname" "misc_teleporter_dest"
+}
+{
+"origin" "-56 -520 224"
+"spawnflags" "2048"
+"classname" "item_power_shield"
+}
+{
+"spawnflags" "2560"
+"origin" "-208 -256 -408"
+"classname" "item_health"
+}
+{
+"origin" "128 64 -96"
+"spawnflags" "1792"
+"classname" "weapon_railgun"
+}
+{
+"origin" "-608 -128 256"
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "-624 -448 224"
+"spawnflags" "1792"
+"classname" "ammo_rockets"
+}
+{
+"origin" "247 544 236"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "295 544 236"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "343 544 236"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "199 544 252"
+"spawnflags" "1792"
+"classname" "item_health_small"
+}
+{
+"origin" "-414 436 242"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"spawnflags" "1792"
+"origin" "-414 284 244"
+"classname" "weapon_grenadelauncher"
+}
+{
+"model" "*3"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"origin" "584 520 82"
+"angle" "-1"
+"spawnflags" "2057"
+"classname" "target_laser"
+"target" "com8"
+"targetname" "com7"
+}
+{
+"origin" "600 520 82"
+"angle" "-1"
+"spawnflags" "2057"
+"classname" "target_laser"
+"target" "com8"
+"targetname" "com7"
+}
+{
+"origin" "600 504 82"
+"angle" "-1"
+"spawnflags" "2057"
+"classname" "target_laser"
+"target" "com8"
+"targetname" "com7"
+}
+{
+"origin" "-120 -256 -408"
+"classname" "item_silencer"
+}
+{
+"classname" "monster_gunner"
+"angle" "0"
+"spawnflags" "769"
+"origin" "-168 -296 -400"
+}
+{
+"classname" "ammo_slugs"
+"origin" "-208 -256 -360"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "48 -472 -104"
+}
+{
+"spawnflags" "1792"
+"origin" "8 -472 -104"
+"classname" "item_armor_shard"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "128 -472 -104"
+}
+{
+"spawnflags" "1792"
+"origin" "88 -472 -104"
+"classname" "item_armor_shard"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "208 -472 -104"
+}
+{
+"spawnflags" "1792"
+"origin" "168 -472 -104"
+"classname" "item_armor_shard"
+}
+{
+"spawnflags" "1792"
+"origin" "-32 -472 -104"
+"classname" "item_armor_shard"
+}
+{
+"origin" "312 -472 -104"
+"classname" "item_health_large"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "184 -520 -552"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-1651 -556 -1104"
+}
+{
+"origin" "-700 -470 -998"
+"spawnflags" "259"
+"classname" "monster_soldier_light"
+"angle" "0"
+"targetname" "pg1"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "488 1248 358"
+"_color" "1.000000 0.292490 0.193676"
+}
+{
+"deathtarget" "t243"
+"spawnflags" "257"
+"origin" "128 -468 -540"
+"angle" "180"
+"classname" "monster_soldier"
+"item" "ammo_shells"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "90"
+"origin" "-606 -585 -87"
+"spawnflags" "768"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "45"
+"origin" "-486 -441 -87"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-24 744 55"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-24 616 55"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "40 744 55"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "40 680 55"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "40 616 55"
+}
+{
+"origin" "-88 744 55"
+"classname" "light"
+"light" "32"
+}
+{
+"origin" "-88 680 55"
+"classname" "light"
+"light" "32"
+}
+{
+"origin" "-88 616 55"
+"classname" "light"
+"light" "32"
+}
+{
+"origin" "40 536 23"
+"classname" "light"
+"light" "48"
+}
+{
+"light" "32"
+"_color" "1.000000 0.774704 0.304348"
+"classname" "light"
+"origin" "-64 -128 326"
+}
+{
+"light" "32"
+"_color" "1.000000 0.774704 0.304348"
+"classname" "light"
+"origin" "0 -128 326"
+}
+{
+"light" "32"
+"_color" "1.000000 0.774704 0.304348"
+"classname" "light"
+"origin" "64 -128 326"
+}
+{
+"light" "32"
+"_color" "1.000000 0.774704 0.304348"
+"classname" "light"
+"origin" "128 -128 326"
+}
+{
+"light" "32"
+"_color" "1.000000 0.774704 0.304348"
+"classname" "light"
+"origin" "192 -128 326"
+}
+{
+"light" "150"
+"_color" "1.000000 0.774704 0.304348"
+"classname" "light"
+"origin" "256 -128 294"
+}
+{
+"style" "1"
+"classname" "func_areaportal"
+"targetname" "t303"
+}
+{
+"style" "2"
+"classname" "func_areaportal"
+"targetname" "t302"
+}
+{
+"style" "3"
+"classname" "func_areaportal"
+"targetname" "t301"
+}
+{
+"model" "*4"
+"classname" "func_door"
+"angle" "180"
+"team" "portal2"
+"lip" "16"
+"wait" "3"
+"_minlight" "0.2"
+"target" "t302"
+"spawnflags" "8"
+}
+{
+"model" "*5"
+"sounds" "3"
+"classname" "func_door"
+"angle" "0"
+"team" "portal2"
+"lip" "16"
+"wait" "3"
+"_minlight" "0.2"
+"target" "t302"
+"spawnflags" "8"
+}
+{
+"model" "*6"
+"wait" "3"
+"lip" "16"
+"team" "p2"
+"angle" "0"
+"classname" "func_door"
+"sounds" "3"
+"_minlight" "0.2"
+"target" "t301"
+"spawnflags" "8"
+}
+{
+"model" "*7"
+"wait" "3"
+"lip" "16"
+"team" "p2"
+"angle" "180"
+"classname" "func_door"
+"_minlight" "0.2"
+"target" "t301"
+"spawnflags" "8"
+}
+{
+"model" "*8"
+"classname" "func_door"
+"spawnflags" "1"
+"targetname" "left_elev"
+"angle" "-2"
+"sounds" "4"
+"speed" "150"
+"wait" "1.75"
+}
+{
+"model" "*9"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*10"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"classname" "trigger_relay"
+"targetname" "pg1"
+"killtarget" "yelmsg"
+"spawnflags" "2048"
+"origin" "948 1288 168"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "88 -568 -504"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "8 -568 -504"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "168 -568 -504"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "-72 -568 -504"
+}
+{
+"origin" "16 -304 -648"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "trigger_relay"
+"killtarget" "bluemsg"
+"targetname" "pg2"
+"origin" "176 496 268"
+}
+{
+"model" "*11"
+"message" "This force field is activated\nby the communication laser."
+"classname" "trigger_multiple"
+"targetname" "bluemsg"
+"wait" "3"
+"spawnflags" "2048"
+}
+{
+"model" "*12"
+"classname" "trigger_multiple"
+"targetname" "bluemsg"
+"message" "This force field is activated\nby the communication laser."
+"wait" "3"
+"spawnflags" "2048"
+}
+{
+"model" "*13"
+"classname" "trigger_multiple"
+"message" "Security pass required\nto deactivate yellow force fields."
+"targetname" "yelmsg"
+"spawnflags" "2048"
+"wait" "3"
+}
+{
+"model" "*14"
+"classname" "trigger_multiple"
+"targetname" "yelmsg"
+"message" "Security pass required\nto deactivate yellow force fields."
+"wait" "3"
+"spawnflags" "2048"
+}
+{
+"origin" "-64 -552 -560"
+"classname" "item_health_large"
+"spawnflags" "2048"
+}
+{
+"classname" "item_health_large"
+"origin" "-24 -552 -560"
+}
+{
+"classname" "trigger_relay"
+"targetname" "passmsg"
+"message" "Security pass grants\naccess to\nforce field control chamber."
+"origin" "-464 -240 -336"
+}
+{
+"model" "*15"
+"classname" "trigger_multiple"
+"target" "t281"
+}
+{
+"origin" "172 -168 -112"
+"classname" "item_pack"
+}
+{
+"origin" "168 -376 -648"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb11.wav"
+"origin" "-40 80 -120"
+}
+{
+"targetname" "city3NH"
+"origin" "-500 -902 -84"
+"angle" "45"
+"classname" "info_player_coop"
+}
+{
+"targetname" "city3NH"
+"origin" "-400 -902 -84"
+"angle" "135"
+"classname" "info_player_coop"
+}
+{
+"targetname" "city3NH"
+"classname" "info_player_coop"
+"angle" "90"
+"origin" "-492 -662 -88"
+}
+{
+"targetname" "city3NL"
+"origin" "-112 -1188 -888"
+"angle" "180"
+"classname" "info_player_coop"
+}
+{
+"targetname" "city3NL"
+"origin" "-168 -1224 -896"
+"angle" "180"
+"classname" "info_player_coop"
+}
+{
+"targetname" "city3NL"
+"origin" "-224 -1216 -900"
+"angle" "180"
+"classname" "info_player_start"
+}
+{
+"model" "*16"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*17"
+"classname" "func_wall"
+"spawnflags" "3840"
+}
+{
+"origin" "176 680 -44"
+"light" "150"
+"spawnflags" "1792"
+"classname" "light"
+}
+{
+"origin" "46 670 242"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-586 -588 -88"
+"spawnflags" "1792"
+"classname" "weapon_shotgun"
+}
+{
+"origin" "-576 384 232"
+"spawnflags" "257"
+"classname" "monster_floater"
+}
+{
+"origin" "-288 368 232"
+"spawnflags" "257"
+"classname" "monster_floater"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "-72 -472 -104"
+}
+{
+"model" "*18"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "225"
+"origin" "308 80 -96"
+}
+{
+"classname" "item_health"
+"origin" "172 -80 -112"
+}
+{
+"angle" "270"
+"classname" "monster_gunner"
+"targetname" "bob"
+"origin" "296 64 -92"
+"item" "ammo_grenades"
+}
+{
+"item" "item_armor_shard"
+"angle" "0"
+"classname" "monster_gunner"
+"targetname" "bob"
+"origin" "168 64 -80"
+}
+{
+"classname" "path_corner"
+"origin" "36 -448 -112"
+"target" "t294"
+"targetname" "t297"
+"spawnflags" "2048"
+}
+{
+"origin" "-112 -444 -112"
+"classname" "path_corner"
+"targetname" "t294"
+"target" "t295"
+"spawnflags" "2048"
+}
+{
+"origin" "-116 -448 -112"
+"classname" "path_corner"
+"targetname" "t296"
+"target" "t297"
+"spawnflags" "2048"
+}
+{
+"origin" "-128 -300 -108"
+"classname" "path_corner"
+"targetname" "t295"
+"target" "t296"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1"
+"angle" "0"
+"classname" "monster_soldier"
+"origin" "-124 -284 -96"
+"target" "t295"
+}
+{
+"classname" "path_corner"
+"origin" "276 -456 -112"
+"targetname" "t290"
+"target" "t291"
+"spawnflags" "2048"
+}
+{
+"origin" "136 -468 -112"
+"classname" "path_corner"
+"target" "t290"
+"targetname" "t293"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "300 -320 -108"
+"targetname" "t291"
+"target" "t292"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "280 -460 -112"
+"targetname" "t292"
+"target" "t293"
+"spawnflags" "2048"
+}
+{
+"item" "ammo_shells"
+"spawnflags" "1"
+"angle" "0"
+"classname" "monster_soldier"
+"origin" "-40 -288 -96"
+}
+{
+"style" "4"
+"targetname" "t289"
+"classname" "func_areaportal"
+}
+{
+"model" "*19"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*20"
+"target" "t289"
+"spawnflags" "1792"
+"lip" "8"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*21"
+"classname" "func_door"
+"angle" "-1"
+"lip" "86"
+"_minlight" "0.2"
+"sounds" "1"
+"speed" "100"
+"targetname" "t149"
+"wait" "2"
+}
+{
+"_color" "1.000000 0.940945 0.708661"
+"origin" "-608 -624 -56"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.940945 0.708661"
+"origin" "-304 -624 -56"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-280 -284 -644"
+"classname" "point_combat"
+"spawnflags" "2048"
+"targetname" "t287"
+}
+{
+"model" "*22"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*23"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*24"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*25"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*26"
+"classname" "func_button"
+"angle" "270"
+"lip" "3"
+"message" "Yellow Force Fields Deactivated."
+"target" "t147"
+"wait" "-1"
+"_minlight" "0.8"
+"spawnflags" "2048"
+}
+{
+"model" "*27"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*28"
+"wait" "0.5"
+"lip" "4"
+"sounds" "4"
+"spawnflags" "2048"
+"angle" "180"
+"_minlight" "0.8"
+"classname" "func_button"
+"target" "reddoor1"
+}
+{
+"model" "*29"
+"spawnflags" "2048"
+"_minlight" "0.1"
+"classname" "func_wall"
+}
+{
+"model" "*30"
+"classname" "func_wall"
+"_minlight" "0.1"
+"spawnflags" "2048"
+}
+{
+"model" "*31"
+"wait" "0.5"
+"classname" "func_button"
+"_minlight" "0.8"
+"angle" "180"
+"spawnflags" "2048"
+"sounds" "4"
+"lip" "4"
+"target" "reddoor2"
+}
+{
+"model" "*32"
+"spawnflags" "2048"
+"_minlight" "0.1"
+"classname" "func_wall"
+}
+{
+"model" "*33"
+"wait" "0.5"
+"target" "reddoor2"
+"lip" "4"
+"sounds" "4"
+"spawnflags" "2048"
+"angle" "180"
+"_minlight" "0.8"
+"classname" "func_button"
+}
+{
+"model" "*34"
+"wait" "0.5"
+"classname" "func_button"
+"_minlight" "0.8"
+"angle" "0"
+"spawnflags" "2048"
+"sounds" "4"
+"lip" "4"
+"target" "t173"
+}
+{
+"model" "*35"
+"classname" "func_wall"
+"_minlight" "0.1"
+"spawnflags" "2048"
+}
+{
+"targetname" "t286"
+"origin" "-452 -296 -644"
+"classname" "point_combat"
+}
+{
+"model" "*36"
+"targetname" "t281"
+"_minlight" "0.3"
+"delay" ".25"
+"wait" "4"
+"lip" "20"
+"speed" "225"
+"angle" "-1"
+"classname" "func_door"
+"sounds" "4"
+}
+{
+"model" "*37"
+"_minlight" "0.2"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"classname" "info_notnull"
+"targetname" "t285"
+"origin" "-336 36 -64"
+}
+{
+"style" "32"
+"classname" "light"
+"targetname" "com7"
+"_color" "0.070866 0.444882 1.000000"
+"origin" "592 512 80"
+}
+{
+"classname" "target_laser"
+"spawnflags" "2057"
+"angle" "-1"
+"targetname" "com7"
+"origin" "584 504 82"
+"target" "com8"
+}
+{
+"model" "*38"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*39"
+"origin" "592 512 320"
+"classname" "func_rotating"
+"spawnflags" "2049"
+"speed" "50"
+"targetname" "com2"
+}
+{
+"model" "*40"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"model" "*41"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "624 16 224"
+}
+{
+"model" "*42"
+"classname" "func_wall"
+"spawnflags" "2048"
+"_minlight" "0.1"
+}
+{
+"model" "*43"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*44"
+"classname" "func_wall"
+"_minlight" "0.1"
+"spawnflags" "1792"
+}
+{
+"model" "*45"
+"classname" "func_button"
+"angle" "90"
+"lip" "4"
+"_minlight" "0.6"
+"spawnflags" "1792"
+"target" "endplat"
+}
+{
+"model" "*46"
+"classname" "trigger_once"
+"target" "t275"
+}
+{
+"model" "*47"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"origin" "32 -368 -632"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"classname" "weapon_hyperblaster"
+"spawnflags" "1792"
+"origin" "-448 68 408"
+}
+{
+"origin" "-456 696 112"
+"classname" "light"
+"light" "120"
+}
+{
+"model" "*48"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "-448 -1152 -728"
+"targetname" "farend"
+"angle" "0"
+"classname" "misc_teleporter_dest"
+}
+{
+"origin" "-488 -1128 -664"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "-472 -1192 -664"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "-488 -1176 -664"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "-472 -1112 -664"
+"light" "32"
+"classname" "light"
+}
+{
+"model" "*49"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*50"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-376 -296 -760"
+"spawnflags" "1792"
+"classname" "item_power_shield"
+"team" "shield"
+}
+{
+"origin" "-376 -296 -760"
+"spawnflags" "1792"
+"team" "shield"
+"classname" "ammo_cells"
+}
+{
+"model" "*51"
+"spawnflags" "1792"
+"wait" "2"
+"angle" "0"
+"health" "2"
+"classname" "func_door"
+}
+{
+"model" "*52"
+"targetname" "t56"
+"dmg" "1"
+"classname" "func_explosive"
+}
+{
+"spawnflags" "1792"
+"origin" "-504 -172 -968"
+"classname" "ammo_bullets"
+}
+{
+"classname" "ammo_grenades"
+"origin" "-602 -164 -404"
+"spawnflags" "0"
+}
+{
+"origin" "-312 32 -408"
+"classname" "weapon_grenadelauncher"
+"spawnflags" "1792"
+}
+{
+"origin" "-312 -24 -408"
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+}
+{
+"target" "bfgtpd"
+"origin" "-216 16 -400"
+"angle" "225"
+"spawnflags" "1792"
+"classname" "misc_teleporter"
+}
+{
+"model" "*53"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"model" "*54"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"origin" "696 896 80"
+"spawnflags" "1792"
+"classname" "weapon_shotgun"
+}
+{
+"targetname" "bfgtpd"
+"origin" "-616 440 -104"
+"spawnflags" "1792"
+"angle" "315"
+"classname" "misc_teleporter_dest"
+}
+{
+"origin" "912 1512 144"
+"light" "64"
+"classname" "light"
+}
+{
+"model" "*55"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*56"
+"classname" "func_door_secret"
+"spawnflags" "3"
+"wait" "5"
+"angle" "0"
+"_minlight" "0.1"
+}
+{
+"team" "green"
+"origin" "200 1496 312"
+"spawnflags" "1792"
+"classname" "item_power_shield"
+}
+{
+"origin" "336 1616 512"
+"classname" "item_health_large"
+"spawnflags" "3072"
+}
+{
+"target" "farend"
+"origin" "592 512 216"
+"spawnflags" "1792"
+"angle" "90"
+"classname" "misc_teleporter"
+}
+{
+"origin" "-628 244 -20"
+"angles" "-45 45 0"
+"classname" "info_player_intermission"
+}
+{
+"targetname" "t284"
+"classname" "misc_teleporter_dest"
+"angle" "90"
+"origin" "-328 88 408"
+"spawnflags" "1792"
+}
+{
+"model" "*57"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"target" "t284"
+"classname" "misc_teleporter"
+"spawnflags" "1792"
+"origin" "-48 -32 -632"
+}
+{
+"model" "*58"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"origin" "216 552 311"
+"classname" "light"
+"light" "32"
+}
+{
+"origin" "296 472 311"
+"classname" "light"
+"light" "32"
+}
+{
+"origin" "216 472 311"
+"classname" "light"
+"light" "32"
+}
+{
+"origin" "296 552 311"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "360 1384 264"
+"target" "t2"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"model" "*59"
+"_minlight" "0.1"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"classname" "item_health"
+"spawnflags" "1792"
+"origin" "167 -169 215"
+}
+{
+"classname" "item_armor_combat"
+"spawnflags" "1792"
+"origin" "324 101 215"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health"
+"origin" "119 -168 215"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "617 167 224"
+}
+{
+"origin" "480 1216 320"
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+}
+{
+"origin" "528 1216 320"
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+}
+{
+"origin" "528 1216 272"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"classname" "item_health_large"
+"origin" "-144 1280 240"
+}
+{
+"model" "*60"
+"angle" "-2"
+"classname" "func_door"
+"speed" "25"
+"sounds" "1"
+"spawnflags" "1824"
+"targetname" "t282"
+"_minlight" "0.3"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_railgun"
+"origin" "544 928 208"
+}
+{
+"classname" "item_armor_body"
+"spawnflags" "1792"
+"origin" "152 680 -80"
+}
+{
+"model" "*61"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"model" "*62"
+"spawnflags" "1792"
+"lip" "8"
+"classname" "func_door"
+"angle" "-1"
+"wait" "5"
+"speed" "200"
+"sounds" "0"
+"team" "door8"
+"targetname" "t283"
+"health" "5"
+}
+{
+"model" "*63"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"classname" "item_armor_jacket"
+"spawnflags" "1792"
+"origin" "-456 96 12"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "660 440 176"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "696 556 176"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "644 612 176"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "528 608 176"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "508 516 208"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "508 444 176"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "592 392 176"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1792"
+"origin" "-330 -592 -88"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "40 472 23"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "88 472 23"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "88 536 23"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "-8 536 23"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "-56 536 23"
+}
+{
+"classname" "light"
+"light" "48"
+"origin" "-8 472 23"
+}
+{
+"origin" "8 768 -112"
+"classname" "item_health"
+"spawnflags" "1792"
+}
+{
+"origin" "-32 768 -112"
+"classname" "ammo_cells"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_cells"
+"origin" "-456 584 160"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_cells"
+"origin" "-336 664 160"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-120 -400 216"
+}
+{
+"spawnflags" "2048"
+"origin" "-1256 -392 -1072"
+"classname" "item_armor_body"
+}
+{
+"classname" "item_health_small"
+"origin" "-720 -560 -1000"
+}
+{
+"classname" "item_health_small"
+"origin" "-800 -560 -1000"
+}
+{
+"classname" "item_health_small"
+"origin" "-760 -560 -1000"
+}
+{
+"classname" "item_health_small"
+"origin" "-680 -560 -1000"
+}
+{
+"origin" "-208 -464 -624"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_shells"
+"origin" "-184 -424 -624"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_slugs"
+"origin" "-312 -1252 -732"
+}
+{
+"classname" "weapon_supershotgun"
+"spawnflags" "1792"
+"origin" "-368 -1256 -728"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+"origin" "-432 -144 -784"
+}
+{
+"spawnflags" "2048"
+"origin" "-504 -172 -984"
+"classname" "ammo_grenades"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "1792"
+"origin" "-1376 -432 -1200"
+}
+{
+"origin" "-1376 -392 -1224"
+"classname" "item_adrenaline"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1792"
+"origin" "-602 -204 -364"
+"classname" "ammo_cells"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_hyperblaster"
+"origin" "-448 -148 -368"
+}
+{
+"spawnflags" "2048"
+"classname" "key_pass"
+"origin" "-448 -116 -344"
+"target" "passmsg"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-320 -104 -408"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1792"
+"origin" "0 -272 -408"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1024"
+"origin" "48 -272 -408"
+}
+{
+"classname" "weapon_supershotgun"
+"spawnflags" "1792"
+"origin" "0 -298 -104"
+}
+{
+"classname" "ammo_slugs"
+"origin" "184 -536 216"
+}
+{
+"spawnflags" "2048"
+"origin" "212 -496 216"
+"classname" "item_invulnerability"
+}
+{
+"team" "ammo2"
+"classname" "ammo_rockets"
+"origin" "-716 -250 -598"
+"spawnflags" "1792"
+}
+{
+"team" "ammo2"
+"classname" "ammo_cells"
+"origin" "-715 -292 -598"
+"spawnflags" "1792"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-716 -250 -638"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-715 -292 -638"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"origin" "-296 28 -48"
+"classname" "ammo_slugs"
+}
+{
+"spawnflags" "2048"
+"origin" "-372 32 -48"
+"classname" "ammo_cells"
+}
+{
+"spawnflags" "2048"
+"origin" "-332 40 -48"
+"classname" "item_adrenaline"
+}
+{
+"classname" "weapon_machinegun"
+"origin" "-464 156 -110"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_cells"
+"origin" "-280 512 -40"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_cells"
+"origin" "-232 512 -40"
+}
+{
+"classname" "weapon_bfg"
+"spawnflags" "1792"
+"origin" "912 1512 112"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health_large"
+"origin" "872 1408 80"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "270"
+"origin" "992 1056 88"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"origin" "-608 176 -104"
+}
+{
+"spawnflags" "2048"
+"classname" "item_quad"
+"origin" "-280 600 -200"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "-16 -168 -112"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"origin" "-1489 -368 -1119"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "225"
+"origin" "-320 -1024 -744"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "0"
+"origin" "-112 -352 224"
+}
+{
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+"classname" "light"
+"origin" "592 248 342"
+}
+{
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+"classname" "light"
+"origin" "592 208 342"
+}
+{
+"classname" "light"
+"_color" "1.000000 0.796078 0.003922"
+"light" "100"
+"origin" "592 160 334"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "270"
+"origin" "528 1000 200"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "225"
+"origin" "520 1272 280"
+}
+{
+"model" "*64"
+"classname" "func_wall"
+"spawnflags" "1792"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "-24 856 351"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "24 792 351"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "-24 792 351"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "24 728 351"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "-24 728 351"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "24 664 351"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "-24 664 351"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "24 600 351"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "-24 600 351"
+}
+{
+"light" "100"
+"classname" "light"
+"_color" "1.000000 0.796078 0.003922"
+"origin" "0 904 327"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "24 856 351"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-24 472 311"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "-24 552 311"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "-104 472 311"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "-104 552 311"
+}
+{
+"light" "32"
+"classname" "light"
+"origin" "56 552 311"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "56 472 311"
+}
+{
+"classname" "info_player_deathmatch"
+"origin" "-344 624 160"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "-240 40 -48"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"origin" "-80 488 248"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "-408 -592 -609"
+}
+{
+"classname" "light"
+"light" "48"
+"origin" "-488 -592 -609"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "-392 -968 -633"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "-392 -904 -633"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "-504 -904 -633"
+}
+{
+"classname" "light"
+"light" "48"
+"origin" "-504 -968 -633"
+}
+{
+"team" "green"
+"spawnflags" "1792"
+"origin" "200 1496 288"
+"classname" "item_invulnerability"
+}
+{
+"origin" "120 1496 264"
+"target" "t282"
+"spawnflags" "1793"
+"wait" "5"
+"classname" "func_timer"
+}
+{
+"origin" "-448 -556 -1004"
+"angle" "135"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-204 -368 -632"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-576 76 408"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "36 -380 -400"
+"angle" "45"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "824 408 296"
+"angle" "135"
+"classname" "info_player_deathmatch"
+}
+{
+"model" "*65"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "520 772 88"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-56 760 -104"
+"angle" "315"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-448 -384 -88"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-456 -432 216"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "0 312 -208"
+"angle" "225"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-440 -1040 -848"
+"spawnflags" "1792"
+"team" "qbest"
+"classname" "item_quad"
+}
+{
+"_color" "0.003937 0.476378 1.000000"
+"origin" "-696 -272 -554"
+"light" "64"
+"classname" "light"
+}
+{
+"model" "*66"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"model" "*67"
+"target" "t281"
+"delay" "0.5"
+"classname" "trigger_multiple"
+"wait" "15"
+}
+{
+"model" "*68"
+"target" "t281"
+"classname" "trigger_multiple"
+}
+{
+"model" "*69"
+"spawnflags" "1792"
+"target" "t280"
+"wait" "1"
+"classname" "func_button"
+"angle" "-1"
+"lip" "4"
+"health" "5"
+}
+{
+"model" "*70"
+"targetname" "t280"
+"spawnflags" "1792"
+"classname" "func_door"
+"angle" "180"
+"wait" "5"
+"_minlight" "0.2"
+"sounds" "3"
+}
+{
+"model" "*71"
+"health" "5"
+"classname" "func_door"
+"angle" "-1"
+"wait" "5"
+"sounds" "2"
+"spawnflags" "1792"
+}
+{
+"origin" "600 664 312"
+"targetname" "t145"
+"killtarget" "block"
+"classname" "trigger_relay"
+}
+{
+"model" "*72"
+"targetname" "block"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "432 1255 304"
+}
+{
+"spawnflags" "2048"
+"light" "48"
+"classname" "light"
+"origin" "480 1287 304"
+}
+{
+"origin" "528 1255 304"
+"classname" "light"
+"light" "64"
+}
+{
+"model" "*73"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*74"
+"spawnflags" "2048"
+"_minlight" "0.8"
+"classname" "func_wall"
+}
+{
+"model" "*75"
+"_minlight" "0.2"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-812 -536 -1004"
+"target" "steps"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"model" "*76"
+"spawnflags" "2048"
+"_minlight" "0.1"
+"classname" "func_wall"
+}
+{
+"origin" "-436 -1044 -848"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-352 -1044 -848"
+"light" "80"
+"classname" "light"
+}
+{
+"model" "*77"
+"health" "5"
+"wait" "6"
+"sounds" "3"
+"spawnflags" "1792"
+"angle" "-2"
+"classname" "func_door"
+"_minlight" "0.1"
+}
+{
+"model" "*78"
+"health" "5"
+"_minlight" "0.1"
+"angle" "-1"
+"spawnflags" "1792"
+"classname" "func_door"
+}
+{
+"origin" "-424 -184 -376"
+"target" "t80"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"targetname" "t162"
+"origin" "-447 -956 52"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"origin" "-448 -344 -24"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-560 32 280"
+"noise" "world/amb2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-640 -464 248"
+"noise" "world/amb2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb2.wav"
+"origin" "-560 32 -8"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb11.wav"
+"origin" "-448 -336 248"
+}
+{
+"noise" "World/amb15.wav"
+"targetname" "pg2"
+"classname" "target_speaker"
+"spawnflags" "2049"
+"origin" "664 504 232"
+}
+{
+"noise" "World/amb15.wav"
+"targetname" "pg2"
+"classname" "target_speaker"
+"spawnflags" "2049"
+"origin" "536 520 232"
+}
+{
+"noise" "World/amb15.wav"
+"targetname" "pg2"
+"classname" "target_speaker"
+"spawnflags" "2049"
+"origin" "600 568 232"
+}
+{
+"noise" "World/amb15.wav"
+"targetname" "pg2"
+"origin" "584 456 232"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"targetname" "t279"
+"origin" "-576 56 424"
+"classname" "target_explosion"
+"dmg" "1"
+"spawnflags" "2048"
+}
+{
+"wait" "5"
+"origin" "-352 56 424"
+"target" "t279"
+"spawnflags" "2049"
+"classname" "func_timer"
+}
+{
+"origin" "-328 56 424"
+"targetname" "t279"
+"dmg" "1"
+"classname" "target_explosion"
+"spawnflags" "2048"
+}
+{
+"origin" "-376 136 -120"
+"classname" "light"
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-520 136 -120"
+"classname" "light"
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-648 136 -120"
+"classname" "light"
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-648 248 -120"
+"classname" "light"
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-648 360 -120"
+"classname" "light"
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-648 472 -120"
+"classname" "light"
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-520 472 -120"
+"classname" "light"
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-376 472 -120"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-248 472 -120"
+"classname" "light"
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-248 360 -120"
+"classname" "light"
+"light" "48"
+"_color" "1.000000 0.796078 0.003922"
+}
+{
+"origin" "-248 136 -120"
+"_color" "1.000000 0.796078 0.003922"
+"light" "48"
+"classname" "light"
+}
+{
+"origin" "-352 584 176"
+"spawnflags" "2048"
+"targetname" "t278"
+"classname" "target_secret"
+}
+{
+"model" "*79"
+"spawnflags" "2048"
+"message" "You have found a secret area."
+"target" "t278"
+"classname" "trigger_once"
+}
+{
+"origin" "592 848 240"
+"targetname" "pg2"
+"spawnflags" "2052"
+"attenuation" "-1"
+"noise" "world/comlas1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "544 1004 221"
+"light" "64"
+"classname" "light"
+}
+{
+"spawnflags" "2048"
+"origin" "520 956 221"
+"light" "200"
+"classname" "light"
+}
+{
+"classname" "target_speaker"
+"noise" "world/yelforce.wav"
+"attenuation" "-1"
+"spawnflags" "2052"
+"origin" "920 1344 160"
+"targetname" "t147"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-336 40 40"
+"target" "t285"
+}
+{
+"model" "*80"
+"spawnflags" "2048"
+"target" "t226"
+"classname" "trigger_once"
+}
+{
+"spawnflags" "2048"
+"origin" "-326 -230 243"
+"targetname" "t277"
+"classname" "point_combat"
+}
+{
+"origin" "-127 -146 223"
+"target" "t277"
+"targetname" "t276"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"spawnflags" "257"
+"targetname" "t171"
+"angle" "270"
+"origin" "-103 -103 223"
+"classname" "monster_soldier_ss"
+}
+{
+"spawnflags" "769"
+"targetname" "t171"
+"angle" "180"
+"origin" "-149 -104 223"
+"classname" "monster_soldier_ss"
+}
+{
+"spawnflags" "1"
+"targetname" "t171"
+"angle" "270"
+"origin" "-77 -143 223"
+"classname" "monster_soldier_ss"
+}
+{
+"spawnflags" "257"
+"targetname" "gunguy"
+"origin" "592 280 224"
+"classname" "monster_gunner"
+}
+{
+"spawnflags" "2048"
+"origin" "664 600 168"
+"target" "t273"
+"targetname" "t272"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "528 616 168"
+"target" "t272"
+"targetname" "t271"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "496 512 184"
+"wait" "3"
+"target" "t271"
+"targetname" "t270"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "528 408 168"
+"target" "t270"
+"targetname" "t269"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "648 400 168"
+"target" "t269"
+"targetname" "t268"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"origin" "704 512 168"
+"wait" "3"
+"targetname" "t273"
+"target" "t268"
+"classname" "path_corner"
+}
+{
+"origin" "584 384 200"
+"target" "t269"
+"classname" "monster_gunner"
+}
+{
+"model" "*81"
+"spawnflags" "2048"
+"sounds" "3"
+"targetname" "t267"
+"_minlight" "0.2"
+"wait" "-1"
+"angle" "180"
+"classname" "func_door"
+}
+{
+"model" "*82"
+"spawnflags" "2048"
+"target" "t267"
+"health" "5"
+"lip" "4"
+"angle" "-1"
+"classname" "func_button"
+"wait" "-1"
+}
+{
+"classname" "item_health"
+"spawnflags" "1024"
+"origin" "-408 768 -216"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_rocketlauncher"
+"origin" "336 1616 496"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+"origin" "432 1216 320"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "480 1216 272"
+}
+{
+"light" "200"
+"classname" "light"
+"_color" "1.000000 0.937255 0.705882"
+"origin" "-644 -468 248"
+}
+{
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.937255 0.705882"
+"origin" "-244 -468 248"
+}
+{
+"model" "*83"
+"spawnflags" "2048"
+"classname" "trigger_multiple"
+"target" "148"
+}
+{
+"classname" "point_combat"
+"targetname" "t266"
+"origin" "-428 -296 -644"
+}
+{
+"target" "t286"
+"classname" "monster_soldier_ss"
+"spawnflags" "1"
+"origin" "-584 -288 -628"
+"angle" "0"
+"targetname" "t29"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"targetname" "t239"
+"target" "t265"
+"origin" "-176 -336 -648"
+}
+{
+"spawnflags" "2048"
+"classname" "point_combat"
+"targetname" "t264"
+"origin" "-186 -294 -648"
+"target" "t287"
+}
+{
+"model" "*84"
+"classname" "func_button"
+"angle" "0"
+"sounds" "4"
+"target" "left_elev"
+"delay" "1.5"
+}
+{
+"model" "*85"
+"_minlight" "0.3"
+"classname" "func_button"
+"angle" "0"
+"lip" "2"
+"target" "left_elev"
+"sounds" "4"
+}
+{
+"origin" "12 1244 240"
+"classname" "info_null"
+"targetname" "t263"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"origin" "304 1240 344"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"origin" "176 1240 344"
+"classname" "light"
+"light" "80"
+}
+{
+"classname" "info_null"
+"targetname" "t259"
+"origin" "268 1244 268"
+}
+{
+"origin" "-64 1056 232"
+"noise" "world/lava1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "light"
+"_cone" "10"
+"origin" "140 1244 468"
+"target" "t261"
+"light" "250"
+}
+{
+"origin" "460 1244 468"
+"_cone" "25"
+"classname" "light"
+}
+{
+"origin" "396 1244 468"
+"_cone" "25"
+"classname" "light"
+}
+{
+"origin" "268 1244 468"
+"_cone" "10"
+"classname" "light"
+"target" "t259"
+"light" "250"
+}
+{
+"origin" "12 1244 468"
+"_cone" "10"
+"classname" "light"
+"target" "t263"
+"light" "250"
+}
+{
+"spawnflags" "2048"
+"origin" "480 1303 264"
+"classname" "light"
+"light" "48"
+}
+{
+"model" "*86"
+"classname" "trigger_once"
+"spawnflags" "2052"
+"target" "pg2"
+"targetname" "t257"
+}
+{
+"spawnflags" "2048"
+"classname" "target_help"
+"message" "Locate and use exit\n from Palace."
+"targetname" "pg2"
+"origin" "588 1000 200"
+}
+{
+"model" "*87"
+"spawnflags" "2048"
+"lip" "16"
+"wait" "-1"
+"angle" "90"
+"classname" "func_button"
+"target" "t1"
+}
+{
+"model" "*88"
+"classname" "func_wall"
+"spawnflags" "2055"
+"targetname" "t250"
+}
+{
+"spawnflags" "2048"
+"origin" "-416 -1064 -744"
+"classname" "trigger_relay"
+"targetname" "t32"
+"target" "BobnFred"
+}
+{
+"spawnflags" "2048"
+"classname" "point_combat"
+"targetname" "t253"
+"origin" "-352 -1280 -744"
+}
+{
+"spawnflags" "2048"
+"classname" "point_combat"
+"targetname" "t254"
+"origin" "-336 -1232 -744"
+}
+{
+"model" "*89"
+"targetname" "t80"
+"speed" "10"
+"spawnflags" "2"
+"classname" "func_train"
+"target" "t252"
+}
+{
+"origin" "-488 -152 -424"
+"targetname" "t252"
+"target" "t251"
+"classname" "path_corner"
+}
+{
+"wait" "-1"
+"origin" "-488 -168 -424"
+"target" "t252"
+"targetname" "t251"
+"classname" "path_corner"
+}
+{
+"model" "*90"
+"spawnflags" "2048"
+"targetname" "t250"
+"dmg" "10"
+"classname" "func_explosive"
+"_minlight" "0.1"
+}
+{
+"model" "*91"
+"spawnflags" "2048"
+"target" "t250"
+"health" "40"
+"dmg" "50"
+"classname" "func_explosive"
+"_minlight" "0.1"
+}
+{
+"spawnflags" "2048"
+"classname" "target_secret"
+"targetname" "t249"
+"origin" "-1379 -632 -1144"
+}
+{
+"model" "*92"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"message" "You have found a secret area."
+"target" "t249"
+}
+{
+"targetname" "pg2"
+"origin" "-128 1256 312"
+"noise" "world/klaxon2.wav"
+"volume" "7"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"targetname" "pg2"
+"origin" "-32 648 304"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"volume" "7"
+"noise" "world/klaxon2.wav"
+}
+{
+"origin" "-432 240 128"
+"volume" ".7"
+"noise" "world/battle5.wav"
+"attenuation" "1"
+"targetname" "t248"
+"classname" "target_speaker"
+}
+{
+"origin" "-432 264 128"
+"random" "10"
+"wait" "20"
+"target" "t248"
+"classname" "func_timer"
+}
+{
+"origin" "-304 232 -96"
+"volume" ".4"
+"attenuation" "1"
+"noise" "world/battle5.wav"
+"targetname" "t247"
+"classname" "target_speaker"
+}
+{
+"origin" "-304 256 -96"
+"wait" "15"
+"random" "5"
+"target" "t247"
+"classname" "func_timer"
+}
+{
+"origin" "-440 704 -192"
+"targetname" "t246"
+"classname" "target_secret"
+"spawnflags" "2048"
+}
+{
+"model" "*93"
+"message" "You have found a secret area."
+"target" "t246"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"model" "*94"
+"spawnflags" "1024"
+"classname" "func_wall"
+}
+{
+"origin" "-280 512 -8"
+"classname" "item_health"
+"spawnflags" "1792"
+}
+{
+"origin" "-232 512 -8"
+"classname" "item_health"
+"spawnflags" "1792"
+}
+{
+"origin" "-688 184 -40"
+"classname" "ammo_grenades"
+"spawnflags" "2048"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "720 384 72"
+}
+{
+"classname" "light"
+"light" "32"
+"_color" "0.284585 0.608696 1.000000"
+"origin" "648 456 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "672 432 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "696 408 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "464 384 72"
+}
+{
+"classname" "light"
+"light" "32"
+"_color" "0.284585 0.608696 1.000000"
+"origin" "536 456 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "512 432 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "488 408 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "648 568 72"
+}
+{
+"classname" "light"
+"light" "32"
+"_color" "0.284585 0.608696 1.000000"
+"origin" "720 640 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "696 616 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "672 592 72"
+}
+{
+"classname" "light"
+"light" "32"
+"_color" "0.284585 0.608696 1.000000"
+"origin" "592 696 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "592 664 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "592 632 72"
+}
+{
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+"origin" "592 600 72"
+}
+{
+"origin" "592 424 72"
+"classname" "light"
+"light" "32"
+"_color" "0.284585 0.608696 1.000000"
+}
+{
+"origin" "592 392 72"
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "592 360 72"
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "592 328 72"
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "680 512 72"
+"classname" "light"
+"light" "32"
+"_color" "0.284585 0.608696 1.000000"
+}
+{
+"origin" "712 512 72"
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "744 512 72"
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "776 512 72"
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "488 616 72"
+"classname" "light"
+"light" "32"
+"_color" "0.284585 0.608696 1.000000"
+}
+{
+"origin" "512 592 72"
+"classname" "light"
+"light" "32"
+"_color" "0.284585 0.608696 1.000000"
+}
+{
+"origin" "536 568 72"
+"classname" "light"
+"light" "32"
+"_color" "0.284585 0.608696 1.000000"
+}
+{
+"origin" "464 640 72"
+"_color" "0.284585 0.608696 1.000000"
+"light" "32"
+"classname" "light"
+}
+{
+"model" "*95"
+"spawnflags" "2048"
+"_minlight" ".6"
+"targetname" "t80"
+"sounds" "2"
+"wait" "-1"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"origin" "-448 -116 -388"
+"targetname" "t244"
+"classname" "info_notnull"
+}
+{
+"style" "33"
+"origin" "-448 -116 -300"
+"_cone" "30"
+"light" "200"
+"targetname" "t245"
+"target" "t244"
+"classname" "light"
+}
+{
+"origin" "-664 -296 -616"
+"delay" "5"
+"target" "t243"
+"targetname" "t49"
+"classname" "trigger_relay"
+}
+{
+"model" "*96"
+"spawnflags" "2304"
+"classname" "trigger_once"
+"target" "t242"
+"delay" "2"
+}
+{
+"model" "*97"
+"spawnflags" "2048"
+"target" "t239"
+"classname" "trigger_once"
+}
+{
+"item" "item_armor_shard"
+"origin" "-560 -216 -392"
+"targetname" "t239"
+"spawnflags" "1"
+"angle" "225"
+"classname" "monster_gunner"
+}
+{
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_gunner"
+"origin" "-42 278 -212"
+}
+{
+"classname" "monster_gunner"
+"angle" "90"
+"spawnflags" "257"
+"origin" "-428 286 -134"
+}
+{
+"classname" "target_secret"
+"targetname" "t236"
+"origin" "28 -500 220"
+"spawnflags" "2048"
+}
+{
+"model" "*98"
+"classname" "trigger_once"
+"target" "t236"
+"message" "You have found a secret area."
+"spawnflags" "2048"
+}
+{
+"classname" "info_notnull"
+"targetname" "t234"
+"origin" "212 -496 244"
+}
+{
+"style" "34"
+"classname" "light"
+"target" "t234"
+"light" "200"
+"_cone" "30"
+"targetname" "t235"
+"origin" "212 -496 284"
+}
+{
+"classname" "weapon_railgun"
+"origin" "212 -496 256"
+"spawnflags" "1792"
+"team" "tm1"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "148 -496 244"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "100 -504 228"
+}
+{
+"model" "*99"
+"sounds" "2"
+"team" "grate"
+"angle" "270"
+"classname" "func_door"
+"lip" "4"
+}
+{
+"model" "*100"
+"team" "grate"
+"angle" "90"
+"classname" "func_door"
+"lip" "4"
+}
+{
+"model" "*101"
+"spawnflags" "2048"
+"targetname" "t243"
+"classname" "func_explosive"
+"mass" "700"
+"dmg" "1"
+}
+{
+"target" "t51"
+"spawnflags" "1"
+"classname" "monster_chick"
+"angle" "0"
+"origin" "-200 -128 -616"
+"targetname" "t265"
+}
+{
+"targetname" "t239"
+"origin" "-180 -376 -632"
+"classname" "monster_gunner"
+"angle" "90"
+"spawnflags" "1"
+"target" "t264"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-498 -220 -968"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "2048"
+"classname" "item_adrenaline"
+"origin" "-440 -1040 -896"
+}
+{
+"classname" "point_combat"
+"targetname" "t26"
+"target" "t233"
+"origin" "-328 -1256 -872"
+}
+{
+"model" "*102"
+"targetname" "t29"
+"classname" "func_door"
+"angle" "-2"
+"spawnflags" "2048"
+"sounds" "3"
+"wait" "-1"
+"_minlight" "0.1"
+}
+{
+"classname" "item_health_small"
+"origin" "-460 -1284 -864"
+}
+{
+"classname" "item_health_small"
+"origin" "-508 -1284 -848"
+}
+{
+"classname" "item_health_small"
+"origin" "-548 -1284 -832"
+}
+{
+"classname" "item_health_small"
+"origin" "-588 -1284 -824"
+}
+{
+"model" "*103"
+"spawnflags" "2048"
+"target" "t121"
+"classname" "trigger_once"
+}
+{
+"targetname" "t121"
+"origin" "-256 704 -104"
+"angle" "270"
+"spawnflags" "1"
+"classname" "monster_soldier"
+}
+{
+"targetname" "t121"
+"origin" "-240 648 -104"
+"angle" "270"
+"spawnflags" "1"
+"classname" "monster_soldier"
+}
+{
+"spawnflags" "1792"
+"classname" "weapon_rocketlauncher"
+"origin" "-1376 -392 -1200"
+}
+{
+"_color" "0.567460 1.000000 0.250000"
+"light" "100"
+"classname" "light"
+"origin" "-1264 -376 -1224"
+}
+{
+"_color" "0.567460 1.000000 0.250000"
+"light" "100"
+"classname" "light"
+"origin" "-1176 -352 -1224"
+}
+{
+"classname" "light"
+"light" "100"
+"_color" "0.567460 1.000000 0.250000"
+"origin" "-1112 -352 -1224"
+}
+{
+"classname" "light"
+"light" "100"
+"_color" "0.567460 1.000000 0.250000"
+"origin" "-1336 -376 -1224"
+}
+{
+"classname" "target_laser"
+"angle" "-1"
+"spawnflags" "81"
+"origin" "-1183 -547 -1060"
+}
+{
+"classname" "item_armor_combat"
+"origin" "-1304 -392 -1072"
+"spawnflags" "1792"
+"team" "head"
+}
+{
+"noise" "world/lava1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "200 1480 224"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/lava1.wav"
+"origin" "-220 1338 232"
+}
+{
+"spawnflags" "2048"
+"origin" "648 736 264"
+"targetname" "pg2"
+"classname" "target_goal"
+}
+{
+"spawnflags" "2048"
+"origin" "692 716 256"
+"targetname" "t162"
+"classname" "target_goal"
+}
+{
+"spawnflags" "1"
+"targetname" "pg2"
+"classname" "target_speaker"
+"origin" "588 480 80"
+"noise" "world/pump2.wav"
+}
+{
+"spawnflags" "2049"
+"targetname" "com2"
+"noise" "world/pump2.wav"
+"origin" "584 528 80"
+"classname" "target_speaker"
+}
+{
+"origin" "912 1440 120"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"classname" "target_speaker"
+}
+{
+"style" "5"
+"targetname" "t230"
+"classname" "func_areaportal"
+}
+{
+"origin" "-404 -176 -408"
+"classname" "item_health"
+}
+{
+"deathtarget" "gunguy"
+"origin" "496 48 224"
+"spawnflags" "257"
+"angle" "180"
+"classname" "monster_chick"
+}
+{
+"origin" "163 -273 -161"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/pump1.wav"
+}
+{
+"origin" "99 -273 95"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"model" "*104"
+"sounds" "3"
+"spawnflags" "8"
+"classname" "func_door"
+"angle" "270"
+"team" "portal2"
+"lip" "16"
+"wait" "4"
+"_minlight" "0.2"
+}
+{
+"model" "*105"
+"spawnflags" "8"
+"target" "t230"
+"classname" "func_door"
+"angle" "90"
+"team" "portal2"
+"lip" "16"
+"wait" "4"
+"_minlight" "0.2"
+}
+{
+"classname" "ammo_bullets"
+"origin" "848 448 80"
+}
+{
+"classname" "ammo_bullets"
+"origin" "816 384 80"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/pump1.wav"
+"origin" "-452 -732 -744"
+}
+{
+"origin" "-456 -1056 -752"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/pump2.wav"
+}
+{
+"origin" "-452 -484 -656"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"volume" "0.3"
+"attenuation" "1"
+"targetname" "t229"
+"noise" "world/battle4.wav"
+"origin" "-424 352 464"
+"classname" "target_speaker"
+}
+{
+"target" "t229"
+"random" "10"
+"wait" "60"
+"spawnflags" "1"
+"classname" "func_timer"
+"origin" "-416 280 496"
+}
+{
+"origin" "-448 152 496"
+"targetname" "t226"
+"target" "t228"
+"classname" "func_timer"
+"spawnflags" "0"
+"wait" "60"
+"random" "10"
+}
+{
+"attenuation" "1"
+"volume" "0.6"
+"targetname" "t228"
+"classname" "target_speaker"
+"origin" "-456 208 496"
+"noise" "world/battle4.wav"
+}
+{
+"origin" "-328 104 304"
+"target" "t227"
+"random" "10"
+"wait" "60"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"noise" "world/battle4.wav"
+"targetname" "t227"
+"origin" "-336 48 304"
+"classname" "target_speaker"
+}
+{
+"targetname" "t225"
+"origin" "-552 328 560"
+"attenuation" "1"
+"volume" "1"
+"noise" "world/battle5.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"origin" "-447 -953 126"
+}
+{
+"origin" "-256 -464 248"
+"noise" "world/amb2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-344 -224 16"
+"spawnflags" "2049"
+"targetname" "reddoor1"
+"noise" "world/force1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-576 -224 16"
+"noise" "world/force1.wav"
+"spawnflags" "2049"
+"targetname" "reddoor2"
+"classname" "target_speaker"
+}
+{
+"origin" "256 -324 224"
+"noise" "world/force2.wav"
+"spawnflags" "2048"
+"classname" "target_speaker"
+"targetname" "pg1"
+"attenuation" "3"
+"volume" "0.3"
+}
+{
+"classname" "trigger_relay"
+"origin" "-536 -200 -632"
+"targetname" "t210"
+"delay" "1"
+"target" "t211"
+}
+{
+"classname" "target_speaker"
+"noise" "world/drip3.wav"
+"attenuation" "1"
+"origin" "-568 -184 -712"
+"targetname" "t211"
+}
+{
+"classname" "func_timer"
+"target" "t210"
+"spawnflags" "1"
+"wait" "2"
+"random" "1.5"
+"origin" "-504 -184 -632"
+}
+{
+"attenuation" "2"
+"classname" "target_speaker"
+"noise" "world/drip1.wav"
+"targetname" "t210"
+"volume" "0.6"
+"origin" "-536 -184 -664"
+}
+{
+"classname" "target_speaker"
+"origin" "-376 -152 -600"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+}
+{
+"origin" "-464 -236 -1008"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "216 -324 -648"
+}
+{
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "112 -324 -648"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/pump1.wav"
+"origin" "160 -480 -552"
+}
+{
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+"origin" "-368 -288 -316"
+}
+{
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+"origin" "-272 -136 -320"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"origin" "-584 -288 -344"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"origin" "-444 -176 -392"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "-764 -512 -1020"
+}
+{
+"classname" "func_timer"
+"spawnflags" "1"
+"wait" "4"
+"random" "1.3"
+"target" "t207"
+"origin" "-536 -1096 -648"
+}
+{
+"volume" "0.4"
+"attenuation" "2"
+"noise" "world/l_hum2.wav"
+"classname" "target_speaker"
+"targetname" "t204"
+"origin" "-576 -1056 -648"
+}
+{
+"classname" "target_speaker"
+"noise" "world/spark1.wav"
+"attenuation" "2"
+"volume" "0.3"
+"targetname" "t205"
+"origin" "-576 -1056 -648"
+}
+{
+"classname" "trigger_relay"
+"target" "t205"
+"origin" "-468 -1056 -648"
+"targetname" "t206"
+"delay" "1.2"
+}
+{
+"classname" "target_splash"
+"sounds" "1"
+"angle" "180"
+"targetname" "t205"
+"origin" "-576 -1056 -648"
+}
+{
+"classname" "trigger_relay"
+"target" "t204"
+"targetname" "t200"
+"delay" "1"
+"origin" "-540 -1132 -648"
+}
+{
+"classname" "target_splash"
+"angle" "225"
+"sounds" "1"
+"targetname" "t204"
+"origin" "-576 -1056 -648"
+}
+{
+"origin" "-508 -1024 -648"
+"classname" "trigger_relay"
+"targetname" "t206"
+"target" "t202"
+}
+{
+"classname" "trigger_relay"
+"origin" "-536 -1064 -648"
+"target" "t206"
+"targetname" "t207"
+}
+{
+"classname" "trigger_relay"
+"origin" "-492 -1080 -648"
+"delay" "1.2"
+"targetname" "t206"
+"target" "t202"
+}
+{
+"style" "35"
+"spawnflags" "1"
+"origin" "-576 -1056 -648"
+"classname" "light"
+"light" "100"
+"targetname" "t202"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t201"
+"target" "t199"
+"origin" "-560 -1104 -648"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t201"
+"delay" "1"
+"target" "t199"
+"origin" "-592 -1112 -648"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t200"
+"target" "t201"
+"origin" "-572 -1144 -648"
+}
+{
+"classname" "func_timer"
+"target" "t200"
+"origin" "-556 -1208 -648"
+"spawnflags" "1"
+"wait" "3"
+"random" "1.9"
+}
+{
+"classname" "func_timer"
+"target" "t198"
+"wait" "3"
+"random" "2.5"
+"origin" "-184 -1244 -812"
+"spawnflags" "1"
+}
+{
+"origin" "-216 -1268 -812"
+"noise" "world/drip1.wav"
+"classname" "target_speaker"
+"targetname" "t198"
+"attenuation" "1"
+"volume" "0.3"
+}
+{
+"classname" "func_timer"
+"origin" "-232 -1252 -812"
+"target" "t197"
+"wait" "5"
+"spawnflags" "1"
+}
+{
+"classname" "target_speaker"
+"noise" "world/drip_amb.wav"
+"origin" "-228 -1172 -812"
+"targetname" "t197"
+"attenuation" "2"
+"volume" "0.4"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2048"
+"noise" "world/force1.wav"
+"origin" "256 -324 240"
+"targetname" "pg1"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2049"
+"noise" "world/force1.wav"
+"origin" "912 1300 116"
+"targetname" "pg1"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2049"
+"noise" "world/force1.wav"
+"origin" "144 516 268"
+"targetname" "pg2"
+}
+{
+"noise" "world/force1.wav"
+"spawnflags" "2049"
+"classname" "target_speaker"
+"targetname" "pg1"
+"origin" "-488 -400 -988"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2049"
+"noise" "world/force1.wav"
+"targetname" "pg2"
+"origin" "-152 672 268"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/lava1.wav"
+"origin" "-396 676 -216"
+}
+{
+"style" "6"
+"classname" "func_areaportal"
+"targetname" "t196"
+}
+{
+"model" "*106"
+"classname" "func_door"
+"angle" "90"
+"sounds" "1"
+"team" "short_red"
+"_minlight" "0.2"
+}
+{
+"model" "*107"
+"classname" "func_door"
+"angle" "270"
+"sounds" "2"
+"team" "short_red"
+"target" "t196"
+"_minlight" "0.2"
+}
+{
+"classname" "info_player_coop"
+"angle" "180"
+"targetname" "city3NL"
+"origin" "-112 -1260 -888"
+}
+{
+"spawnflags" "2048"
+"classname" "target_speaker"
+"origin" "-343 -38 287"
+"targetname" "fldsnd1"
+"noise" "world/force3.wav"
+"attenuation" "3"
+"volume" "1"
+}
+{
+"classname" "target_speaker"
+"noise" "world/force1.wav"
+"spawnflags" "2049"
+"targetname" "pg1"
+"origin" "-336 -32 296"
+}
+{
+"origin" "-192 276 -160"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-256 276 -144"
+"light" "56"
+"classname" "light"
+}
+{
+"origin" "-320 276 -128"
+"light" "56"
+"classname" "light"
+}
+{
+"origin" "-384 276 -112"
+"light" "56"
+"classname" "light"
+}
+{
+"origin" "-448 276 -112"
+"light" "56"
+"classname" "light"
+}
+{
+"origin" "-448 660 -80"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-448 596 -80"
+"classname" "light"
+"light" "56"
+}
+{
+"origin" "-448 532 -80"
+"classname" "light"
+"light" "56"
+}
+{
+"origin" "-448 468 -80"
+"classname" "light"
+"light" "56"
+}
+{
+"origin" "-448 404 -80"
+"classname" "light"
+"light" "56"
+}
+{
+"origin" "-448 340 -96"
+"classname" "light"
+"light" "56"
+}
+{
+"origin" "-128 276 -160"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-384 672 -80"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-264 404 -112"
+"classname" "ammo_shells"
+}
+{
+"origin" "-264 456 -112"
+"classname" "ammo_shells"
+}
+{
+"origin" "-288 672 -124"
+"targetname" "t190"
+"classname" "info_notnull"
+}
+{
+"origin" "-288 672 19"
+"_color" "1.000000 0.889764 0.279528"
+"light" "400"
+"_cone" "20"
+"target" "t190"
+"classname" "light"
+}
+{
+"origin" "-224 672 -124"
+"targetname" "t191"
+"classname" "info_null"
+}
+{
+"origin" "-224 672 19"
+"_color" "1.000000 0.889764 0.279528"
+"light" "400"
+"_cone" "20"
+"target" "t191"
+"classname" "light"
+}
+{
+"origin" "-160 672 -124"
+"targetname" "t192"
+"classname" "info_null"
+}
+{
+"origin" "-160 672 19"
+"_color" "1.000000 0.889764 0.279528"
+"light" "400"
+"_cone" "20"
+"target" "t192"
+"classname" "light"
+}
+{
+"origin" "-352 672 -124"
+"targetname" "t189"
+"classname" "info_null"
+}
+{
+"origin" "-352 672 19"
+"_color" "1.000000 0.889764 0.279528"
+"light" "400"
+"_cone" "20"
+"target" "t189"
+"classname" "light"
+}
+{
+"spawnflags" "2048"
+"origin" "-392 -396 -92"
+"classname" "ammo_shells"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-328 -472 208"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-272 -448 208"
+}
+{
+"noise" "world/klaxon2.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"origin" "-448 -448 272"
+"targetname" "pg2"
+}
+{
+"origin" "-440 280 408"
+"classname" "target_speaker"
+"spawnflags" "2"
+"volume" "7"
+"noise" "world/klaxon2.wav"
+"targetname" "pg2"
+}
+{
+"targetname" "pg2"
+"origin" "-56 -344 272"
+"classname" "target_speaker"
+"spawnflags" "2"
+"volume" "7"
+"noise" "world/klaxon2.wav"
+}
+{
+"origin" "360 -152 360"
+"classname" "target_speaker"
+"spawnflags" "2"
+"volume" "7"
+"noise" "world/klaxon2.wav"
+}
+{
+"origin" "616 520 360"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"volume" "7"
+"noise" "world/klaxon2.wav"
+}
+{
+"noise" "world/klaxon2.wav"
+"volume" "7"
+"spawnflags" "2050"
+"classname" "target_speaker"
+"targetname" "pg2"
+"origin" "536 588 304"
+}
+{
+"noise" "world/klaxon2.wav"
+"volume" "7"
+"spawnflags" "2"
+"classname" "target_speaker"
+"origin" "-448 -464 -24"
+"targetname" "pg2"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2050"
+"volume" "7"
+"noise" "world/klaxon2.wav"
+"targetname" "pg2"
+"origin" "264 1464 312"
+}
+{
+"classname" "light"
+"origin" "-184 216 -40"
+"_cone" "20"
+"target" "t186"
+"light" "325"
+}
+{
+"classname" "info_notnull"
+"origin" "-176 216 120"
+"targetname" "t186"
+}
+{
+"classname" "info_notnull"
+"origin" "-176 144 120"
+"targetname" "t187"
+}
+{
+"light" "325"
+"classname" "light"
+"origin" "-184 144 -48"
+"_cone" "20"
+"target" "t187"
+}
+{
+"classname" "light"
+"origin" "-184 72 -48"
+"_cone" "20"
+"target" "t188"
+"light" "325"
+}
+{
+"classname" "info_notnull"
+"origin" "-176 72 120"
+"targetname" "t188"
+}
+{
+"origin" "-184 328 -40"
+"classname" "light"
+"_cone" "20"
+"target" "t185"
+"light" "325"
+}
+{
+"origin" "-176 328 120"
+"classname" "info_notnull"
+"targetname" "t185"
+}
+{
+"origin" "-176 400 120"
+"classname" "info_notnull"
+"targetname" "t178"
+}
+{
+"light" "325"
+"origin" "-184 400 -48"
+"classname" "light"
+"target" "t178"
+"_cone" "20"
+}
+{
+"origin" "-184 472 -48"
+"classname" "light"
+"target" "t177"
+"_cone" "20"
+"light" "325"
+}
+{
+"origin" "-176 472 120"
+"classname" "info_notnull"
+"targetname" "t177"
+}
+{
+"origin" "-720 216 120"
+"classname" "info_notnull"
+"targetname" "t181"
+}
+{
+"origin" "-720 144 120"
+"classname" "info_notnull"
+"targetname" "t180"
+}
+{
+"origin" "-720 72 120"
+"classname" "info_notnull"
+"targetname" "t179"
+}
+{
+"origin" "-712 216 -48"
+"classname" "light"
+"_cone" "20"
+"target" "t181"
+"light" "325"
+}
+{
+"light" "325"
+"origin" "-712 144 -48"
+"classname" "light"
+"_cone" "20"
+"target" "t180"
+}
+{
+"origin" "-712 72 -48"
+"classname" "light"
+"_cone" "20"
+"target" "t179"
+"light" "325"
+}
+{
+"classname" "info_notnull"
+"origin" "-720 400 120"
+"targetname" "t183"
+}
+{
+"classname" "info_notnull"
+"origin" "-720 328 120"
+"targetname" "t182"
+}
+{
+"classname" "info_notnull"
+"origin" "-720 472 120"
+"targetname" "t184"
+}
+{
+"light" "325"
+"classname" "light"
+"origin" "-712 400 -48"
+"_cone" "20"
+"target" "t183"
+}
+{
+"classname" "light"
+"origin" "-712 472 -48"
+"_cone" "20"
+"target" "t184"
+"light" "325"
+}
+{
+"classname" "light"
+"origin" "-712 328 -48"
+"_cone" "20"
+"target" "t182"
+"light" "325"
+}
+{
+"style" "7"
+"classname" "func_areaportal"
+"targetname" "t176"
+}
+{
+"origin" "-328 -284 -16"
+"targetname" "t173"
+"target" "reddoor1"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-328 -292 -48"
+"target" "t174"
+"targetname" "t173"
+"classname" "trigger_relay"
+}
+{
+"origin" "-48 -64 -116"
+"spawnflags" "2"
+"targetname" "t174"
+"classname" "monster_soldier_light"
+"angle" "180"
+}
+{
+"origin" "-20 -128 -116"
+"spawnflags" "2"
+"targetname" "t174"
+"classname" "monster_soldier_light"
+"angle" "180"
+}
+{
+"origin" "-100 -108 -100"
+"spawnflags" "2"
+"targetname" "t174"
+"angle" "180"
+"classname" "monster_soldier_light"
+}
+{
+"model" "*108"
+"sounds" "4"
+"team" "paldoor1"
+"angle" "270"
+"classname" "func_door"
+"target" "t176"
+"_minlight" "0.2"
+"spawnflags" "8"
+}
+{
+"model" "*109"
+"team" "paldoor1"
+"angle" "90"
+"classname" "func_door"
+"_minlight" "0.2"
+"spawnflags" "8"
+}
+{
+"model" "*110"
+"classname" "func_door"
+"angle" "270"
+"team" "comexit"
+"sounds" "3"
+"target" "t175"
+"_minlight" "0.2"
+}
+{
+"model" "*111"
+"classname" "func_door"
+"angle" "90"
+"team" "comexit"
+"_minlight" "0.2"
+}
+{
+"style" "8"
+"classname" "func_areaportal"
+"targetname" "t175"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "536 440 104"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "680 440 104"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "664 600 104"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "600 632 104"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "584 408 104"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "488 520 104"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "728 520 104"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "520 600 104"
+}
+{
+"spawnflags" "2048"
+"classname" "target_explosion"
+"dmg" "0"
+"targetname" "t56"
+"origin" "-384 -304 -892"
+}
+{
+"light" "125"
+"_color" "1.000000 0.774704 0.304348"
+"classname" "light"
+"origin" "280 -320 294"
+}
+{
+"classname" "info_null"
+"targetname" "t169"
+"origin" "104 -440 -572"
+}
+{
+"classname" "light"
+"origin" "104 -440 -488"
+"target" "t169"
+"_cone" "20"
+}
+{
+"classname" "info_null"
+"targetname" "t168"
+"origin" "216 -440 -572"
+}
+{
+"classname" "light"
+"target" "t168"
+"origin" "216 -440 -488"
+"_cone" "20"
+}
+{
+"spawnflags" "2048"
+"classname" "target_secret"
+"message" "You have found a secret."
+"targetname" "t167"
+"origin" "-376 -328 -808"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-440 -264 -600"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-376 -264 -600"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-568 -264 -600"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-504 -264 -600"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-312 -264 -600"
+}
+{
+"origin" "-336 -1216 -696"
+"light" "60"
+"classname" "light"
+}
+{
+"origin" "-336 -1152 -696"
+"light" "60"
+"classname" "light"
+}
+{
+"origin" "-336 -1088 -696"
+"light" "60"
+"classname" "light"
+}
+{
+"origin" "-384 -1040 -680"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-448 -1040 -696"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-512 -1040 -712"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-560 -1064 -728"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-560 -1096 -744"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-568 -1144 -760"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-568 -1200 -776"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-568 -1248 -792"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-520 -1264 -808"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-472 -1264 -824"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-424 -1264 -840"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-376 -1264 -856"
+"light" "64"
+"classname" "light"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-328 -1264 -856"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "-232 -1216 -856"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "-168 -1216 -856"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "-104 -1232 -856"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "-40 -1248 -856"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-336 -1264 -696"
+}
+{
+"spawnflags" "2048"
+"origin" "700 752 272"
+"message" "Reprogram Data Spinner\nat Central Computer."
+"targetname" "t162"
+"classname" "target_help"
+}
+{
+"spawnflags" "2048"
+"origin" "-4 -264 -632"
+"angle" "90"
+"classname" "misc_insane"
+}
+{
+"origin" "336 64 232"
+"target" "t142"
+"classname" "monster_chick"
+}
+{
+"model" "*112"
+"target" "t145"
+"targetname" "t156"
+"spawnflags" "2052"
+"classname" "trigger_once"
+}
+{
+"origin" "632 680 256"
+"targetname" "t162"
+"spawnflags" "2056"
+"classname" "target_crosslevel_trigger"
+}
+{
+"spawnflags" "2048"
+"origin" "528 956 256"
+"delay" "2"
+"targetname" "t163"
+"item" "key_data_spinner"
+"classname" "trigger_key"
+"target" "t257"
+}
+{
+"targetname" "t161"
+"origin" "592 664 192"
+"classname" "info_null"
+}
+{
+"light" "150"
+"target" "t161"
+"origin" "592 664 284"
+"classname" "light"
+}
+{
+"spawnflags" "2048"
+"target" "t162"
+"origin" "592 664 196"
+"classname" "key_data_cd"
+}
+{
+"origin" "848 1312 80"
+"classname" "ammo_cells"
+"spawnflags" "2048"
+}
+{
+"origin" "856 1352 80"
+"classname" "ammo_cells"
+"spawnflags" "2048"
+}
+{
+"origin" "912 1392 80"
+"classname" "item_adrenaline"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "0"
+"origin" "848 1272 80"
+"classname" "ammo_cells"
+}
+{
+"model" "*113"
+"spawnflags" "2048"
+"target" "t145"
+"classname" "trigger_once"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-72 736 -112"
+}
+{
+"spawnflags" "2048"
+"origin" "-72 768 -112"
+"classname" "ammo_cells"
+}
+{
+"classname" "item_health"
+"origin" "-152 536 -216"
+}
+{
+"classname" "item_health"
+"origin" "-184 576 -216"
+}
+{
+"model" "*114"
+"classname" "func_wall"
+"spawnflags" "2816"
+}
+{
+"model" "*115"
+"classname" "func_wall"
+"spawnflags" "1536"
+}
+{
+"model" "*116"
+"classname" "func_wall"
+"spawnflags" "1280"
+}
+{
+"model" "*117"
+"classname" "func_wall"
+"spawnflags" "3584"
+}
+{
+"origin" "140 1244 264"
+"classname" "info_null"
+"targetname" "t261"
+}
+{
+"classname" "light"
+"_cone" "25"
+"origin" "524 1244 468"
+}
+{
+"origin" "944 1308 168"
+"spawnflags" "2050"
+"targetname" "pg1"
+"classname" "target_crosslevel_trigger"
+}
+{
+"origin" "624 602 280"
+"spawnflags" "2076"
+"target" "t156"
+"classname" "target_crosslevel_target"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "1.000000 1.000000 0.874510"
+"origin" "-448 -840 120"
+}
+{
+"origin" "-448 -840 112"
+"_color" "1.000000 1.000000 1.000000"
+"light" "300"
+"classname" "light"
+"_cone" "20"
+"target" "t154"
+}
+{
+"origin" "-448 -840 -100"
+"classname" "info_notnull"
+"targetname" "t154"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "1.000000 1.000000 0.874510"
+"origin" "-448 -756 120"
+}
+{
+"origin" "-448 -756 112"
+"_color" "1.000000 1.000000 1.000000"
+"light" "300"
+"classname" "light"
+"_cone" "20"
+"target" "t155"
+}
+{
+"origin" "-448 -756 -100"
+"classname" "info_notnull"
+"targetname" "t155"
+}
+{
+"origin" "-456 620 160"
+"classname" "item_armor_combat"
+}
+{
+"target" "t153"
+"_color" "1.000000 0.255144 0.004115"
+"origin" "-216 600 -152"
+"light" "200"
+"classname" "light"
+}
+{
+"targetname" "t153"
+"origin" "-216 600 -232"
+"classname" "info_notnull"
+}
+{
+"target" "t151"
+"classname" "light"
+"light" "200"
+"origin" "-152 600 -152"
+"_color" "1.000000 0.255144 0.004115"
+}
+{
+"targetname" "t151"
+"classname" "info_notnull"
+"origin" "-152 600 -232"
+}
+{
+"target" "t152"
+"classname" "light"
+"light" "200"
+"origin" "-344 600 -152"
+"_color" "1.000000 0.255144 0.004115"
+}
+{
+"targetname" "t152"
+"classname" "info_notnull"
+"origin" "-344 600 -228"
+}
+{
+"origin" "-280 600 -232"
+"targetname" "t150"
+"classname" "info_notnull"
+}
+{
+"_color" "1.000000 0.255144 0.004115"
+"origin" "-280 600 -152"
+"light" "200"
+"target" "t150"
+"classname" "light"
+}
+{
+"model" "*118"
+"target" "t149"
+"classname" "trigger_multiple"
+}
+{
+"origin" "-280 600 -168"
+"classname" "item_health_mega"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "1792"
+"origin" "-456 584 184"
+"classname" "ammo_shells"
+}
+{
+"spawnflags" "0"
+"origin" "-392 704 160"
+"classname" "ammo_slugs"
+}
+{
+"origin" "-352 704 160"
+"classname" "item_health_large"
+}
+{
+"origin" "-512 -124 -984"
+"classname" "item_health"
+}
+{
+"origin" "-568 -152 -1000"
+"spawnflags" "2064"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-312 -1252 -692"
+"classname" "item_bandolier"
+"spawnflags" "1792"
+}
+{
+"origin" "-308 -1292 -732"
+"classname" "item_health"
+}
+{
+"origin" "-588 -1224 -812"
+"classname" "item_health_small"
+}
+{
+"origin" "-412 -1284 -880"
+"classname" "item_health_small"
+}
+{
+"origin" "-592 -1156 -800"
+"classname" "item_health_small"
+}
+{
+"model" "*119"
+"target" "pg1"
+"targetname" "t147"
+"classname" "trigger_once"
+"spawnflags" "2048"
+"message" "Yellow force fields deactivated."
+}
+{
+"classname" "target_speaker"
+"targetname" "com5"
+"noise" "world/electro.wav"
+"origin" "592 512 360"
+}
+{
+"spawnflags" "2048"
+"classname" "target_speaker"
+"targetname" "com7"
+"origin" "592 520 360"
+"noise" "world/spark2.wav"
+}
+{
+"spawnflags" "2048"
+"classname" "target_speaker"
+"targetname" "com6"
+"noise" "world/spark2.wav"
+"origin" "592 504 360"
+}
+{
+"classname" "target_speaker"
+"targetname" "com3"
+"noise" "world/spark1.wav"
+"origin" "592 512 360"
+}
+{
+"classname" "target_speaker"
+"targetname" "com4"
+"noise" "world/electro.wav"
+"origin" "592 512 360"
+}
+{
+"spawnflags" "2048"
+"origin" "584 504 360"
+"classname" "target_explosion"
+"targetname" "com2"
+}
+{
+"spawnflags" "2048"
+"origin" "600 512 376"
+"classname" "target_explosion"
+"targetname" "com7"
+}
+{
+"classname" "target_explosion"
+"origin" "600 512 312"
+"targetname" "com5"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"target" "com7"
+"origin" "680 384 328"
+"targetname" "pg2"
+"delay" "3.5"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"target" "com6"
+"origin" "648 384 328"
+"targetname" "pg2"
+"delay" "3.25"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"target" "com5"
+"origin" "616 384 328"
+"targetname" "pg2"
+"delay" "3"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"target" "com4"
+"origin" "584 384 328"
+"targetname" "pg2"
+"delay" "2.75"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"target" "com3"
+"origin" "552 384 328"
+"targetname" "pg2"
+"delay" "2.5"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"target" "com2"
+"origin" "520 384 328"
+"targetname" "pg2"
+"delay" "2"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"target" "com1"
+"origin" "488 384 328"
+"targetname" "pg2"
+"delay" "1"
+}
+{
+"classname" "trigger_relay"
+"target" "com8"
+"origin" "712 384 328"
+"targetname" "pg2"
+"delay" "4.25"
+}
+{
+"model" "*120"
+"classname" "func_explosive"
+"targetname" "com8"
+"dmg" "50"
+"mass" "300"
+}
+{
+"attenuation" "3"
+"volume" "3"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb12.wav"
+"targetname" "com2"
+"origin" "608 512 336"
+}
+{
+"model" "*121"
+"spawnflags" "2048"
+"target" "t163"
+"classname" "trigger_once"
+"message" "Warning. Communication laser shut down."
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "544 916 221"
+}
+{
+"model" "*122"
+"sounds" "4"
+"spawnflags" "2089"
+"classname" "func_door"
+"angle" "-2"
+"lip" "128"
+"targetname" "t145"
+"wait" "-1"
+"_minlight" "0.1"
+}
+{
+"model" "*123"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"classname" "path_corner"
+"origin" "328 -160 216"
+"targetname" "t143"
+"target" "t144"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t139"
+"target" "t140"
+"origin" "328 -160 216"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t140"
+"target" "t141"
+"origin" "328 40 216"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t141"
+"target" "t142"
+"origin" "376 40 216"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t142"
+"origin" "328 40 216"
+"target" "t143"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"target" "t139"
+"origin" "28 -136 216"
+"targetname" "t144"
+}
+{
+"classname" "item_health"
+"origin" "840 600 80"
+}
+{
+"classname" "item_health"
+"origin" "816 640 80"
+}
+{
+"classname" "item_health"
+"origin" "656 752 80"
+}
+{
+"classname" "target_secret"
+"targetname" "t138"
+"message" "You have found a secret area."
+"origin" "-312 -8 -56"
+}
+{
+"model" "*124"
+"classname" "trigger_once"
+"target" "t138"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-544 392 392"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-440 360 392"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-440 408 392"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-336 392 392"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-336 168 392"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-440 200 392"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-544 200 392"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-544 360 520"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-544 408 520"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-440 360 520"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-440 408 520"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-336 360 520"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-336 408 520"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-336 168 520"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-440 168 520"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-544 168 520"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"classname" "item_health"
+"origin" "-456 96 -56"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_tank_commander"
+"angle" "270"
+"origin" "4 964 244"
+"targetname" "pg2"
+"spawnflags" "1"
+}
+{
+"model" "*125"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t134"
+}
+{
+"origin" "120 1612 324"
+"classname" "monster_floater"
+"spawnflags" "769"
+"item" "ammo_cells"
+}
+{
+"origin" "240 1424 384"
+"classname" "monster_floater"
+"spawnflags" "1"
+"item" "ammo_cells"
+}
+{
+"angle" "180"
+"classname" "monster_chick"
+"spawnflags" "1"
+"origin" "139 1242 284"
+"targetname" "t134"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-372 32 -16"
+"spawnflags" "1792"
+}
+{
+"classname" "weapon_chaingun"
+"origin" "-332 40 -16"
+"spawnflags" "1792"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-296 28 -16"
+"spawnflags" "1792"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2049"
+"angle" "45"
+"origin" "-444 -408 -112"
+}
+{
+"origin" "-448 520 228"
+"classname" "info_null"
+"targetname" "t124"
+}
+{
+"origin" "-448 520 375"
+"_cone" "20"
+"classname" "light"
+"target" "t124"
+}
+{
+"origin" "-448 520 383"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "monster_soldier"
+"targetname" "t121"
+"spawnflags" "257"
+"angle" "270"
+"origin" "-200 704 -104"
+}
+{
+"classname" "monster_soldier"
+"targetname" "t121"
+"spawnflags" "769"
+"angle" "270"
+"origin" "-312 680 -104"
+}
+{
+"classname" "monster_soldier"
+"targetname" "t121"
+"spawnflags" "1"
+"angle" "270"
+"origin" "-184 648 -104"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"origin" "-464 232 -128"
+"targetname" "t226"
+"target" "t121"
+}
+{
+"model" "*126"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t119"
+}
+{
+"classname" "monster_floater"
+"origin" "-1124 -344 -1072"
+"spawnflags" "258"
+"targetname" "t119"
+}
+{
+"angle" "0"
+"classname" "monster_soldier_light"
+"spawnflags" "3"
+"targetname" "pg1"
+"origin" "-700 -518 -998"
+}
+{
+"angle" "0"
+"classname" "monster_gunner"
+"spawnflags" "259"
+"targetname" "pg1"
+"origin" "-804 -480 -998"
+}
+{
+"angle" "45"
+"classname" "monster_soldier_light"
+"spawnflags" "3"
+"targetname" "pg1"
+"origin" "-620 -528 -998"
+}
+{
+"classname" "target_secret"
+"targetname" "t109"
+"message" "You have found a secret area."
+"origin" "-1246 -392 -1086"
+}
+{
+"model" "*127"
+"classname" "trigger_once"
+"target" "t109"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health"
+"origin" "48 768 -112"
+}
+{
+"classname" "misc_deadsoldier"
+"angle" "315"
+"spawnflags" "2064"
+"origin" "-111 759 -128"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t104"
+"target" "t105"
+"wait" "1"
+"origin" "-576 168 -120"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t105"
+"target" "t106"
+"origin" "-592 168 -120"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t103"
+"target" "t104"
+"origin" "-576 400 -120"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"target" "t103"
+"targetname" "t106"
+"wait" "1"
+"origin" "-592 400 -120"
+}
+{
+"classname" "monster_chick"
+"target" "t103"
+"item" "ammo_rockets"
+"origin" "-560 416 -104"
+"spawnflags" "1"
+}
+{
+"classname" "monster_soldier_ss"
+"origin" "-632 316 -104"
+"angle" "0"
+"spawnflags" "1"
+}
+{
+"classname" "monster_soldier_ss"
+"origin" "-632 252 -104"
+"angle" "0"
+"item" "ammo_shells"
+"spawnflags" "1"
+}
+{
+"classname" "monster_soldier_ss"
+"origin" "-632 192 -104"
+"spawnflags" "769"
+}
+{
+"classname" "monster_soldier_ss"
+"origin" "-632 380 -104"
+"angle" "0"
+"item" "ammo_shells"
+"spawnflags" "257"
+}
+{
+"origin" "-476 32 468"
+"classname" "info_null"
+"targetname" "t102"
+}
+{
+"origin" "-448 32 480"
+"classname" "info_null"
+"targetname" "t101"
+}
+{
+"classname" "info_null"
+"origin" "-420 32 468"
+"targetname" "t100"
+}
+{
+"_cone" "5"
+"light" "200"
+"classname" "light"
+"origin" "-448 40 388"
+"target" "t101"
+}
+{
+"_cone" "5"
+"light" "200"
+"classname" "light"
+"target" "t100"
+"origin" "-464 40 388"
+}
+{
+"_cone" "5"
+"classname" "light"
+"light" "200"
+"origin" "-432 40 388"
+"target" "t102"
+}
+{
+"classname" "info_notnull"
+"targetname" "t99"
+"origin" "-448 520 -124"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-448 520 63"
+}
+{
+"classname" "light"
+"target" "t99"
+"_cone" "20"
+"origin" "-448 520 55"
+}
+{
+"classname" "monster_chick"
+"angle" "180"
+"origin" "-196 704 256"
+"spawnflags" "3"
+"targetname" "t257"
+}
+{
+"classname" "monster_chick"
+"angle" "180"
+"origin" "-192 632 256"
+"spawnflags" "3"
+"targetname" "t257"
+}
+{
+"classname" "monster_tank_commander"
+"angle" "90"
+"origin" "-452 616 256"
+"item" "ammo_rockets"
+"spawnflags" "1"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "-208 -464 -584"
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+}
+{
+"origin" "-1183 -299 -1060"
+"spawnflags" "81"
+"angle" "-1"
+"classname" "target_laser"
+}
+{
+"deathtarget" "t171"
+"targetname" "t275"
+"origin" "-380 -316 232"
+"spawnflags" "1"
+"angle" "270"
+"classname" "monster_chick"
+"item" "ammo_rockets"
+}
+{
+"targetname" "t275"
+"origin" "-268 -336 232"
+"spawnflags" "257"
+"angle" "270"
+"classname" "monster_chick"
+"item" "item_armor_shard"
+}
+{
+"targetname" "t90"
+"classname" "point_combat"
+"origin" "-454 -576 -732"
+}
+{
+"origin" "296 -304 -96"
+"classname" "monster_soldier"
+"angle" "0"
+"spawnflags" "257"
+"item" "item_armor_shard"
+"target" "t291"
+"deathtarget" "bob"
+}
+{
+"origin" "-1119 -579 -1060"
+"spawnflags" "81"
+"angle" "-1"
+"classname" "target_laser"
+}
+{
+"origin" "-318 -593 -87"
+"angle" "90"
+"classname" "monster_soldier_light"
+"spawnflags" "768"
+}
+{
+"origin" "-384 -307 -56"
+"angle" "135"
+"classname" "monster_soldier_light"
+"spawnflags" "256"
+}
+{
+"spawnflags" "2048"
+"origin" "-16 -152 -640"
+"classname" "misc_explobox"
+}
+{
+"spawnflags" "2048"
+"origin" "40 -232 -656"
+"classname" "misc_explobox"
+}
+{
+"spawnflags" "2048"
+"origin" "-424 -288 -1008"
+"target" "t84"
+"targetname" "t83"
+"classname" "path_corner"
+}
+{
+"origin" "-448 -168 -1016"
+"target" "t83"
+"targetname" "t82"
+"classname" "path_corner"
+}
+{
+"origin" "-472 -344 -1016"
+"targetname" "t84"
+"target" "t82"
+"classname" "path_corner"
+}
+{
+"item" "ammo_cells"
+"origin" "-412 -340 -984"
+"classname" "monster_soldier_light"
+"spawnflags" "2304"
+"angle" "180"
+"targetname" "t242"
+}
+{
+"origin" "-496 -352 -984"
+"target" "t84"
+"angle" "180"
+"spawnflags" "1"
+"classname" "monster_soldier_light"
+}
+{
+"targetname" "148"
+"classname" "trigger_key"
+"spawnflags" "2052"
+"message" "Security pass approved. \nYou may enter force field control."
+"target" "t81"
+"origin" "744 744 72"
+"item" "key_pass"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "96 676 16"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_grenades"
+"origin" "-602 -204 -404"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"delay" "1"
+"targetname" "t56"
+"origin" "-497 -325 -1008"
+"target" "t76"
+}
+{
+"classname" "info_notnull"
+"targetname" "t75"
+"origin" "-376 -296 -772"
+}
+{
+"classname" "light"
+"origin" "-376 -296 -880"
+"target" "t75"
+"light" "150"
+"_cone" "20"
+}
+{
+"spawnflags" "2048"
+"classname" "item_enviro"
+"origin" "-376 -296 -760"
+}
+{
+"model" "*128"
+"spawnflags" "2048"
+"classname" "func_explosive"
+"dmg" "100"
+"health" "1"
+"mass" "500"
+"_minlight" "0.2"
+"target" "t167"
+}
+{
+"classname" "monster_floater"
+"spawnflags" "1"
+"origin" "-464 -224 -376"
+"target" "t80"
+}
+{
+"classname" "light"
+"origin" "872 1424 183"
+"target" "t64"
+"light" "175"
+"_cone" "15"
+}
+{
+"classname" "info_null"
+"origin" "872 1424 68"
+"targetname" "t64"
+}
+{
+"classname" "light"
+"origin" "952 1424 183"
+"target" "t63"
+"light" "175"
+"_cone" "15"
+}
+{
+"classname" "info_null"
+"origin" "952 1424 68"
+"targetname" "t63"
+}
+{
+"classname" "light"
+"origin" "952 1344 183"
+"target" "t65"
+"light" "175"
+"_cone" "15"
+}
+{
+"classname" "info_null"
+"origin" "952 1344 68"
+"targetname" "t65"
+}
+{
+"classname" "info_null"
+"origin" "872 1344 68"
+"targetname" "t66"
+}
+{
+"classname" "light"
+"origin" "872 1344 183"
+"target" "t66"
+"light" "175"
+"_cone" "15"
+}
+{
+"model" "*129"
+"sounds" "3"
+"classname" "func_door"
+"angle" "0"
+"team" "p1"
+"lip" "16"
+"wait" "3"
+"_minlight" "0.2"
+"target" "t303"
+}
+{
+"model" "*130"
+"classname" "func_door"
+"angle" "180"
+"team" "p1"
+"lip" "16"
+"wait" "3"
+"_minlight" "0.2"
+"target" "t303"
+}
+{
+"classname" "info_null"
+"origin" "-392 -216 -628"
+"targetname" "t60"
+}
+{
+"classname" "light"
+"origin" "-392 -216 -568"
+"target" "t60"
+}
+{
+"classname" "light"
+"target" "t59"
+"origin" "-320 -216 -568"
+}
+{
+"classname" "info_null"
+"targetname" "t59"
+"origin" "-320 -216 -644"
+}
+{
+"classname" "light"
+"origin" "-504 -216 -568"
+"target" "t61"
+}
+{
+"classname" "info_null"
+"origin" "-504 -216 -620"
+"targetname" "t61"
+}
+{
+"classname" "info_null"
+"targetname" "t58"
+"origin" "-264 -216 -644"
+}
+{
+"classname" "light"
+"target" "t58"
+"origin" "-264 -216 -568"
+}
+{
+"style" "9"
+"targetname" "t57"
+"classname" "func_areaportal"
+}
+{
+"model" "*131"
+"sounds" "3"
+"wait" "4"
+"lip" "16"
+"team" "portal1"
+"angle" "180"
+"classname" "func_door"
+"_minlight" "0.2"
+"spawnflags" "8"
+}
+{
+"model" "*132"
+"target" "t57"
+"wait" "4"
+"lip" "16"
+"team" "portal1"
+"angle" "0"
+"classname" "func_door"
+"_minlight" "0.2"
+"spawnflags" "8"
+}
+{
+"model" "*133"
+"spawnflags" "2048"
+"target" "t56"
+"delay" "5"
+"classname" "trigger_once"
+}
+{
+"model" "*134"
+"angle" "-2"
+"spawnflags" "1"
+"classname" "trigger_push"
+"speed" "25"
+}
+{
+"spawnflags" "2"
+"origin" "-376 -290 -849"
+"classname" "monster_floater"
+"targetname" "t76"
+}
+{
+"classname" "monster_soldier_ss"
+"spawnflags" "257"
+"angle" "270"
+"origin" "-480 -672 -728"
+"targetname" "t11"
+"item" "ammo_bullets"
+}
+{
+"classname" "monster_soldier_ss"
+"spawnflags" "769"
+"angle" "270"
+"origin" "-416 -664 -728"
+"targetname" "t11"
+}
+{
+"item" "item_armor_shard"
+"angle" "180"
+"classname" "monster_soldier"
+"origin" "180 -488 -540"
+"spawnflags" "1"
+"deathtarget" "t243"
+}
+{
+"item" "ammo_shells"
+"classname" "monster_soldier"
+"angle" "180"
+"origin" "156 -536 -540"
+"spawnflags" "1"
+"deathtarget" "t243"
+}
+{
+"item" "ammo_shells"
+"classname" "monster_soldier"
+"angle" "180"
+"origin" "100 -524 -540"
+"spawnflags" "769"
+"deathtarget" "t243"
+}
+{
+"spawnflags" "2048"
+"classname" "point_combat"
+"targetname" "t51"
+"origin" "-198 -262 -644"
+}
+{
+"target" "t266"
+"targetname" "t243"
+"item" "ammo_rockets"
+"classname" "monster_chick"
+"spawnflags" "2"
+"angle" "90"
+"origin" "-672 -272 -624"
+}
+{
+"style" "36"
+"targetname" "t45"
+"spawnflags" "0"
+"_color" "1.000000 0.316206 0.142292"
+"classname" "light"
+"light" "175"
+"origin" "-132 -368 232"
+}
+{
+"model" "*135"
+"health" "5"
+"lip" "4"
+"classname" "func_door"
+"angle" "0"
+"team" "2grate"
+}
+{
+"model" "*136"
+"health" "5"
+"lip" "4"
+"classname" "func_door"
+"angle" "180"
+"team" "2grate"
+"sounds" "2"
+}
+{
+"style" "36"
+"origin" "-128 -272 232"
+"light" "175"
+"classname" "light"
+"targetname" "t45"
+"_color" "1.000000 0.316206 0.142292"
+"spawnflags" "0"
+}
+{
+"model" "*137"
+"spawnflags" "2048"
+"targetname" "t81"
+"sounds" "2"
+"wait" "-1"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"origin" "432 544 126"
+"target" "t36"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "432 544 70"
+"targetname" "t36"
+"classname" "info_null"
+}
+{
+"origin" "432 480 70"
+"targetname" "t35"
+"classname" "info_null"
+}
+{
+"origin" "432 480 126"
+"light" "100"
+"target" "t35"
+"classname" "light"
+}
+{
+"origin" "-480 -744 -728"
+"angle" "270"
+"targetname" "t11"
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-416 -736 -728"
+"angle" "270"
+"targetname" "t11"
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+}
+{
+"spawnflags" "2048"
+"targetname" "t22"
+"target" "t34"
+"origin" "-576 -1264 -832"
+"classname" "point_combat"
+}
+{
+"classname" "info_notnull"
+"targetname" "t33"
+"origin" "-448 -952 -100"
+}
+{
+"origin" "-448 -952 120"
+"_color" "1.000000 1.000000 0.874510"
+"light" "80"
+"classname" "light"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"targetname" "t11"
+"target" "t32"
+"origin" "-344 -1112 -744"
+}
+{
+"origin" "-368 -1020 -760"
+"spawnflags" "2048"
+"classname" "point_combat"
+"targetname" "t30"
+"wait" "10"
+}
+{
+"classname" "point_combat"
+"spawnflags" "2048"
+"origin" "-320 -1040 -760"
+"targetname" "t31"
+"wait" "10"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "180"
+"origin" "-312 -1020 -742"
+"spawnflags" "0"
+"target" "t30"
+"targetname" "t32"
+}
+{
+"model" "*138"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t29"
+}
+{
+"target" "t90"
+"classname" "point_combat"
+"targetname" "t25"
+"origin" "-454 -734 -712"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"target" "t25"
+"targetname" "t28"
+"origin" "-452 -1024 -736"
+}
+{
+"classname" "point_combat"
+"targetname" "t27"
+"target" "t28"
+"origin" "-560 -1032 -720"
+}
+{
+"spawnflags" "2048"
+"classname" "point_combat"
+"target" "t27"
+"origin" "-552 -1264 -776"
+"targetname" "t233"
+}
+{
+"item" "ammo_cells"
+"classname" "monster_floater"
+"target" "t26"
+"targetname" "t29"
+"angle" "180"
+"spawnflags" "1"
+"origin" "-324 -1072 -864"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "180"
+"origin" "-360 -1184 -728"
+"spawnflags" "1"
+"item" "ammo_bullets"
+"target" "t253"
+"targetname" "BobnFred"
+}
+{
+"spawnflags" "769"
+"origin" "-364 -1144 -728"
+"angle" "180"
+"classname" "monster_soldier_ss"
+"targetname" "t11"
+"target" "t31"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "180"
+"origin" "-312 -1152 -728"
+"spawnflags" "257"
+"target" "t254"
+"Targetname" "BobnFred"
+"targetname" "BobnFred"
+}
+{
+"model" "*139"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t23"
+}
+{
+"pathtarget" "BobnFred"
+"wait" "1"
+"targetname" "t34"
+"classname" "point_combat"
+"origin" "-592 -1176 -804"
+}
+{
+"spawnflags" "2048"
+"origin" "592 514 3972"
+"targetname" "jimmy"
+"classname" "info_notnull"
+}
+{
+"model" "*140"
+"spawnflags" "2048"
+"target" "t11"
+"classname" "trigger_once"
+}
+{
+"origin" "-560 -1160 -792"
+"classname" "monster_soldier_ss"
+"target" "t22"
+"targetname" "t23"
+"spawnflags" "1"
+"angle" "270"
+"wait" ".5"
+"delay" ".25"
+}
+{
+"origin" "-312 -1107 -728"
+"targetname" "t11"
+"angle" "90"
+"classname" "monster_chick"
+"spawnflags" "257"
+}
+{
+"target" "jimmy"
+"origin" "586 516 352"
+"targetname" "com5"
+"classname" "target_laser"
+"spawnflags" "2057"
+}
+{
+"target" "jimmy"
+"origin" "596 516 352"
+"targetname" "com4"
+"classname" "target_laser"
+"spawnflags" "2057"
+}
+{
+"target" "jimmy"
+"origin" "596 508 352"
+"targetname" "com3"
+"classname" "target_laser"
+"spawnflags" "2057"
+}
+{
+"target" "jimmy"
+"origin" "592 512 350"
+"targetname" "com7"
+"classname" "target_laser"
+"spawnflags" "2057"
+}
+{
+"target" "jimmy"
+"origin" "586 508 352"
+"targetname" "com6"
+"spawnflags" "2057"
+"classname" "target_laser"
+}
+{
+"model" "*141"
+"classname" "func_wall"
+"spawnflags" "2055"
+"targetname" "pg1"
+}
+{
+"model" "*142"
+"spawnflags" "2055"
+"classname" "func_wall"
+"targetname" "pg2"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-456 696 160"
+}
+{
+"item" "item_silencer"
+"angle" "45"
+"classname" "monster_soldier_light"
+"origin" "-507 -311 -72"
+"spawnflags" "256"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "135"
+"origin" "-413 -463 -87"
+}
+{
+"model" "*143"
+"spawnflags" "2055"
+"classname" "func_wall"
+"targetname" "reddoor2"
+}
+{
+"model" "*144"
+"classname" "func_wall"
+"spawnflags" "2055"
+"targetname" "reddoor1"
+}
+{
+"origin" "-48 168 -154"
+"_color" "1.000000 0.830709 0.263780"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-40 96 -122"
+"_color" "1.000000 0.830709 0.263780"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-40 16 -90"
+"_color" "1.000000 0.830709 0.263780"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-40 -56 -74"
+"_color" "1.000000 0.830709 0.263780"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-40 -128 -58"
+"_color" "1.000000 0.830709 0.263780"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.830709 0.263780"
+"origin" "-56 280 -154"
+}
+{
+"model" "*145"
+"classname" "func_wall"
+"spawnflags" "2055"
+"targetname" "pg2"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "-168 -328 -568"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "-168 -216 -568"
+}
+{
+"origin" "-392 -104 -568"
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+}
+{
+"classname" "trigger_relay"
+"targetname" "endplat"
+"target" "city3X"
+"delay" "0.3"
+"origin" "192 1472 344"
+}
+{
+"_color" "1.000000 1.000000 0.850980"
+"light" "150"
+"classname" "light"
+"origin" "168 -320 -424"
+}
+{
+"_color" "1.000000 1.000000 0.850980"
+"light" "150"
+"classname" "light"
+"origin" "168 -320 -296"
+}
+{
+"_color" "1.000000 1.000000 0.850980"
+"light" "150"
+"classname" "light"
+"origin" "168 -320 -104"
+}
+{
+"_color" "1.000000 1.000000 0.850980"
+"light" "150"
+"classname" "light"
+"origin" "168 -320 24"
+}
+{
+"_color" "1.000000 1.000000 0.850980"
+"light" "150"
+"classname" "light"
+"origin" "168 -320 152"
+}
+{
+"_color" "1.000000 1.000000 0.850980"
+"light" "150"
+"classname" "light"
+"origin" "168 -320 280"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 1.000000 0.850980"
+"origin" "168 -320 -600"
+}
+{
+"model" "*146"
+"lip" "4"
+"spawnflags" "2048"
+"classname" "func_button"
+"angle" "45"
+"sounds" "2"
+"target" "endsecret"
+"wait" "-1"
+}
+{
+"model" "*147"
+"spawnflags" "2048"
+"_minlight" "0.1"
+"classname" "func_door"
+"angle" "90"
+"targetname" "endsecret"
+"wait" "-1"
+"speed" "50"
+"sounds" "4"
+}
+{
+"model" "*148"
+"spawnflags" "2048"
+"classname" "func_explosive"
+"health" "25"
+"dmg" "25"
+}
+{
+"classname" "light"
+"light" "100"
+"_style" "6"
+"origin" "-1268 -396 -1044"
+}
+{
+"model" "*149"
+"spawnflags" "2048"
+"sounds" "4"
+"lip" "4"
+"angle" "180"
+"target" "steps"
+"_minlight" "0.9"
+"classname" "func_button"
+"wait" "-1"
+}
+{
+"map" "city2$city2XH"
+"classname" "target_changelevel"
+"targetname" "back_high"
+"target" "city2XH"
+"origin" "-392 -920 -40"
+}
+{
+"model" "*150"
+"angle" "270"
+"classname" "trigger_multiple"
+"target" "back_high"
+}
+{
+"classname" "target_changelevel"
+"targetname" "back_low"
+"map" "city2$city2XL"
+"origin" "-72 -1176 -856"
+}
+{
+"model" "*151"
+"angle" "360"
+"classname" "trigger_multiple"
+"target" "back_low"
+}
+{
+"classname" "target_changelevel"
+"map" "*boss1$bosstart"
+"origin" "128 1392 460"
+"targetname" "city3X"
+"spawnflags" "1"
+}
+{
+"light" "150"
+"origin" "-424 -584 -992"
+"_color" "0.071429 0.444444 1.000000"
+"classname" "light"
+}
+{
+"light" "150"
+"origin" "-424 -440 -992"
+"_color" "0.071429 0.444444 1.000000"
+"classname" "light"
+}
+{
+"origin" "-48 -16 -26"
+"_color" "1.000000 0.830709 0.263780"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-48 176 -98"
+"_color" "1.000000 0.830709 0.263780"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-160 272 -130"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.830709 0.263780"
+}
+{
+"origin" "-240 -128 14"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.830709 0.263780"
+}
+{
+"origin" "-208 272 -130"
+"_color" "1.000000 0.830709 0.263780"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*152"
+"classname" "func_button"
+"lip" "6"
+"angle" "0"
+"health" "1"
+"target" "blastshield"
+"delay" "0"
+"wait" "1"
+"sounds" "4"
+"_minlight" "0.8"
+"spawnflags" "2048"
+}
+{
+"model" "*153"
+"classname" "func_door"
+"spawnflags" "2049"
+"targetname" "blastshield"
+"lip" "-2"
+"speed" "100"
+"sounds" "2"
+"wait" "3"
+"delay" "0"
+"angle" "-2"
+}
+{
+"model" "*154"
+"classname" "func_door"
+"spawnflags" "2049"
+"lip" "24"
+"dmg" "0"
+"targetname" "endplat"
+"angle" "-2"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "364 1592 364"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "364 1636 364"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "308 1636 364"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "308 1592 364"
+}
+{
+"model" "*155"
+"classname" "func_button"
+"angle" "45"
+"_minlight" "0.2"
+"lip" "2"
+"sounds" "4"
+"target" "endplat"
+"spawnflags" "2048"
+}
+{
+"model" "*156"
+"classname" "func_wall"
+"_minlight" "0.2"
+"spawnflags" "2048"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "424 1244 344"
+"_color" "1.000000 0.388235 0.239216"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"origin" "336 1616 572"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.937255 0.705882"
+"light" "150"
+"classname" "light"
+"origin" "-568 24 284"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-568 -128 256"
+}
+{
+"model" "*157"
+"team" "exit1"
+"angle" "90"
+"classname" "func_door"
+}
+{
+"model" "*158"
+"classname" "func_door"
+"angle" "270"
+"team" "exit1"
+"sounds" "2"
+}
+{
+"model" "*159"
+"sounds" "2"
+"wait" "2"
+"classname" "func_plat"
+"_minlight" "0.2"
+}
+{
+"origin" "-488 -616 -600"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-504 -632 -600"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-504 -864 -600"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-488 -880 -600"
+}
+{
+"origin" "-408 -880 -600"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-392 -864 -600"
+"classname" "light"
+"light" "100"
+}
+{
+"targetname" "gun3"
+"origin" "112 664 -104"
+"angle" "180"
+"sounds" "1"
+"classname" "target_splash"
+}
+{
+"origin" "-440 408 328"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-440 360 328"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-336 392 328"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-544 392 328"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-336 168 328"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-544 200 328"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-440 200 328"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.976471 0.501961"
+}
+{
+"origin" "-376 -232 -952"
+"light" "120"
+"classname" "light"
+"_color" "1.000000 0.892430 0.294821"
+}
+{
+"origin" "-504 -232 -952"
+"light" "125"
+"classname" "light"
+"_color" "1.000000 0.892430 0.294821"
+}
+{
+"origin" "-408 -232 -952"
+"light" "120"
+"classname" "light"
+"_color" "1.000000 0.892430 0.294821"
+}
+{
+"origin" "-296 -232 -952"
+"light" "120"
+"classname" "light"
+"_color" "1.000000 0.892430 0.294821"
+}
+{
+"_color" "1.000000 0.968627 0.725490"
+"light" "80"
+"classname" "light"
+"origin" "-408 -840 120"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.968627 0.725490"
+"origin" "-488 -840 120"
+}
+{
+"_color" "1.000000 0.968627 0.725490"
+"light" "80"
+"classname" "light"
+"origin" "-488 -952 120"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.968627 0.725490"
+"origin" "-408 -952 120"
+}
+{
+"_cone" "20"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 1.000000 1.000000"
+"origin" "-448 -952 112"
+"target" "t33"
+}
+{
+"model" "*160"
+"angle" "-2"
+"targetname" "step2"
+"classname" "func_door"
+"lip" "26"
+"wait" "-1"
+"sounds" "1"
+}
+{
+"model" "*161"
+"angle" "-2"
+"targetname" "step3"
+"classname" "func_door"
+"lip" "42"
+"wait" "-1"
+"sounds" "1"
+}
+{
+"model" "*162"
+"angle" "-2"
+"targetname" "step4"
+"classname" "func_door"
+"lip" "58"
+"wait" "-1"
+"sounds" "1"
+}
+{
+"model" "*163"
+"angle" "-2"
+"targetname" "step5"
+"classname" "func_door"
+"lip" "74"
+"wait" "-1"
+"sounds" "1"
+}
+{
+"model" "*164"
+"angle" "-2"
+"targetname" "step6"
+"classname" "func_door"
+"lip" "90"
+"wait" "-1"
+"sounds" "1"
+}
+{
+"model" "*165"
+"angle" "-2"
+"targetname" "step7"
+"classname" "func_door"
+"lip" "106"
+"wait" "-1"
+"sounds" "1"
+}
+{
+"model" "*166"
+"sounds" "3"
+"angle" "-2"
+"wait" "-1"
+"targetname" "step1"
+"lip" "10"
+"classname" "func_door"
+}
+{
+"classname" "light"
+"_color" "0.071429 0.444444 1.000000"
+"origin" "-962 -506 -992"
+"light" "100"
+}
+{
+"classname" "light"
+"_color" "0.071429 0.444444 1.000000"
+"origin" "-832 -461 -994"
+"light" "150"
+}
+{
+"origin" "-568 -128 -40"
+"light" "100"
+"classname" "light"
+}
+{
+"model" "*167"
+"spawnflags" "2055"
+"classname" "func_wall"
+"targetname" "pg1"
+}
+{
+"light" "150"
+"origin" "-1000 -456 -992"
+"_color" "0.071429 0.444444 1.000000"
+"classname" "light"
+}
+{
+"light" "100"
+"origin" "-836 -510 -992"
+"_color" "0.071429 0.444444 1.000000"
+"classname" "light"
+}
+{
+"origin" "360 -320 294"
+"classname" "light"
+"_color" "1.000000 0.774704 0.304348"
+"light" "125"
+}
+{
+"origin" "216 -440 -488"
+"classname" "light"
+"_color" "1.000000 0.976471 0.792157"
+"light" "64"
+}
+{
+"origin" "232 -504 -504"
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "100"
+}
+{
+"origin" "-136 -504 -504"
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "100"
+}
+{
+"origin" "-136 -264 -504"
+"classname" "light"
+"_color" "1.000000 1.000000 0.949020"
+"light" "100"
+}
+{
+"origin" "-120 -216 -544"
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "100"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "-136 -216 -568"
+}
+{
+"light" "64"
+"_color" "1.000000 0.976471 0.792157"
+"classname" "light"
+"origin" "104 -440 -488"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "-40 -216 -544"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "40 -216 -544"
+}
+{
+"origin" "-232 -328 -568"
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "100"
+}
+{
+"origin" "8 -104 -568"
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "100"
+}
+{
+"origin" "-112 -104 -568"
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "100"
+}
+{
+"origin" "-232 -104 -568"
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "100"
+}
+{
+"origin" "-232 -216 -568"
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "100"
+}
+{
+"origin" "-264 -216 -568"
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "110"
+}
+{
+"classname" "trigger_relay"
+"targetname" "steps"
+"target" "step2"
+"delay" "0.2"
+"origin" "-960 -532 -1004"
+}
+{
+"classname" "trigger_relay"
+"targetname" "steps"
+"target" "step3"
+"delay" "0.4"
+"origin" "-940 -532 -1004"
+}
+{
+"classname" "trigger_relay"
+"targetname" "steps"
+"target" "step4"
+"delay" "0.6"
+"origin" "-916 -532 -1004"
+}
+{
+"classname" "trigger_relay"
+"targetname" "steps"
+"target" "step5"
+"delay" "0.8"
+"origin" "-892 -532 -1004"
+}
+{
+"classname" "trigger_relay"
+"targetname" "steps"
+"target" "step6"
+"delay" "1.0"
+"origin" "-868 -532 -1004"
+}
+{
+"classname" "trigger_relay"
+"targetname" "steps"
+"target" "step7"
+"delay" "1.2"
+"origin" "-844 -532 -1004"
+}
+{
+"classname" "trigger_relay"
+"targetname" "steps"
+"target" "step1"
+"origin" "-984 -532 -1004"
+}
+{
+"origin" "-128 -128 294"
+"classname" "light"
+"_color" "1.000000 0.774704 0.304348"
+"light" "175"
+}
+{
+"origin" "-504 -216 -568"
+"light" "110"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+}
+{
+"origin" "-448 -834 -84"
+"angle" "90"
+"classname" "info_player_start"
+"targetname" "city3NH"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-336 -1272 -648"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-352 -1256 -648"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-320 -1256 -648"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-336 -1240 -648"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-336 -1072 -648"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-352 -1056 -648"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-320 -1056 -648"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-336 -1040 -648"
+}
+{
+"style" "37"
+"light" "200"
+"classname" "light"
+"origin" "-576 -1056 -648"
+"spawnflags" "1"
+"targetname" "t199"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-408 -616 -600"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-392 -632 -600"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-544 -1256 -648"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-560 -1240 -648"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-576 -1256 -648"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-560 -1272 -648"
+"wait" ".5"
+}
+{
+"model" "*168"
+"spawnflags" "2055"
+"classname" "func_wall"
+"targetname" "pg1"
+}
+{
+"light" "150"
+"_color" "1.000000 0.774704 0.304348"
+"classname" "light"
+"origin" "232 -320 294"
+}
+{
+"light" "150"
+"_color" "1.000000 0.774704 0.304348"
+"classname" "light"
+"origin" "344 -168 294"
+}
+{
+"_color" "0.071429 0.444444 1.000000"
+"classname" "light"
+"origin" "-568 -440 -1000"
+"light" "150"
+}
+{
+"classname" "light"
+"_color" "0.071429 0.444444 1.000000"
+"origin" "-568 -584 -1000"
+"light" "150"
+}
+{
+"classname" "light"
+"_color" "0.071429 0.444444 1.000000"
+"origin" "-996 -564 -992"
+"light" "150"
+}
+{
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "100"
+"origin" "-264 -104 -568"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "-600 -104 -568"
+}
+{
+"light" "110"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "-320 -216 -568"
+}
+{
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "110"
+"origin" "-392 -216 -568"
+}
+{
+"light" "100"
+"_color" "0.602362 1.000000 0.555118"
+"classname" "light"
+"origin" "56 -184 -568"
+}
+{
+"classname" "light"
+"_color" "0.602362 1.000000 0.555118"
+"light" "100"
+"origin" "-504 -104 -568"
+}
+{
+"origin" "-328 24 296"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-568 -40 104"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.937255 0.705882"
+"origin" "-568 24 -16"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-328 -136 -24"
+"light" "150"
+"classname" "light"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-328 24 -24"
+}
+{
+"origin" "-328 -72 104"
+"light" "150"
+"classname" "light"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-328 24 104"
+}
+{
+"model" "*169"
+"team" "big_red"
+"sounds" "4"
+"classname" "func_door"
+"angle" "0"
+"speed" "50"
+"lip" "8"
+}
+{
+"model" "*170"
+"team" "big_red"
+"lip" "8"
+"speed" "50"
+"angle" "180"
+"classname" "func_door"
+}
+{
+"model" "*171"
+"origin" "372 1536 280"
+"team" "grandexit"
+"targetname" "t2"
+"classname" "func_door_rotating"
+"speed" "33"
+"distance" "95"
+"wait" "-1"
+"angle" "-2"
+"spawnflags" "68"
+}
+{
+"classname" "light"
+"origin" "-200 1424 380"
+"light" "200"
+}
+{
+"classname" "light"
+"origin" "-136 1216 376"
+"light" "200"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "48 1240 344"
+"_color" "1.000000 0.388235 0.239216"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "152 728 -128"
+}
+{
+"model" "*172"
+"delay" ".25"
+"angle" "0"
+"speed" "500"
+"wait" ".25"
+"lip" "6"
+"classname" "func_door"
+"targetname" "gun1"
+"spawnflags" "2048"
+"sounds" "2"
+}
+{
+"model" "*173"
+"delay" ".25"
+"angle" "0"
+"speed" "500"
+"wait" ".25"
+"lip" "6"
+"classname" "func_door"
+"targetname" "gun2"
+"spawnflags" "2048"
+"sounds" "2"
+}
+{
+"model" "*174"
+"classname" "func_door"
+"lip" "6"
+"wait" ".25"
+"speed" "500"
+"angle" "0"
+"delay" ".25"
+"targetname" "gun4"
+"spawnflags" "2048"
+"sounds" "2"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "152 616 -128"
+}
+{
+"origin" "112 664 -104"
+"angle" "180"
+"targetname" "gun3"
+"classname" "target_blaster"
+"dmg" "15"
+}
+{
+"angle" "180"
+"origin" "112 688 -104"
+"targetname" "gun2"
+"classname" "target_blaster"
+"dmg" "15"
+}
+{
+"origin" "112 712 -104"
+"angle" "180"
+"targetname" "gun1"
+"classname" "target_blaster"
+"dmg" "15"
+}
+{
+"classname" "target_blaster"
+"angle" "180"
+"targetname" "gun4"
+"origin" "112 640 -104"
+"dmg" "15"
+}
+{
+"model" "*175"
+"spawnflags" "2048"
+"delay" ".25"
+"angle" "0"
+"speed" "500"
+"wait" ".25"
+"lip" "6"
+"classname" "func_door"
+"targetname" "gun3"
+"sounds" "2"
+}
+{
+"classname" "target_splash"
+"sounds" "1"
+"angle" "270"
+"targetname" "gun4"
+"origin" "112 640 -104"
+}
+{
+"angle" "180"
+"sounds" "1"
+"classname" "target_splash"
+"targetname" "gun1"
+"origin" "112 712 -104"
+}
+{
+"angle" "180"
+"sounds" "1"
+"classname" "target_splash"
+"targetname" "gun2"
+"origin" "112 688 -104"
+}
+{
+"classname" "trigger_relay"
+"targetname" "trap_gun"
+"target" "gun4"
+"delay" ".8"
+"origin" "40 680 24"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"targetname" "trap_gun"
+"target" "gun3"
+"delay" ".6"
+"origin" "40 704 24"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"targetname" "trap_gun"
+"target" "gun2"
+"delay" ".4"
+"origin" "40 728 24"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"targetname" "trap_gun"
+"target" "gun1"
+"delay" ".2"
+"origin" "40 752 24"
+"spawnflags" "2048"
+}
+{
+"model" "*176"
+"classname" "trigger_multiple"
+"wait" ".8"
+"delay" ".5"
+"target" "trap_gun"
+"spawnflags" "2048"
+}
+{
+"model" "*177"
+"team" "door8"
+"sounds" "0"
+"speed" "200"
+"wait" "-1"
+"angle" "-1"
+"classname" "func_door"
+"lip" "8"
+"targetname" "trap_gun"
+"spawnflags" "2048"
+}
+{
+"_color" "0.501961 0.501961 1.000000"
+"light" "200"
+"classname" "light"
+"origin" "696 272 295"
+}
+{
+"origin" "472 263 295"
+"classname" "light"
+"light" "200"
+"_color" "0.501961 0.501961 1.000000"
+}
+{
+"origin" "353 381 295"
+"_color" "0.501961 0.501961 1.000000"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "426 759 295"
+"classname" "light"
+"light" "200"
+"_color" "0.501961 0.501961 1.000000"
+}
+{
+"_color" "0.501961 0.501961 1.000000"
+"light" "200"
+"classname" "light"
+"origin" "533 801 295"
+}
+{
+"_color" "0.501961 0.501961 1.000000"
+"light" "200"
+"classname" "light"
+"origin" "484 780 295"
+}
+{
+"origin" "824 360 295"
+"classname" "light"
+"light" "200"
+"_color" "0.501961 0.501961 1.000000"
+}
+{
+"origin" "872 453 295"
+"classname" "light"
+"light" "200"
+"_color" "0.501961 0.501961 1.000000"
+}
+{
+"_color" "0.501961 0.501961 1.000000"
+"light" "200"
+"classname" "light"
+"origin" "852 408 295"
+}
+{
+"_color" "0.501961 0.501961 1.000000"
+"light" "200"
+"classname" "light"
+"origin" "878 569 295"
+}
+{
+"origin" "836 670 295"
+"classname" "light"
+"light" "200"
+"_color" "0.501961 0.501961 1.000000"
+}
+{
+"origin" "857 619 295"
+"classname" "light"
+"light" "200"
+"_color" "0.501961 0.501961 1.000000"
+}
+{
+"origin" "754 756 295"
+"classname" "light"
+"light" "200"
+"_color" "0.501961 0.501961 1.000000"
+}
+{
+"_color" "0.501961 0.501961 1.000000"
+"light" "200"
+"classname" "light"
+"origin" "648 797 295"
+}
+{
+"_color" "0.501961 0.501961 1.000000"
+"light" "200"
+"classname" "light"
+"origin" "700 779 295"
+}
+{
+"model" "*178"
+"spawnflags" "2048"
+"classname" "func_button"
+"angle" "180"
+"wait" "-1"
+"lip" "16"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t1"
+"delay" "1"
+"target" "t2"
+"origin" "128 1404 268"
+}
+{
+"origin" "-1651 -532 -1104"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1635 -588 -1056"
+"light" "64"
+"classname" "light"
+}
+{
+"model" "*179"
+"_minlight" "0.2"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*180"
+"_minlight" "0.2"
+"spawnflags" "2048"
+"classname" "func_button"
+"angle" "180"
+"target" "a108"
+"wait" "5"
+"lip" "16"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-1603 -556 -1104"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1603 -532 -1104"
+}
+{
+"spawnflags" "2048"
+"classname" "item_ancient_head"
+"origin" "-1632 -415 -1076"
+"target" "t304"
+}
+{
+"classname" "light"
+"origin" "-1464 -596 -1088"
+"light" "175"
+}
+{
+"style" "38"
+"_cone" "20"
+"origin" "-1616 -416 -1088"
+"targetname" "a6"
+"light" "300"
+"target" "a5"
+"classname" "light"
+"_color" "0.124498 1.000000 0.000000"
+"spawnflags" "2048"
+}
+{
+"origin" "-1632 -416 -1036"
+"targetname" "a5"
+"classname" "info_notnull"
+"spawnflags" "2048"
+}
+{
+"light" "76"
+"origin" "-1584 -392 -1120"
+"classname" "light"
+}
+{
+"light" "76"
+"origin" "-1584 -440 -1120"
+"classname" "light"
+}
+{
+"light" "76"
+"origin" "-1584 -416 -1120"
+"classname" "light"
+}
+{
+"model" "*181"
+"spawnflags" "2048"
+"targetname" "a_water"
+"sounds" "1"
+"speed" "10"
+"angle" "-2"
+"classname" "func_water"
+}
+{
+"model" "*182"
+"targetname" "a134"
+"spawnflags" "2055"
+"classname" "func_wall"
+}
+{
+"spawnflags" "2048"
+"origin" "-1524 -488 -1048"
+"target" "a_water"
+"targetname" "a108"
+"classname" "trigger_relay"
+}
+{
+"targetname" "a134"
+"origin" "-1632 -416 -1080"
+"noise" "world/force1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1556 -424 -1058"
+"volume" ".8"
+"attenuation" "2"
+"noise" "world/brkglas.wav"
+"targetname" "a132"
+"classname" "target_speaker"
+"spawnflags" "2048"
+}
+{
+"model" "*183"
+"spawnflags" "2048"
+"target" "a132"
+"health" "10"
+"mass" "200"
+"dmg" "0"
+"classname" "func_explosive"
+}
+{
+"origin" "-1592 -440 -1068"
+"attenuation" "1"
+"volume" "0.6"
+"noise" "world/bubbl4.wav"
+"targetname" "a133"
+"classname" "target_speaker"
+"spawnflags" "2048"
+}
+{
+"targetname" "a_water"
+"origin" "-1592 -408 -1064"
+"noise" "world/bubl2.wav"
+"spawnflags" "2049"
+"classname" "target_speaker"
+}
+{
+"targetname" "a_water"
+"origin" "-1528 -392 -1064"
+"wait" "5"
+"random" "3"
+"spawnflags" "2049"
+"target" "a133"
+"classname" "func_timer"
+}
+{
+"spawnflags" "2048"
+"origin" "-1592 -504 -1080"
+"target" "a134"
+"targetname" "a108"
+"item" "key_red_key"
+"classname" "trigger_key"
+}
+{
+"spawnflags" "2048"
+"origin" "-1560 -392 -1064"
+"targetname" "a132"
+"killtarget" "a_water"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1628 -620 -1096"
+"classname" "item_enviro"
+"team" "head"
+}
+{
+"classname" "target_speaker"
+"origin" "-416 -400 -600"
+"spawnflags" "2048"
+"noise" "world/v_fac3.wav"
+"attenuation" "-1"
+"volume" "0.7"
+"targetname" "t300"
+}
+{
+"classname" "target_speaker"
+"targetname" "t298"
+"origin" "-448 -400 -600"
+"spawnflags" "2048"
+"noise" "world/v_cit2.wav"
+"attenuation" "-1"
+"volume" "0.7"
+}
+{
+"classname" "target_speaker"
+"targetname" "t299"
+"origin" "-472 -400 -600"
+"spawnflags" "2048"
+"noise" "world/voice7.wav"
+"attenuation" "-1"
+"volume" "0.7"
+}
+{
+"classname" "func_timer"
+"target" "t299"
+"attenuation" "-1"
+"random" "60"
+"wait" "180"
+"targetname" "t89"
+"origin" "-472 -368 -600"
+"spawnflags" "2048"
+}
+{
+"classname" "func_timer"
+"target" "t298"
+"attenuation" "-1"
+"random" "20"
+"wait" "200"
+"targetname" "t89"
+"origin" "-448 -368 -600"
+"spawnflags" "2048"
+}
+{
+"classname" "func_timer"
+"attenuation" "-1"
+"random" "100"
+"wait" "400"
+"origin" "-416 -368 -600"
+"spawnflags" "2048"
+"target" "t300"
+}
+{
+"classname" "target_spawner"
+"origin" "-1612 -428 -1068"
+"target" "item_adrenaline"
+"spawnflags" "2048"
+"targetname" "t306"
+}
+{
+"origin" "-1612 -428 -1068"
+"classname" "target_spawner"
+"target" "item_adrenaline"
+"spawnflags" "2048"
+"targetname" "t304"
+}
+{
+"origin" "-1612 -404 -1068"
+"classname" "target_spawner"
+"target" "item_adrenaline"
+"spawnflags" "2048"
+"targetname" "t305"
+}
+{
+"classname" "target_spawner"
+"origin" "-1612 -404 -1068"
+"target" "item_adrenaline"
+"spawnflags" "2048"
+"targetname" "t307"
+}
+{
+"delay" ".05"
+"origin" "-1592 -456 -1080"
+"classname" "trigger_relay"
+"targetname" "t304"
+"spawnflags" "2048"
+"target" "t305"
+}
+{
+"delay" ".1"
+"origin" "-1584 -424 -1080"
+"classname" "trigger_relay"
+"targetname" "t304"
+"spawnflags" "2048"
+"target" "t306"
+}
+{
+"delay" ".15"
+"origin" "-1588 -396 -1080"
+"classname" "trigger_relay"
+"targetname" "t304"
+"spawnflags" "2048"
+"target" "t307"
+}

--- a/stuff/mapfixes/baseq2/cool1.ent
+++ b/stuff/mapfixes/baseq2/cool1.ent
@@ -1,0 +1,4751 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Fixed monster_gladiator (810) in box being inaccessible on Medium
+//
+// This gladiator spawns on Medium and above but the trigger_once (784)
+// that blows up the box is only spawned on Hard and above, making the
+// monster count off by 1 on Medium. I changed the gladiator's spawnflags
+// from 259 to 771 to fix this inconsistency.
+{
+"sky" "unit6_"
+"classname" "worldspawn"
+"message" "Cooling Facility"
+"sounds" "5"
+"nextmap" "waste1"
+}
+{
+"origin" "-192 -1704 -112"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*1"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "404 -624 16"
+"spawnflags" "4"
+"target" "t188"
+"classname" "target_crosslevel_target"
+}
+{
+"model" "*2"
+"targetname" "t188"
+"classname" "func_explosive"
+}
+{
+"origin" "720 -932 68"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "732 -820 68"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "892 -940 68"
+"light" "80"
+"classname" "light"
+}
+{
+"model" "*3"
+"message" "Design is law."
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "812 -896 68"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*4"
+"dmg" "10"
+"health" "10"
+"classname" "func_explosive"
+}
+{
+"model" "*5"
+"team" "td1"
+"_minlight" ".18"
+"angle" "180"
+"classname" "func_door"
+}
+{
+"model" "*6"
+"classname" "trigger_once"
+"killtarget" "prevent"
+"spawnflags" "2048"
+}
+{
+"model" "*7"
+"classname" "func_wall"
+"targetname" "prevent"
+"spawnflags" "2048"
+}
+{
+"targetname" "cool1b"
+"origin" "-1496 -1308 24"
+"classname" "info_player_coop"
+"angle" "90"
+}
+{
+"targetname" "cool1b"
+"origin" "-1652 -1208 24"
+"classname" "info_player_coop"
+"angle" "45"
+}
+{
+"targetname" "cool1b"
+"origin" "-1388 -1308 24"
+"angle" "90"
+"classname" "info_player_coop"
+}
+{
+"origin" "-960 828 -388"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.931193 0.064220"
+}
+{
+"origin" "-1144 844 -388"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.931193 0.064220"
+}
+{
+"origin" "-1124 988 -388"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.931193 0.064220"
+}
+{
+"origin" "-980 988 -388"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.931193 0.064220"
+}
+{
+"origin" "-960 616 -388"
+"_color" "1.000000 0.931193 0.064220"
+"light" "120"
+"classname" "light"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1328 -1752 -728"
+"spawnflags" "2048"
+}
+{
+"model" "*8"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "408 -264 24"
+"angle" "225"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-2024 -128 -296"
+"target" "t186"
+"spawnflags" "1792"
+"classname" "misc_teleporter"
+}
+{
+"origin" "-2432 -544 -960"
+"targetname" "t186"
+"spawnflags" "1792"
+"angle" "270"
+"classname" "misc_teleporter_dest"
+}
+{
+"targetname" "t187"
+"origin" "-408 -80 24"
+"spawnflags" "1792"
+"angle" "0"
+"classname" "misc_teleporter_dest"
+}
+{
+"model" "*9"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"target" "t187"
+"origin" "-24 552 -360"
+"classname" "misc_teleporter"
+}
+{
+"origin" "-80 888 -160"
+"spawnflags" "1792"
+"classname" "item_health_large"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "1792"
+"origin" "336 -1568 -452"
+}
+{
+"origin" "260 -1344 -216"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "220 -1344 -216"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "300 -1344 -216"
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+}
+{
+"origin" "312 -1500 -216"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "92 -1676 -452"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "92 -1636 -452"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "92 -1596 -452"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "92 -1716 -452"
+"spawnflags" "1792"
+"classname" "item_health_small"
+}
+{
+"origin" "-448 -1576 -256"
+"classname" "ammo_cells"
+"spawnflags" "1792"
+}
+{
+"origin" "-492 -1464 -244"
+"spawnflags" "1792"
+"classname" "ammo_cells"
+}
+{
+"origin" "-416 -1516 -216"
+"target" "t1"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"origin" "-440 -1496 -228"
+"target" "t80"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"origin" "88 -1240 -216"
+"spawnflags" "2048"
+"classname" "ammo_shells"
+}
+{
+"origin" "64 -1364 -216"
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+}
+{
+"origin" "80 -1320 -216"
+"spawnflags" "2048"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-156 -1288 -456"
+"classname" "item_health"
+}
+{
+"origin" "-196 -1288 -456"
+"classname" "item_health"
+}
+{
+"model" "*10"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*11"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "136 -1332 -228"
+"spawnflags" "1792"
+"target" "t185"
+"classname" "trigger_always"
+}
+{
+"model" "*12"
+"wait" "-1"
+"targetname" "t185"
+"target" "t182"
+"angle" "-1"
+"spawnflags" "8"
+"classname" "func_door"
+}
+{
+"origin" "-148 -1588 -460"
+"target" "t184"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"model" "*13"
+"wait" "-1"
+"targetname" "t184"
+"target" "t183"
+"spawnflags" "8"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*14"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"model" "*15"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"style" "1"
+"targetname" "t183"
+"classname" "func_areaportal"
+}
+{
+"style" "2"
+"targetname" "t182"
+"classname" "func_areaportal"
+}
+{
+"model" "*16"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"target" "t181"
+"targetname" "t180"
+"classname" "path_corner"
+"origin" "-472 -1620 -448"
+}
+{
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+"origin" "-332 -1636 -396"
+}
+{
+"classname" "item_armor_jacket"
+"spawnflags" "1792"
+"origin" "-1648 -456 -288"
+}
+{
+"model" "*17"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_shells"
+"origin" "-2232 -588 -960"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1792"
+"origin" "-2272 -588 -960"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-1716 104 -840"
+}
+{
+"classname" "weapon_machinegun"
+"spawnflags" "1792"
+"origin" "-1752 104 -840"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "1792"
+"origin" "-1836 -136 -392"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+"origin" "-1640 -1044 32"
+}
+{
+"classname" "weapon_machinegun"
+"spawnflags" "1792"
+"origin" "-1640 -1008 32"
+}
+{
+"model" "*18"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1792"
+"origin" "-76 -764 -216"
+}
+{
+"origin" "-520 1208 -88"
+"classname" "light"
+"light" "250"
+}
+{
+"origin" "-676 1164 -88"
+"classname" "light"
+"light" "250"
+}
+{
+"origin" "-812 840 -156"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "-812 1136 -156"
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-368 -808 -212"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-312 -1564 -448"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "-640 -1568 -340"
+"_color" "1.000000 1.000000 0.000000"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-604 -1664 -340"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 1.000000 0.000000"
+}
+{
+"origin" "-576 -1568 -340"
+"_color" "1.000000 1.000000 0.000000"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-876 -1740 -648"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-808 -1740 -648"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*19"
+"target" "t179"
+"spawnflags" "2048"
+"classname" "trigger_once"
+}
+{
+"model" "*20"
+"origin" "-500 -1572 -704"
+"targetname" "t179"
+"distance" "180"
+"wait" "-1"
+"target" "t33"
+"spawnflags" "2120"
+"classname" "func_door_rotating"
+}
+{
+"model" "*21"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+"origin" "-2272 -548 -956"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-2232 -548 -956"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health_small"
+"origin" "-2464 -1032 -952"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "1792"
+"origin" "-2464 -1072 -952"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "-1924 -648 -928"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "-1924 -608 -928"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "-1924 -568 -928"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "-1924 -688 -928"
+}
+{
+"classname" "item_armor_body"
+"spawnflags" "1792"
+"origin" "-1504 -1316 -868"
+}
+{
+"classname" "weapon_rocketlauncher"
+"spawnflags" "1792"
+"origin" "-1728 -700 -728"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health"
+"origin" "-948 -1500 -732"
+}
+{
+"classname" "item_health"
+"spawnflags" "1792"
+"origin" "-988 -1500 -732"
+}
+{
+"classname" "weapon_supershotgun"
+"spawnflags" "1792"
+"origin" "-1056 -1988 -724"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_grenades"
+"origin" "-984 -2016 -788"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "2048"
+"origin" "-944 -2016 -788"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "-1240 -2020 -728"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "-1240 -1984 -728"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "-1240 -1948 -728"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health_small"
+"origin" "-888 -1984 -728"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health_small"
+"origin" "-888 -1948 -728"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "1792"
+"origin" "-888 -2020 -728"
+}
+{
+"classname" "item_armor_combat"
+"spawnflags" "1792"
+"origin" "-604 -1572 -424"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-736 -1320 -272"
+}
+{
+"classname" "weapon_grenadelauncher"
+"spawnflags" "1792"
+"origin" "-776 -1344 -272"
+}
+{
+"origin" "-1712 52 -1252"
+"spawnflags" "1792"
+"classname" "item_health_mega"
+}
+{
+"origin" "816 -532 12"
+"classname" "ammo_shells"
+"spawnflags" "1792"
+}
+{
+"origin" "816 -568 12"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "816 -760 16"
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+}
+{
+"origin" "884 -616 20"
+"spawnflags" "1792"
+"team" "pow"
+"classname" "item_quad"
+}
+{
+"origin" "884 -616 12"
+"spawnflags" "1792"
+"team" "pow"
+"classname" "item_invulnerability"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "340 -224 16"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-56 -592 24"
+}
+{
+"classname" "weapon_chaingun"
+"spawnflags" "1792"
+"origin" "-56 -552 24"
+}
+{
+"classname" "weapon_supershotgun"
+"spawnflags" "1792"
+"origin" "-220 1152 -136"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-384 1256 -160"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-344 1256 -160"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1792"
+"origin" "-1104 640 -280"
+}
+{
+"classname" "ammo_cells"
+"origin" "-984 544 -432"
+}
+{
+"classname" "weapon_bfg"
+"spawnflags" "1792"
+"origin" "-1144 800 -424"
+}
+{
+"origin" "-1144 672 -280"
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+}
+{
+"origin" "-1832 -16 -264"
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+}
+{
+"origin" "-1760 -16 -264"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"model" "*22"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "trigger_always"
+"spawnflags" "1792"
+"target" "t33"
+"origin" "-744 -1656 -648"
+}
+{
+"classname" "trigger_always"
+"spawnflags" "1792"
+"target" "t173"
+"origin" "-1464 -168 -304"
+}
+{
+"origin" "-96 680 -152"
+"angle" "135"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1088 -456 -296"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-416 336 -848"
+"angle" "180"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-968 -972 -724"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1768 -1496 -724"
+"angle" "45"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-160 -1336 -452"
+"angle" "225"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-104 -616 -208"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "320 -296 24"
+"angle" "180"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-424 1208 -152"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1840 -480 -296"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1224 -1376 24"
+"angle" "135"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-608 -1296 -688"
+"spawnflags" "2816"
+"classname" "item_health"
+}
+{
+"origin" "-608 -1376 -632"
+"spawnflags" "2816"
+"classname" "item_health_large"
+}
+{
+"origin" "-1440 -1528 80"
+"light" "130"
+"classname" "light"
+}
+{
+"model" "*23"
+"target" "t178"
+"targetname" "t177"
+"spawnflags" "2820"
+"classname" "trigger_once"
+}
+{
+"origin" "-272 232 40"
+"target" "t177"
+"targetname" "t176"
+"classname" "trigger_relay"
+}
+{
+"origin" "-248 192 40"
+"spawnflags" "256"
+"target" "t176"
+"targetname" "t133"
+"classname" "trigger_relay"
+}
+{
+"origin" "-304 752 -64"
+"spawnflags" "256"
+"targetname" "t175"
+"classname" "target_explosion"
+}
+{
+"origin" "-384 832 -136"
+"targetname" "t176"
+"spawnflags" "771"
+"angle" "315"
+"classname" "monster_gladiator"
+}
+{
+"model" "*24"
+"spawnflags" "2048"
+"targetname" "t178"
+"target" "t175"
+"mass" "400"
+"dmg" "5"
+"classname" "func_explosive"
+}
+{
+"model" "*25"
+"target" "t174"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-2056 -88 -206"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-2024 -128 -296"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1440 -280 -296"
+}
+{
+"classname" "target_goal"
+"targetname" "t173"
+"origin" "-2012 -104 -296"
+"spawnflags" "2048"
+}
+{
+"model" "*26"
+"target" "t173"
+"speed" "150"
+"wait" "-1"
+"angle" "180"
+"classname" "func_button"
+"spawnflags" "2048"
+}
+{
+"style" "3"
+"targetname" "t172"
+"classname" "func_areaportal"
+}
+{
+"model" "*27"
+"_minlight" ".2"
+"angle" "270"
+"lip" "132"
+"targetname" "t173"
+"target" "t172"
+"classname" "func_door"
+"speed" "40"
+"wait" "-1"
+}
+{
+"origin" "-416 -1344 -548"
+"targetname" "t157"
+"noise" "world/explod1.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2048"
+"origin" "-780 -1324 -272"
+"classname" "item_health"
+}
+{
+"spawnflags" "2048"
+"origin" "-780 -1364 -272"
+"classname" "item_health"
+}
+{
+"model" "*28"
+"target" "t144"
+"targetname" "ho1"
+"spawnflags" "2052"
+"classname" "trigger_once"
+}
+{
+"classname" "info_player_intermission"
+"angles" "23 310 0"
+"origin" "-1784 56 104"
+}
+{
+"origin" "-1872 -552 -296"
+"classname" "ammo_shells"
+}
+{
+"origin" "-1872 -512 -296"
+"classname" "ammo_shells"
+}
+{
+"spawnflags" "0"
+"origin" "152 -1092 20"
+"classname" "item_armor_shard"
+}
+{
+"spawnflags" "0"
+"origin" "152 -1048 20"
+"classname" "item_armor_shard"
+}
+{
+"spawnflags" "2048"
+"origin" "-364 -600 -216"
+"classname" "item_health_large"
+}
+{
+"origin" "-1936 -208 -1208"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1872 -184 -1208"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1936 -216 -1152"
+"light" "120"
+"classname" "light"
+}
+{
+"spawnflags" "2048"
+"origin" "-1408 -1720 -720"
+"classname" "ammo_slugs"
+}
+{
+"origin" "48 -1376 -232"
+"angle" "45"
+"spawnflags" "2050"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-604 -1572 -596"
+"targetname" "t33"
+"classname" "target_speaker"
+"noise" "world/pump1.wav"
+"spawnflags" "2"
+}
+{
+"origin" "-604 -1572 -532"
+"targetname" "t33"
+"spawnflags" "2"
+"noise" "world/pump1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-604 -1572 -560"
+"targetname" "t33"
+"spawnflags" "2"
+"noise" "world/pump3.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2048"
+"origin" "-1640 -948 28"
+"classname" "item_health_large"
+}
+{
+"spawnflags" "2048"
+"origin" "-1240 -948 28"
+"classname" "item_health_large"
+}
+{
+"spawnflags" "2048"
+"origin" "-424 -64 24"
+"classname" "ammo_bullets"
+}
+{
+"spawnflags" "2048"
+"origin" "-64 -656 20"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-64 -696 20"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-72 -756 -212"
+"classname" "ammo_grenades"
+}
+{
+"light" "140"
+"origin" "-272 -1740 -436"
+"classname" "light"
+}
+{
+"spawnflags" "2048"
+"origin" "-1304 -1704 -728"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-1392 -1700 -744"
+"angle" "270"
+"spawnflags" "2056"
+"classname" "misc_deadsoldier"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_shells"
+"origin" "-416 -1820 -716"
+}
+{
+"spawnflags" "2048"
+"origin" "-416 -1856 -716"
+"classname" "item_health"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1648 -1248 -1084"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1500 -1260 -1084"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1244 -1260 -1084"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1184 -1144 -1084"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1188 -896 -1084"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1248 -776 -1084"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1416 -776 -1084"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1568 -776 -1084"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1620 -852 -1084"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1644 -992 -1084"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+"origin" "-220 960 -172"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+"origin" "-220 724 -172"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+"origin" "-220 544 -124"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+"origin" "-220 296 -8"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+"origin" "-180 84 -8"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+"origin" "76 84 -8"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+"origin" "120 -120 -8"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+"origin" "-52 -200 -8"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+"origin" "-296 -200 -8"
+}
+{
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+"origin" "-844 208 -876"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2048"
+"angle" "45"
+"origin" "-324 -776 -236"
+}
+{
+"model" "*29"
+"speed" "200"
+"wait" "-1"
+"target" "t1"
+"angle" "270"
+"classname" "func_button"
+"spawnflags" "2048"
+}
+{
+"style" "4"
+"classname" "func_areaportal"
+"targetname" "t109"
+}
+{
+"style" "5"
+"classname" "func_areaportal"
+"targetname" "t171"
+}
+{
+"model" "*30"
+"_minlight" ".18"
+"classname" "func_door"
+"angle" "-1"
+"spawnflags" "8"
+"target" "t171"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-812 840 -156"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-812 1136 -156"
+}
+{
+"origin" "-960 524 -408"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"target" "t169"
+"wait" "10"
+"random" "8"
+"spawnflags" "1"
+"classname" "func_timer"
+"origin" "-960 628 -356"
+}
+{
+"target" "t170"
+"wait" "16"
+"random" "5"
+"origin" "-1144 824 -368"
+"classname" "func_timer"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-428 604 -352"
+}
+{
+"targetname" "t170"
+"classname" "target_speaker"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"origin" "-1152 892 -368"
+}
+{
+"classname" "target_speaker"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"origin" "-960 992 -408"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "-1024 988 -336"
+}
+{
+"targetname" "kill1"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "-912 988 -336"
+}
+{
+"volume" ".5"
+"classname" "target_speaker"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+"origin" "-1036 988 -176"
+}
+{
+"classname" "target_speaker"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"origin" "116 84 48"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "284 -128 48"
+}
+{
+"origin" "-220 272 48"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "332 -184 116"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "332 -448 -16"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "52 -448 -16"
+}
+{
+"origin" "352 -704 -16"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "188 -704 -16"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "188 -736 32"
+"spawnflags" "1"
+"noise" "world/pump3.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "88 -636 116"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-376 -168 116"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-224 -428 116"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "-148 -436 -16"
+}
+{
+"origin" "-224 -636 116"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-52 -128 48"
+}
+{
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "68 -1120 116"
+}
+{
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-220 -916 -28"
+}
+{
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-164 -1116 -28"
+}
+{
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "92 -1116 -28"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+"origin" "92 -1116 -168"
+}
+{
+"origin" "88 -428 116"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "148 -1112 -168"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+"origin" "88 -1344 -168"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+"origin" "-120 -1344 -168"
+}
+{
+"origin" "-104 -1116 -168"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-340 -1344 -168"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-272 -1752 -376"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+"origin" "-896 -1740 -676"
+}
+{
+"killtarget" "kill1"
+"origin" "-324 -1724 -424"
+"target" "t168"
+"targetname" "t1"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"targetname" "t168"
+"origin" "-708 -1712 -376"
+"spawnflags" "2"
+"noise" "world/amb12.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t168"
+"origin" "-496 -1716 -376"
+"spawnflags" "2"
+"noise" "world/amb12.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t168"
+"classname" "target_speaker"
+"noise" "world/amb12.wav"
+"spawnflags" "2"
+"origin" "-496 -1432 -376"
+}
+{
+"targetname" "t168"
+"origin" "-712 -1432 -376"
+"spawnflags" "2"
+"noise" "world/amb12.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t168"
+"classname" "target_speaker"
+"noise" "world/force1.wav"
+"spawnflags" "2"
+"origin" "-712 -1432 -456"
+}
+{
+"targetname" "t168"
+"classname" "target_speaker"
+"noise" "world/force1.wav"
+"spawnflags" "2"
+"origin" "-708 -1712 -456"
+}
+{
+"targetname" "t168"
+"classname" "target_speaker"
+"noise" "world/force1.wav"
+"spawnflags" "2"
+"origin" "-496 -1716 -456"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+"origin" "-28 -1344 -220"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-272 -1752 -400"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-256 -1252 -400"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-400 -1256 -688"
+}
+{
+"origin" "-704 -1904 -688"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"noise" "world/pump3.wav"
+"classname" "target_speaker"
+"origin" "-604 -1792 -656"
+}
+{
+"spawnflags" "1"
+"noise" "world/pump3.wav"
+"classname" "target_speaker"
+"origin" "-604 -1816 -656"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+"origin" "-512 -1904 -688"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-816 -1264 -704"
+}
+{
+"targetname" "t168"
+"origin" "-496 -1432 -456"
+"spawnflags" "2"
+"noise" "world/force1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-340 -1344 -676"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1176 -1948 -676"
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1196 -1720 -676"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-940 -1948 -676"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1056 -2100 -744"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1176 -2100 -744"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1064 -1932 -688"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-604 -1704 -656"
+"classname" "target_speaker"
+"noise" "world/pump3.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1392 -1680 -676"
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1388 -1520 -676"
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1080 -1108 -676"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1276 -1344 -676"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1716 -1176 -676"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-932 -2100 -744"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1680 -1296 -816"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1132 -728 -816"
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1424 -720 -816"
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1680 -720 -816"
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1716 -816 -676"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1132 -1296 -816"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+"origin" "-2284 -1032 -928"
+}
+{
+"origin" "-2472 -688 -956"
+"target" "t166"
+"spawnflags" "1"
+"classname" "func_timer"
+"random" "4"
+"wait" "12"
+}
+{
+"origin" "-2472 -824 -956"
+"target" "t165"
+"spawnflags" "1"
+"classname" "func_timer"
+"random" "4"
+"wait" "9"
+}
+{
+"origin" "-2472 -544 -956"
+"target" "t167"
+"spawnflags" "1"
+"wait" "11"
+"random" "8"
+"classname" "func_timer"
+}
+{
+"targetname" "t166"
+"classname" "target_speaker"
+"spawnflags" "0"
+"noise" "world/steam1.wav"
+"origin" "-2500 -688 -956"
+}
+{
+"targetname" "t165"
+"classname" "target_speaker"
+"spawnflags" "0"
+"noise" "world/steam1.wav"
+"origin" "-2500 -824 -956"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"origin" "-2332 -724 -912"
+}
+{
+"targetname" "t167"
+"origin" "-2500 -544 -956"
+"noise" "world/steam1.wav"
+"spawnflags" "0"
+"classname" "target_speaker"
+}
+{
+"origin" "-1868 -704 -912"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2368 -1140 -912"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2028 -996 -980"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2056 -684 -928"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2056 -400 -928"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1980 208 -800"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2172 -96 -1120"
+"target" "t163"
+"classname" "func_timer"
+"spawnflags" "1"
+"random" "4"
+"wait" "13"
+}
+{
+"origin" "-2172 -224 -1120"
+"target" "t162"
+"classname" "func_timer"
+"spawnflags" "1"
+"random" "6"
+"wait" "15"
+}
+{
+"origin" "-2172 32 -1120"
+"target" "t164"
+"wait" "12"
+"random" "7"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"targetname" "t163"
+"origin" "-2192 -96 -1120"
+"noise" "world/steam1.wav"
+"spawnflags" "0"
+"classname" "target_speaker"
+}
+{
+"targetname" "t162"
+"origin" "-2192 -224 -1120"
+"noise" "world/steam1.wav"
+"spawnflags" "0"
+"classname" "target_speaker"
+}
+{
+"origin" "-2052 -252 -1128"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2064 -196 -1164"
+"target" "t161"
+"classname" "func_timer"
+"wait" "12"
+"random" "3"
+"spawnflags" "1"
+}
+{
+"targetname" "t161"
+"classname" "target_speaker"
+"spawnflags" "0"
+"noise" "world/drip2.wav"
+"origin" "-2040 -196 -1164"
+}
+{
+"origin" "-1948 -192 -1116"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"targetname" "t160"
+"classname" "target_speaker"
+"spawnflags" "0"
+"noise" "world/drip1.wav"
+"origin" "-2044 -8 -1116"
+}
+{
+"targetname" "t164"
+"classname" "target_speaker"
+"spawnflags" "0"
+"noise" "world/steam1.wav"
+"origin" "-2192 32 -1120"
+}
+{
+"origin" "-2068 -8 -1116"
+"target" "t160"
+"spawnflags" "1"
+"wait" "8"
+"random" "4"
+"classname" "func_timer"
+}
+{
+"origin" "-1724 108 -1204"
+"target" "t159"
+"spawnflags" "1"
+"random" "3"
+"wait" "12"
+"classname" "func_timer"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"origin" "-2332 -1012 -912"
+}
+{
+"targetname" "t159"
+"origin" "-1700 108 -1204"
+"noise" "world/drip2.wav"
+"spawnflags" "0"
+"classname" "target_speaker"
+}
+{
+"origin" "-896 208 -800"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1192 208 -800"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1532 208 -800"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1564 -16 -628"
+"noise" "world/amb15.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1568 -192 -488"
+"noise" "world/amb15.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1300 -192 -488"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb15.wav"
+}
+{
+"origin" "-1296 -16 -628"
+"noise" "world/amb15.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-504 212 -636"
+"noise" "world/pump3.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-356 352 -800"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "-2072 236 -800"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "-504 212 -796"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/pump3.wav"
+}
+{
+"origin" "-356 96 -800"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"volume" ".2"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-220 704 -44"
+}
+{
+"volume" ".2"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-256 984 -44"
+}
+{
+"volume" ".2"
+"origin" "20 1056 -140"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".2"
+"origin" "-220 1220 -44"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".2"
+"origin" "-432 984 -44"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-608 984 -44"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-788 984 -116"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".5"
+"origin" "-836 984 -176"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t169"
+"origin" "-960 608 -356"
+"spawnflags" "0"
+"noise" "world/drip1.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".5"
+"origin" "-1144 804 -176"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".5"
+"origin" "-1292 688 -176"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".5"
+"origin" "-1444 632 -176"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".5"
+"origin" "-1444 460 -176"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1444 336 -144"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".2"
+"origin" "-1444 196 -256"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".2"
+"origin" "-1116 48 -256"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".2"
+"origin" "-1828 48 -256"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".2"
+"origin" "-1672 -320 -256"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".2"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-24 832 -140"
+}
+{
+"volume" ".2"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-1440 -216 -172"
+}
+{
+"volume" ".2"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-1440 -412 -172"
+}
+{
+"volume" ".2"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-1440 -608 -172"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump3.wav"
+"spawnflags" "1"
+"origin" "-1444 -812 -172"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump3.wav"
+"spawnflags" "1"
+"origin" "-1444 -932 -92"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump3.wav"
+"spawnflags" "1"
+"origin" "-1444 -932 224"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"origin" "-1340 -1040 168"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1712 -992 88"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"origin" "-1548 -1304 168"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "-1548 -1304 24"
+}
+{
+"origin" "-1548 -1040 24"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "-1340 -1040 24"
+}
+{
+"origin" "-1340 -1304 24"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"origin" "-1548 -1040 168"
+}
+{
+"origin" "-1176 -992 88"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"origin" "-1340 -1304 168"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1444 -1600 128"
+}
+{
+"volume" ".2"
+"origin" "-1216 -320 -256"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "item_health_small"
+"origin" "-872 1016 -420"
+"spawnflags" "2048"
+}
+{
+"classname" "item_health_small"
+"origin" "-872 952 -420"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "0"
+"classname" "item_health"
+"origin" "420 -64 24"
+}
+{
+"spawnflags" "0"
+"classname" "item_health"
+"origin" "420 -100 24"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2056"
+"angle" "180"
+"origin" "-296 -1360 -752"
+}
+{
+"spawnflags" "2048"
+"classname" "item_quad"
+"origin" "-276 -1376 -724"
+}
+{
+"spawnflags" "0"
+"classname" "item_armor_shard"
+"origin" "152 -1180 20"
+}
+{
+"classname" "misc_deadsoldier"
+"angle" "45"
+"spawnflags" "2050"
+"origin" "-236 -1304 -476"
+}
+{
+"style" "6"
+"classname" "func_areaportal"
+"targetname" "t157"
+}
+{
+"classname" "target_secret"
+"message" "You have found a secret."
+"targetname" "t158"
+"origin" "-352 -1328 -712"
+}
+{
+"model" "*31"
+"classname" "trigger_once"
+"target" "t158"
+}
+{
+"spawnflags" "0"
+"classname" "item_health"
+"origin" "-416 -1892 -716"
+}
+{
+"delay" ".3"
+"dmg" "10"
+"classname" "target_explosion"
+"targetname" "t157"
+"origin" "-392 -1318 -648"
+}
+{
+"classname" "target_explosion"
+"dmg" "10"
+"delay" ".6"
+"targetname" "t157"
+"origin" "-400 -1374 -696"
+}
+{
+"model" "*32"
+"targetname" "exp69"
+"classname" "func_explosive"
+"mass" "100"
+"dmg" "10"
+"target" "t157"
+}
+{
+"spawnflags" "2816"
+"classname" "weapon_rocketlauncher"
+"origin" "-696 -1816 -728"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2816"
+"angle" "135"
+"origin" "-720 -1840 -744"
+}
+{
+"model" "*33"
+"spawnflags" "4"
+"classname" "func_train"
+"target" "t27"
+}
+{
+"model" "*34"
+"spawnflags" "4"
+"classname" "func_train"
+"target" "t31"
+}
+{
+"spawnflags" "0"
+"classname" "ammo_rockets"
+"origin" "-1776 -720 -728"
+}
+{
+"spawnflags" "0"
+"classname" "ammo_rockets"
+"origin" "-1776 -680 -728"
+}
+{
+"spawnflags" "2048"
+"origin" "-1536 -1312 -864"
+"targetname" "t155"
+"message" "You have found a secret."
+"classname" "target_secret"
+}
+{
+"spawnflags" "2048"
+"origin" "-2464 -1112 -952"
+"classname" "item_health_large"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_shells"
+"origin" "-112 1132 -148"
+}
+{
+"spawnflags" "0"
+"origin" "-76 1132 -148"
+"classname" "ammo_shells"
+}
+{
+"spawnflags" "2048"
+"message" "You have found a secret."
+"classname" "target_secret"
+"targetname" "t154"
+"origin" "-1712 -48 -1232"
+}
+{
+"spawnflags" "2048"
+"classname" "target_help"
+"targetname" "t36"
+"origin" "-176 -1656 -184"
+"message" "Coolant systems drained.\nReturn to the Reactor.\n"
+}
+{
+"spawnflags" "2048"
+"classname" "weapon_railgun"
+"origin" "-288 -1320 -720"
+}
+{
+"spawnflags" "2048"
+"classname" "target_goal"
+"targetname" "t36"
+"origin" "-176 -1656 -120"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-552 208 -872"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-844 208 -872"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-1040 208 -872"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-1276 208 -872"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-1504 208 -872"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-1752 208 -872"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-1952 208 -872"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-2056 124 -872"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-2056 -36 -892"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-2056 -196 -960"
+}
+{
+"origin" "-2056 -392 -976"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2052 -592 -976"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2052 -752 -976"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2256 -752 -976"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2312 -924 -976"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2140 -992 -980"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1940 -992 -1056"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1760 -992 -1116"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "-1544 -776 -1116"
+}
+{
+"origin" "-1280 -776 -1116"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1280 -996 -1116"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "-1544 -996 -1116"
+}
+{
+"origin" "-1544 -1220 -1116"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "-1280 -1220 -1116"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-1544 -1220 -1120"
+}
+{
+"origin" "-1544 -996 -1120"
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1544 -776 -1120"
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-1280 -776 -1120"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-1280 -996 -1120"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-1760 -992 -1120"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-1940 -992 -1060"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-2140 -992 -984"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-2312 -924 -980"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-2256 -752 -980"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-2052 -752 -980"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-2052 -592 -980"
+}
+{
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"origin" "-2056 -392 -980"
+}
+{
+"origin" "-2056 -196 -964"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-2056 -36 -896"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-2056 124 -876"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1952 208 -876"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1752 208 -876"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1504 208 -876"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1276 208 -876"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1040 208 -876"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-220 1232 -172"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-552 208 -876"
+"classname" "target_speaker"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1280 -1220 -1120"
+"spawnflags" "1"
+"noise" "world/curnt2.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-664 208 -856"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-816 208 -856"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-960 208 -856"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-1104 208 -856"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-1268 208 -856"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-1428 208 -856"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-1608 208 -856"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-1780 208 -856"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-1912 208 -856"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-2052 208 -856"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-2052 52 -860"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-2052 -96 -900"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-2052 -260 -940"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-2052 -376 -964"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-2052 -516 -964"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1792 -992 -1028"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1920 -992 -992"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2052 -992 -964"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2176 -992 -964"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2312 -992 -964"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2312 -860 -964"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2312 -736 -964"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2176 -736 -964"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2056 -736 -964"
+}
+{
+"origin" "-2052 -624 -964"
+"light" "140"
+"classname" "light"
+}
+{
+"origin" "-1648 -1132 -1084"
+"classname" "light"
+"light" "140"
+}
+{
+"origin" "-528 208 -856"
+"light" "140"
+"classname" "light"
+}
+{
+"origin" "416 -600 12"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "296 -600 12"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "184 -600 12"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "52 -600 12"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "416 -440 12"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "296 -440 12"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "184 -440 12"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "52 -440 12"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "416 -752 12"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "296 -752 12"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "184 -752 12"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "52 -752 12"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-84 -440 12"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-200 -440 12"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-436 -204 12"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-288 -200 12"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-156 -204 12"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-28 -204 12"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "120 -204 12"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "120 -84 12"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "120 20 12"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "48 84 12"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-80 84 12"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-216 84 12"
+}
+{
+"spawnflags" "2048"
+"classname" "weapon_hyperblaster"
+"origin" "-2288 -1100 -968"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2048"
+"angle" "180"
+"origin" "-2268 -1116 -984"
+}
+{
+"model" "*35"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t154"
+}
+{
+"spawnflags" "2048"
+"classname" "item_adrenaline"
+"origin" "-1712 52 -1252"
+}
+{
+"spawnflags" "0"
+"origin" "-1712 112 -1248"
+"classname" "ammo_grenades"
+}
+{
+"spawnflags" "0"
+"origin" "-2284 -632 -944"
+"classname" "misc_explobox"
+"mass" "80"
+"health" "25"
+"dmg" "40"
+}
+{
+"spawnflags" "2048"
+"origin" "-2452 -880 -944"
+"classname" "misc_explobox"
+"mass" "80"
+"health" "25"
+"dmg" "40"
+}
+{
+"classname" "func_group"
+}
+{
+"spawnflags" "2048"
+"origin" "-600 32 -864"
+"classname" "ammo_rockets"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-76 656 -160"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-40 656 -160"
+}
+{
+"origin" "28 1088 -144"
+"classname" "light"
+"light" "140"
+}
+{
+"origin" "-220 1104 -116"
+"classname" "light"
+"light" "140"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-1096 24 -816"
+}
+{
+"classname" "light"
+"light" "96"
+"origin" "-1096 80 -848"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-1848 80 -848"
+}
+{
+"classname" "light"
+"light" "96"
+"origin" "-1848 24 -816"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1672 -1248 440"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1672 -1160 440"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1672 -1072 440"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1216 -1152 440"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1216 -1064 440"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1216 -1240 440"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-1392 -1116 44"
+}
+{
+"classname" "light"
+"light" "96"
+"origin" "-1240 -1052 40"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1440 -1296 80"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1440 -1368 80"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1440 -1424 80"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1444 -1252 -60"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1444 -1132 -60"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-1444 -1392 -60"
+}
+{
+"origin" "-1340 -1116 -60"
+"classname" "light"
+"light" "200"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-1340 -1248 -60"
+}
+{
+"origin" "-1340 -1420 -60"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1552 -1216 -60"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1288 -1256 -60"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "-1288 -1112 -60"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "-1288 -968 -60"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "-1712 -992 136"
+"light" "120"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1176 -992 136"
+}
+{
+"origin" "-1440 -1196 80"
+"light" "130"
+"classname" "light"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1552 -1084 -60"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1288 -1372 -60"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1608 -1004 -60"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1556 -1148 -60"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-1556 -1280 -60"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-1552 -1388 -60"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_rockets"
+"origin" "-1384 -1064 16"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_shells"
+"origin" "-1224 -1108 16"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-1792 48 -304"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-1828 48 -304"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-1756 48 -304"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2048"
+"angle" "315"
+"origin" "-1784 -36 -288"
+}
+{
+"angle" "45"
+"spawnflags" "2048"
+"classname" "misc_deadsoldier"
+"origin" "-1240 -1052 0"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2048"
+"angle" "90"
+"origin" "-1392 -1116 0"
+}
+{
+"spawnflags" "2048"
+"classname" "target_help"
+"message" "Activate cooling pump to\nlower coolant around\nreactor."
+"targetname" "t153"
+"origin" "-1484 -1508 24"
+}
+{
+"model" "*36"
+"classname" "trigger_once"
+"target" "t153"
+}
+{
+"spawnflags" "2048"
+"origin" "-1664 -1348 20"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-1664 -1384 20"
+"classname" "item_health_small"
+}
+{
+"origin" "-152 -1536 -200"
+"targetname" "t36"
+"spawnflags" "2"
+"classname" "target_crosslevel_trigger"
+}
+{
+"model" "*37"
+"target" "t180"
+"dmg" "5"
+"spawnflags" "4"
+"classname" "func_train"
+"speed" "80"
+"targetname" "t1"
+}
+{
+"model" "*38"
+"dmg" "5"
+"spawnflags" "4"
+"classname" "func_train"
+"target" "t76"
+"targetname" "t80"
+"speed" "70"
+}
+{
+"model" "*39"
+"spawnflags" "4"
+"classname" "func_train"
+"target" "t28"
+}
+{
+"model" "*40"
+"spawnflags" "4"
+"classname" "func_train"
+"target" "t29"
+}
+{
+"spawnflags" "2048"
+"dmg" "40"
+"health" "25"
+"mass" "80"
+"classname" "misc_explobox"
+"origin" "-2164 -620 -944"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-1768 44 -1248"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-1656 48 -1248"
+}
+{
+"spawnflags" "0"
+"classname" "ammo_bullets"
+"origin" "-1672 112 -1248"
+}
+{
+"spawnflags" "0"
+"classname" "ammo_bullets"
+"origin" "-1752 112 -1248"
+}
+{
+"spawnflags" "0"
+"classname" "item_armor_shard"
+"origin" "-368 80 -864"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-368 124 -864"
+}
+{
+"spawnflags" "0"
+"classname" "item_armor_shard"
+"origin" "-368 168 -864"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-368 212 -864"
+}
+{
+"spawnflags" "0"
+"classname" "item_armor_shard"
+"origin" "-368 256 -864"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-368 300 -864"
+}
+{
+"spawnflags" "0"
+"classname" "item_armor_shard"
+"origin" "-368 344 -864"
+}
+{
+"classname" "ammo_slugs"
+"origin" "-1124 792 -428"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_chick"
+"angle" "90"
+"spawnflags" "769"
+"target" "t117"
+"origin" "-216 -1732 -420"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-396 212 -516"
+}
+{
+"model" "*41"
+"classname" "trigger_once"
+"target" "t148"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_chick"
+"target" "t116"
+"spawnflags" "769"
+"angle" "270"
+"origin" "-312 -1328 -416"
+"item" "ammo_rockets"
+}
+{
+"classname" "path_corner"
+"target" "t145"
+"targetname" "t146"
+"origin" "-1024 -1456 -712"
+}
+{
+"classname" "path_corner"
+"targetname" "t145"
+"target" "t146"
+"origin" "-1368 -1456 -712"
+}
+{
+"targetname" "t174"
+"classname" "monster_berserk"
+"angle" "180"
+"spawnflags" "770"
+"target" "t146"
+"origin" "-992 -1456 -696"
+}
+{
+"classname" "monster_berserk"
+"targetname" "t144"
+"spawnflags" "257"
+"angle" "180"
+"origin" "-1152 992 -264"
+}
+{
+"model" "*42"
+"classname" "trigger_once"
+"target" "t143"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_berserk"
+"angle" "225"
+"spawnflags" "1"
+"targetname" "t144"
+"origin" "-1144 760 -272"
+}
+{
+"classname" "path_corner"
+"target" "t141"
+"targetname" "t142"
+"origin" "96 -1116 64"
+}
+{
+"classname" "path_corner"
+"targetname" "t141"
+"target" "t142"
+"origin" "-260 -1116 64"
+}
+{
+"classname" "monster_hover"
+"spawnflags" "1"
+"target" "t142"
+"angle" "180"
+"origin" "128 -1116 80"
+}
+{
+"classname" "monster_chick"
+"angle" "225"
+"spawnflags" "769"
+"origin" "-1920 -524 -940"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_small"
+"origin" "-1664 -1312 20"
+}
+{
+"spawnflags" "0"
+"classname" "weapon_chaingun"
+"origin" "-1796 -52 -264"
+}
+{
+"spawnflags" "1"
+"classname" "point_combat"
+"targetname" "t137"
+"origin" "-1248 -416 -304"
+}
+{
+"spawnflags" "1"
+"classname" "point_combat"
+"targetname" "t138"
+"origin" "-1648 -416 -304"
+}
+{
+"spawnflags" "0"
+"classname" "ammo_grenades"
+"origin" "-600 392 -864"
+}
+{
+"spawnflags" "0"
+"classname" "item_health"
+"origin" "-1112 -360 -400"
+}
+{
+"spawnflags" "0"
+"classname" "item_health"
+"origin" "-1112 -320 -400"
+}
+{
+"model" "*43"
+"spawnflags" "2052"
+"targetname" "ho1"
+"classname" "trigger_once"
+"target" "t133"
+}
+{
+"spawnflags" "3"
+"angle" "270"
+"classname" "monster_hover"
+"targetname" "t133"
+"origin" "-408 1048 320"
+}
+{
+"classname" "monster_hover"
+"angle" "270"
+"spawnflags" "771"
+"targetname" "t133"
+"origin" "-168 1152 80"
+}
+{
+"classname" "point_combat"
+"targetname" "t130"
+"origin" "208 -424 256"
+}
+{
+"classname" "point_combat"
+"targetname" "t129"
+"spawnflags" "1"
+"origin" "0 -312 280"
+}
+{
+"classname" "point_combat"
+"spawnflags" "0"
+"targetname" "t131"
+"origin" "132 -668 256"
+}
+{
+"classname" "monster_hover"
+"target" "t129"
+"spawnflags" "3"
+"angle" "225"
+"origin" "260 -164 348"
+"targetname" "t132"
+}
+{
+"classname" "monster_hover"
+"angle" "225"
+"spawnflags" "771"
+"target" "t130"
+"origin" "368 -196 348"
+"targetname" "t132"
+"item" "ammo_cells"
+}
+{
+"classname" "monster_hover"
+"angle" "180"
+"spawnflags" "771"
+"target" "t131"
+"targetname" "t132"
+"origin" "384 -672 300"
+}
+{
+"model" "*44"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t132"
+}
+{
+"spawnflags" "2048"
+"classname" "misc_explobox"
+"origin" "-52 -560 8"
+}
+{
+"spawnflags" "2048"
+"classname" "misc_explobox"
+"origin" "-72 -616 8"
+}
+{
+"spawnflags" "2048"
+"origin" "-380 -100 8"
+"classname" "misc_explobox"
+}
+{
+"spawnflags" "2048"
+"classname" "misc_explobox"
+"origin" "-100 -620 -192"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"spawnflags" "0"
+"classname" "item_armor_shard"
+"origin" "152 -1136 20"
+}
+{
+"classname" "point_combat"
+"targetname" "t128"
+"spawnflags" "1"
+"origin" "396 -284 8"
+}
+{
+"classname" "monster_gunner"
+"angle" "270"
+"target" "t128"
+"spawnflags" "1"
+"origin" "360 -160 24"
+}
+{
+"classname" "point_combat"
+"targetname" "t127"
+"spawnflags" "1"
+"origin" "256 -172 8"
+}
+{
+"spawnflags" "0"
+"classname" "ammo_bullets"
+"origin" "-76 -804 -212"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_shells"
+"origin" "-368 -808 -212"
+}
+{
+"spawnflags" "0"
+"classname" "ammo_bullets"
+"origin" "-328 -808 -212"
+}
+{
+"classname" "path_corner"
+"targetname" "t126"
+"target" "t121"
+"origin" "-220 -920 -200"
+}
+{
+"classname" "path_corner"
+"targetname" "t125"
+"target" "t126"
+"origin" "-220 -1120 -200"
+}
+{
+"classname" "path_corner"
+"targetname" "t124"
+"target" "t125"
+"origin" "36 -1120 -200"
+}
+{
+"classname" "path_corner"
+"targetname" "t123"
+"target" "t124"
+"origin" "36 -1120 -200"
+}
+{
+"classname" "path_corner"
+"targetname" "t122"
+"target" "t123"
+"origin" "-220 -1120 -200"
+}
+{
+"classname" "path_corner"
+"targetname" "t121"
+"target" "t122"
+"origin" "-220 -920 -200"
+}
+{
+"classname" "path_corner"
+"targetname" "t120"
+"target" "t121"
+"origin" "-220 -792 -200"
+}
+{
+"item" "ammo_slugs"
+"classname" "monster_gladiator"
+"angle" "270"
+"target" "t120"
+"spawnflags" "1"
+"origin" "-220 -740 -184"
+}
+{
+"origin" "-100 812 276"
+"light" "150"
+"classname" "light"
+"_color" "1.000000 0.972549 0.043137"
+}
+{
+"_color" "1.000000 0.972549 0.043137"
+"classname" "light"
+"light" "150"
+"origin" "-48 864 276"
+}
+{
+"origin" "-44 1112 276"
+"light" "150"
+"classname" "light"
+"_color" "1.000000 0.972549 0.043137"
+}
+{
+"_color" "1.000000 0.972549 0.043137"
+"classname" "light"
+"light" "150"
+"origin" "-96 1164 276"
+}
+{
+"origin" "-352 1164 276"
+"light" "150"
+"classname" "light"
+"_color" "1.000000 0.972549 0.043137"
+}
+{
+"_color" "1.000000 0.972549 0.043137"
+"classname" "light"
+"light" "150"
+"origin" "-404 1112 276"
+}
+{
+"origin" "-352 812 276"
+"light" "150"
+"classname" "light"
+"_color" "1.000000 0.972549 0.043137"
+}
+{
+"origin" "-368 1128 276"
+"light" "150"
+"classname" "light"
+"_color" "1.000000 0.972549 0.043137"
+}
+{
+"classname" "path_corner"
+"target" "t117"
+"targetname" "t118"
+"origin" "-216 -1372 -436"
+}
+{
+"classname" "path_corner"
+"targetname" "t117"
+"target" "t118"
+"origin" "-216 -1736 -436"
+}
+{
+"classname" "path_corner"
+"targetname" "t115"
+"target" "t116"
+"origin" "-312 -1536 -436"
+}
+{
+"classname" "path_corner"
+"target" "t115"
+"targetname" "t116"
+"origin" "-312 -1344 -436"
+}
+{
+"model" "*45"
+"classname" "trigger_once"
+"target" "t114"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_chick"
+"angle" "270"
+"targetname" "t114"
+"origin" "-796 -1328 -720"
+}
+{
+"classname" "point_combat"
+"targetname" "t112"
+"spawnflags" "1"
+"origin" "-448 -1596 -724"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_gunner"
+"angle" "135"
+"target" "t112"
+"origin" "-456 -1856 -708"
+"targetname" "t114"
+"spawnflags" "1"
+}
+{
+"spawnflags" "2048"
+"classname" "item_armor_body"
+"origin" "-252 -1344 -724"
+}
+{
+"spawnflags" "1"
+"classname" "monster_gunner"
+"angle" "270"
+"origin" "-960 -1752 -712"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_gunner"
+"angle" "90"
+"spawnflags" "1"
+"target" "t59"
+"targetname" "t109"
+"origin" "-1176 -1888 -708"
+}
+{
+"spawnflags" "2048"
+"target" "t155"
+"classname" "item_health_mega"
+"origin" "-1504 -1316 -880"
+}
+{
+"classname" "path_corner"
+"target" "t107"
+"targetname" "t108"
+"origin" "-964 -984 -728"
+}
+{
+"classname" "path_corner"
+"targetname" "t107"
+"target" "t108"
+"origin" "-1052 -1436 -728"
+}
+{
+"targetname" "t174"
+"classname" "monster_berserk"
+"angle" "270"
+"target" "t108"
+"origin" "-1012 -1088 -712"
+"spawnflags" "3"
+}
+{
+"classname" "path_corner"
+"target" "t105"
+"targetname" "t106"
+"origin" "-1708 -1316 -732"
+}
+{
+"classname" "path_corner"
+"targetname" "t104"
+"target" "t105"
+"origin" "-1744 -1448 -732"
+}
+{
+"classname" "path_corner"
+"target" "t104"
+"targetname" "t105"
+"origin" "-1740 -1320 -732"
+}
+{
+"classname" "path_corner"
+"targetname" "t105"
+"target" "t104"
+"origin" "-1448 -1448 -732"
+}
+{
+"targetname" "t174"
+"classname" "monster_berserk"
+"target" "t106"
+"spawnflags" "3"
+"origin" "-1740 -1280 -716"
+}
+{
+"classname" "path_corner"
+"target" "t99"
+"targetname" "t100"
+"origin" "-1948 -860 -956"
+}
+{
+"classname" "path_corner"
+"targetname" "t99"
+"target" "t100"
+"origin" "-2200 -860 -956"
+}
+{
+"item" "ammo_rockets"
+"classname" "monster_chick"
+"target" "t100"
+"spawnflags" "0"
+"angle" "180"
+"origin" "-1920 -860 -940"
+}
+{
+"model" "*46"
+"classname" "trigger_once"
+"target" "t98"
+"spawnflags" "2048"
+}
+{
+"item" "ammo_cells"
+"classname" "monster_floater"
+"spawnflags" "769"
+"angle" "90"
+"targetname" "t98"
+"origin" "-1816 -344 -544"
+}
+{
+"angle" "90"
+"spawnflags" "3"
+"classname" "monster_hover"
+"targetname" "t96"
+"origin" "-1248 -420 -64"
+}
+{
+"angle" "90"
+"spawnflags" "771"
+"classname" "monster_hover"
+"targetname" "t96"
+"origin" "-1040 -264 28"
+}
+{
+"classname" "monster_hover"
+"spawnflags" "3"
+"angle" "90"
+"targetname" "t96"
+"origin" "-1764 -340 104"
+"item" "ammo_cells"
+}
+{
+"classname" "point_combat"
+"spawnflags" "1"
+"targetname" "t97"
+"origin" "16 1132 -160"
+}
+{
+"classname" "monster_gunner"
+"spawnflags" "769"
+"angle" "90"
+"target" "t97"
+"origin" "16 812 -144"
+"targetname" "t96"
+}
+{
+"model" "*47"
+"classname" "trigger_once"
+"target" "t96"
+"spawnflags" "2048"
+}
+{
+"classname" "point_combat"
+"spawnflags" "0"
+"targetname" "t95"
+"origin" "-472 760 -160"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_gunner"
+"angle" "180"
+"spawnflags" "1"
+"target" "t95"
+"targetname" "t96"
+"origin" "-328 736 -136"
+}
+{
+"angle" "90"
+"classname" "monster_gunner"
+"origin" "-1248 -448 -288"
+"target" "t137"
+"spawnflags" "1"
+"targetname" "t148"
+"item" "ammo_grenades"
+}
+{
+"angle" "180"
+"classname" "monster_floater"
+"origin" "-864 244 -820"
+"spawnflags" "1"
+"targetname" "t98"
+}
+{
+"item" "ammo_cells"
+"classname" "monster_floater"
+"angle" "180"
+"origin" "-888 176 -820"
+"spawnflags" "1"
+"targetname" "t98"
+}
+{
+"spawnflags" "0"
+"classname" "item_health"
+"origin" "-404 -792 24"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-404 -752 24"
+}
+{
+"classname" "path_corner"
+"targetname" "t85"
+"target" "t86"
+"origin" "-2432 -784 -936"
+}
+{
+"classname" "path_corner"
+"targetname" "t84"
+"target" "t85"
+"origin" "-2432 -584 -936"
+}
+{
+"classname" "path_corner"
+"targetname" "t83"
+"target" "t84"
+"origin" "-2212 -584 -936"
+}
+{
+"classname" "path_corner"
+"targetname" "t87"
+"target" "t88"
+"origin" "-2416 -600 -936"
+}
+{
+"classname" "path_corner"
+"targetname" "t88"
+"target" "t83"
+"origin" "-2220 -600 -936"
+}
+{
+"classname" "path_corner"
+"targetname" "t86"
+"target" "t87"
+"origin" "-2416 -800 -936"
+}
+{
+"spawnflags" "1"
+"classname" "monster_chick"
+"target" "t83"
+"origin" "-2184 -584 -920"
+}
+{
+"classname" "point_combat"
+"origin" "-44 832 -144"
+"targetname" "t82"
+"spawnflags" "1"
+}
+{
+"spawnflags" "2048"
+"classname" "misc_explobox"
+"origin" "-56 -776 8"
+}
+{
+"spawnflags" "2048"
+"origin" "-328 -88 8"
+"classname" "misc_explobox"
+}
+{
+"spawnflags" "2048"
+"origin" "-340 -700 -192"
+"classname" "misc_explobox"
+}
+{
+"origin" "-148 -1752 -440"
+"classname" "light"
+"light" "72"
+}
+{
+"light" "72"
+"classname" "light"
+"origin" "-148 -1716 -412"
+}
+{
+"origin" "-148 -1680 -440"
+"classname" "light"
+"light" "72"
+}
+{
+"origin" "-480 -1572 -708"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-224 -1700 -408"
+"target" "t80"
+"targetname" "t1"
+"classname" "trigger_relay"
+"delay" ".3"
+"spawnflags" "2048"
+}
+{
+"origin" "-248 -1588 -408"
+"target" "exp69"
+"targetname" "t1"
+"delay" ".6"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-536 -1508 -440"
+"target" "t76"
+"targetname" "t77"
+"classname" "path_corner"
+}
+{
+"wait" ".5"
+"origin" "-536 -1508 -508"
+"target" "t77"
+"targetname" "t76"
+"classname" "path_corner"
+}
+{
+"target" "t180"
+"targetname" "t181"
+"wait" ".5"
+"origin" "-472 -1620 -508"
+"classname" "path_corner"
+}
+{
+"wait" ".5"
+"origin" "-688 -1652 -812"
+"target" "t73"
+"targetname" "t72"
+"classname" "path_corner"
+}
+{
+"wait" ".5"
+"origin" "-688 -1652 -644"
+"target" "t72"
+"targetname" "t73"
+"classname" "path_corner"
+}
+{
+"model" "*48"
+"dmg" "15"
+"spawnflags" "4"
+"targetname" "t33"
+"speed" "150"
+"target" "t72"
+"classname" "func_train"
+}
+{
+"_color" "1.000000 0.976471 0.023529"
+"light" "64"
+"classname" "light"
+"origin" "-2216 -96 -1120"
+}
+{
+"_color" "1.000000 0.976471 0.023529"
+"light" "64"
+"classname" "light"
+"origin" "-2216 32 -1120"
+}
+{
+"_color" "0.087379 1.000000 0.043689"
+"light" "64"
+"classname" "light"
+"origin" "-2224 32 -1120"
+}
+{
+"spawnflags" "0"
+"origin" "-2332 -560 -944"
+"classname" "misc_explobox"
+"mass" "80"
+"health" "25"
+"dmg" "40"
+}
+{
+"spawnflags" "2048"
+"origin" "-1928 -776 -944"
+"dmg" "40"
+"health" "25"
+"mass" "80"
+"classname" "misc_explobox"
+}
+{
+"_color" "1.000000 0.976471 0.023529"
+"light" "64"
+"classname" "light"
+"origin" "-2540 -688 -952"
+}
+{
+"_color" "1.000000 0.976471 0.023529"
+"light" "64"
+"classname" "light"
+"origin" "-2540 -544 -952"
+}
+{
+"_color" "0.087379 1.000000 0.043689"
+"light" "64"
+"classname" "light"
+"origin" "-2548 -544 -952"
+}
+{
+"origin" "-2548 -688 -952"
+"_color" "0.087379 1.000000 0.043689"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-2548 -824 -952"
+"_color" "0.087379 1.000000 0.043689"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-2224 -96 -1120"
+"_color" "0.087379 1.000000 0.043689"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-2540 -824 -952"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.976471 0.023529"
+}
+{
+"origin" "-2216 -224 -1120"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.976471 0.023529"
+}
+{
+"origin" "-2224 -224 -1120"
+"_color" "0.087379 1.000000 0.043689"
+"light" "64"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.972549 0.043137"
+"classname" "light"
+"light" "150"
+"origin" "-404 864 276"
+}
+{
+"_color" "1.000000 0.972549 0.043137"
+"classname" "light"
+"light" "150"
+"origin" "-80 1128 276"
+}
+{
+"_color" "1.000000 0.972549 0.043137"
+"classname" "light"
+"light" "150"
+"origin" "-80 848 276"
+}
+{
+"classname" "light"
+"light" "160"
+"origin" "36 732 120"
+}
+{
+"model" "*49"
+"target" "t71"
+"classname" "trigger_multiple"
+"angle" "360"
+}
+{
+"origin" "-376 592 -416"
+"targetname" "t71"
+"map" "power2$cool1a"
+"classname" "target_changelevel"
+}
+{
+"model" "*50"
+"target" "t70"
+"classname" "trigger_multiple"
+"angle" "270"
+}
+{
+"origin" "-1432 -1672 80"
+"targetname" "t70"
+"map" "power2$cool1"
+"classname" "target_changelevel"
+}
+{
+"spawnflags" "2048"
+"classname" "misc_explobox"
+"origin" "-1768 -240 -416"
+}
+{
+"spawnflags" "2048"
+"classname" "misc_explobox"
+"origin" "-1800 -168 -416"
+}
+{
+"spawnflags" "2048"
+"classname" "misc_explobox"
+"origin" "-1824 -320 -416"
+}
+{
+"origin" "-1176 -1728 -728"
+"target" "t61"
+"targetname" "t60"
+"classname" "path_corner"
+}
+{
+"origin" "-1176 -1728 -728"
+"target" "t59"
+"targetname" "t58"
+"classname" "path_corner"
+}
+{
+"origin" "-1176 -1864 -728"
+"target" "t60"
+"targetname" "t59"
+"classname" "path_corner"
+}
+{
+"origin" "-1392 -1728 -728"
+"targetname" "t61"
+"target" "t58"
+"classname" "path_corner"
+}
+{
+"origin" "-1032 -1992 -712"
+"target" "t57"
+"classname" "monster_gunner"
+"spawnflags" "1"
+}
+{
+"origin" "-944 -1984 -728"
+"target" "t57"
+"targetname" "t56"
+"classname" "path_corner"
+}
+{
+"origin" "-1176 -1992 -728"
+"targetname" "t57"
+"target" "t56"
+"classname" "path_corner"
+}
+{
+"origin" "320 -160 24"
+"classname" "monster_gunner"
+"spawnflags" "1"
+"target" "t127"
+"angle" "180"
+"item" "ammo_bullets"
+}
+{
+"origin" "320 -296 24"
+"target" "t52"
+"classname" "monster_gladiator"
+"spawnflags" "1"
+}
+{
+"origin" "-400 -328 8"
+"targetname" "t53"
+"target" "t52"
+"classname" "path_corner"
+}
+{
+"origin" "256 -328 8"
+"target" "t53"
+"targetname" "t52"
+"classname" "path_corner"
+}
+{
+"targetname" "t96"
+"origin" "-24 936 -144"
+"classname" "monster_gunner"
+"angle" "270"
+"spawnflags" "1"
+"target" "t82"
+}
+{
+"spawnflags" "1"
+"deathtarget" "ho1"
+"item" "ammo_slugs"
+"origin" "-440 1192 -136"
+"target" "t48"
+"classname" "monster_gladiator"
+}
+{
+"origin" "-528 1144 -152"
+"classname" "path_corner"
+"targetname" "t92"
+"target" "t93"
+}
+{
+"origin" "-384 932 -152"
+"classname" "path_corner"
+"targetname" "t94"
+"target" "t91"
+}
+{
+"origin" "-384 1144 -152"
+"classname" "path_corner"
+"targetname" "t91"
+"target" "t92"
+}
+{
+"origin" "-384 1208 -152"
+"classname" "path_corner"
+"target" "t91"
+"targetname" "t48"
+}
+{
+"origin" "-536 840 -152"
+"classname" "path_corner"
+"targetname" "t93"
+"target" "t94"
+}
+{
+"origin" "-1648 -456 -288"
+"angle" "90"
+"classname" "monster_gunner"
+"target" "t138"
+"spawnflags" "1"
+"targetname" "t148"
+"item" "ammo_bullets"
+}
+{
+"origin" "-1264 -24 -384"
+"target" "t38"
+"classname" "monster_gladiator"
+"spawnflags" "1"
+}
+{
+"origin" "-1168 -40 -400"
+"target" "t38"
+"targetname" "t37"
+"classname" "path_corner"
+}
+{
+"origin" "-1652 -40 -400"
+"targetname" "t38"
+"target" "t37"
+"classname" "path_corner"
+}
+{
+"model" "*51"
+"spawnflags" "2048"
+"target" "t36"
+"targetname" "t35"
+"classname" "trigger_counter"
+}
+{
+"model" "*52"
+"targetname" "t1"
+"target" "t35"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"model" "*53"
+"targetname" "t33"
+"target" "t35"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"model" "*54"
+"lip" "-128"
+"classname" "func_water"
+"spawnflags" "0"
+"targetname" "t1"
+"angle" "-2"
+}
+{
+"model" "*55"
+"targetname" "t36"
+"classname" "func_water"
+"spawnflags" "2048"
+"angle" "-2"
+}
+{
+"origin" "-448 -1388 -624"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-448 -1296 -624"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-448 -1340 -572"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1544 -64 -552"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-1168 -256 -496"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-1344 -208 -496"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-1440 -432 -240"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2056 -168 -206"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1444 -528 -176"
+"light" "120"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-1384 -1336 -684"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1384 -1336 -824"
+}
+{
+"origin" "-1384 -1336 -1216"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1384 -1336 -1048"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1384 -1336 -912"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1076 -1000 -684"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "-1076 -1000 -1048"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1076 -1000 -912"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1076 -1000 -824"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1076 -1000 -1216"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1384 -1520 -664"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-1440 -1688 80"
+}
+{
+"model" "*56"
+"angle" "270"
+"classname" "func_door"
+"sounds" "4"
+"speed" "70"
+"team" "cl1"
+}
+{
+"model" "*57"
+"angle" "90"
+"classname" "func_door"
+"sounds" "4"
+"team" "cl1"
+}
+{
+"model" "*58"
+"classname" "func_plat"
+}
+{
+"light" "150"
+"origin" "-168 -1344 -192"
+"classname" "light"
+}
+{
+"target" "t26"
+"targetname" "t25"
+"origin" "-1464 -1366 -1336"
+"classname" "path_corner"
+}
+{
+"target" "t27"
+"targetname" "t26"
+"origin" "-1464 -1366 -776"
+"classname" "path_corner"
+}
+{
+"target" "t28"
+"targetname" "t27"
+"origin" "-1464 -1488 -776"
+"classname" "path_corner"
+}
+{
+"target" "t25"
+"targetname" "t28"
+"origin" "-1464 -1488 -1336"
+"classname" "path_corner"
+}
+{
+"classname" "light"
+"light" "250"
+"origin" "-676 812 -88"
+}
+{
+"light" "250"
+"classname" "light"
+"origin" "-520 768 -88"
+}
+{
+"origin" "-368 848 276"
+"light" "150"
+"classname" "light"
+"_color" "1.000000 0.972549 0.043137"
+}
+{
+"origin" "36 1244 120"
+"classname" "light"
+"light" "160"
+}
+{
+"origin" "-620 988 176"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-484 732 120"
+"classname" "light"
+"light" "160"
+}
+{
+"origin" "-484 1244 120"
+"classname" "light"
+"light" "160"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-564 988 216"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1444 -704 -176"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1448 -936 -40"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1444 -936 -176"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1444 -808 -176"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1344 -56 -552"
+}
+{
+"origin" "-1448 -936 152"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1448 -936 296"
+"classname" "light"
+"light" "100"
+}
+{
+"classname" "path_corner"
+"origin" "-1008 -1080 -1336"
+"target" "t29"
+"targetname" "t32"
+}
+{
+"classname" "path_corner"
+"origin" "-1008 -1080 -776"
+"targetname" "t31"
+"target" "t32"
+}
+{
+"classname" "path_corner"
+"origin" "-1130 -1080 -776"
+"targetname" "t30"
+"target" "t31"
+}
+{
+"classname" "path_corner"
+"origin" "-1130 -1080 -1336"
+"targetname" "t29"
+"target" "t30"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1728 -280 -496"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-1560 -208 -496"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-224 1252 -116"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "28 880 -144"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-220 928 -116"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-220 752 -116"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-220 576 -116"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-220 440 -48"
+}
+{
+"origin" "-220 272 12"
+"classname" "light"
+"light" "140"
+}
+{
+"model" "*59"
+"_minlight" ".18"
+"sounds" "4"
+"classname" "func_door"
+"angle" "-1"
+"target" "t109"
+"spawnflags" "0"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1060 -2168 -816"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-248 -1304 -700"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-248 -1380 -700"
+}
+{
+"origin" "-496 604 -356"
+"classname" "light"
+"light" "120"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-368 604 -356"
+}
+{
+"model" "*60"
+"angle" "0"
+"classname" "func_door"
+"team" "td1"
+"_minlight" ".18"
+}
+{
+"origin" "-1448 -1520 24"
+"angle" "90"
+"classname" "info_player_start"
+"targetname" "cool1b"
+}
+{
+"model" "*61"
+"spawnflags" "2048"
+"_minlight" ".18"
+"targetname" "t36"
+"classname" "func_door"
+"angle" "270"
+"wait" "-1"
+"sounds" "4"
+}
+{
+"model" "*62"
+"spawnflags" "2048"
+"_minlight" ".18"
+"targetname" "t36"
+"classname" "func_door"
+"angle" "90"
+"wait" "-1"
+"sounds" "4"
+}
+{
+"classname" "info_player_start"
+"angle" "180"
+"targetname" "power2a"
+"origin" "-516 600 -480"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-320 604 -412"
+}
+{
+"origin" "-608 604 -412"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-552 604 -412"
+"light" "100"
+"classname" "light"
+}

--- a/stuff/mapfixes/baseq2/lab.ent
+++ b/stuff/mapfixes/baseq2/lab.ent
@@ -1,0 +1,9324 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Removed inaccessible monster_medic (1781) from Easy
+//
+// A trigger_once that releases this guy into the level only spawns
+// on Medium and above and unleashes this guy on the player after
+// activating the bridge. I set his spawnflags from 0 to 256 so that
+// he doesn't spawn on Easy.
+//
+// 2. Removed 2x inaccessible monster_parasite (1443, 1449) from Easy/Medium
+//
+// These guys fall from the ceiling by the 3 Brains past the medic.
+// The trigger_once that drops them down only spawns on Hard/Nightmare so
+// I set both guys to spawnflags 768.
+{
+"message" "Research Lab"
+"classname" "worldspawn"
+"sounds" "6"
+"angle" "90"
+"nextmap" "command"
+}
+{
+"classname" "point_combat"
+"targetname" "t383"
+"origin" "-456 -216 0"
+}
+{
+"classname" "point_combat"
+"targetname" "t382"
+"target" "t383"
+"origin" "-424 -216 0"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-1624 636 8"
+}
+{
+"classname" "item_health"
+"spawnflags" "2048"
+"origin" "-1660 636 8"
+}
+{
+"model" "*1"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-936 832 -400"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-936 736 -400"
+}
+{
+"origin" "-2096 -128 -400"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-2000 -128 -400"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-936 832 48"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-936 736 48"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-2000 -128 48"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2096 -128 48"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1644 1632 -412"
+"target" "makeitstop2"
+"targetname" "killmenow"
+"delay" "2"
+"classname" "trigger_relay"
+}
+{
+"model" "*2"
+"targetname" "makeitstop"
+"spawnflags" "4"
+"classname" "trigger_once"
+}
+{
+"model" "*3"
+"spawnflags" "1"
+"mass" "100"
+"targetname" "makeitstop2"
+"classname" "func_explosive"
+}
+{
+"origin" "-1656 1608 -412"
+"target" "makeitstop"
+"delay" "1"
+"targetname" "killmenow"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1676 1632 -412"
+"killtarget" "dead"
+"targetname" "killmenow"
+"classname" "trigger_relay"
+}
+{
+"model" "*4"
+"targetname" "dead"
+"classname" "func_wall"
+}
+{
+"model" "*5"
+"message" "A.H.D.S.S.I.B.H.\nbjjc"
+"classname" "trigger_once"
+}
+{
+"targetname" "t190"
+"classname" "target_speaker"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"origin" "-320 1216 72"
+}
+{
+"targetname" "t190"
+"classname" "target_speaker"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"origin" "-320 976 72"
+}
+{
+"targetname" "t190"
+"classname" "target_speaker"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"origin" "-368 776 72"
+}
+{
+"targetname" "t190"
+"classname" "target_speaker"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"origin" "-640 760 72"
+}
+{
+"targetname" "t190"
+"classname" "target_speaker"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"origin" "-640 464 72"
+}
+{
+"targetname" "t190"
+"classname" "target_speaker"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"origin" "-640 256 72"
+}
+{
+"classname" "point_combat"
+"targetname" "t379"
+"origin" "-2848 888 -424"
+}
+{
+"model" "*6"
+"target" "t339"
+"pathtarget" "e1"
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+}
+{
+"model" "*7"
+"target" "t341"
+"pathtarget" "e4"
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+}
+{
+"origin" "-1604 1120 -416"
+"target" "t378"
+"targetname" "t343"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"model" "*8"
+"targetname" "t378"
+"spawnflags" "2051"
+"classname" "func_wall"
+}
+{
+"model" "*9"
+"_minlight" ".2"
+"wait" "-1"
+"targetname" "t375"
+"lip" "-80"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*10"
+"targetname" "t296"
+"wait" "-1"
+"_minlight" ".2"
+"speed" "120"
+"lip" "-126"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"origin" "-1528 1632 -400"
+"spawnflags" "2048"
+"targetname" "t32"
+"classname" "target_goal"
+}
+{
+"origin" "-1776 248 8"
+"targetname" "t259"
+"classname" "target_goal"
+}
+{
+"model" "*11"
+"classname" "func_button"
+"wait" "-1"
+"angle" "90"
+"target" "t229"
+"_minlight" ".3"
+}
+{
+"model" "*12"
+"classname" "func_button"
+"angle" "90"
+"_minlight" ".3"
+"target" "t228"
+"wait" "-1"
+"spawnflags" "2048"
+}
+{
+"origin" "-1440 -608 48"
+"targetname" "t373"
+"noise" "world/brkglas.wav"
+"classname" "target_speaker"
+}
+{
+"model" "*13"
+"target" "t373"
+"targetname" "t328"
+"mass" "150"
+"classname" "func_explosive"
+}
+{
+"classname" "info_player_coop"
+"angle" "90"
+"origin" "92 436 16"
+}
+{
+"classname" "info_player_coop"
+"angle" "90"
+"origin" "36 436 16"
+}
+{
+"origin" "64 368 16"
+"angle" "90"
+"classname" "info_player_coop"
+}
+{
+"origin" "-2092 144 8"
+"spawnflags" "1536"
+"classname" "ammo_slugs"
+}
+{
+"origin" "-824 1284 -472"
+"spawnflags" "2048"
+"classname" "ammo_shells"
+}
+{
+"model" "*14"
+"classname" "trigger_counter"
+"count" "20"
+"spawnflags" "1"
+"targetname" "marduk"
+"target" "killmenow"
+}
+{
+"classname" "path_corner"
+"targetname" "t371"
+"target" "t372"
+"origin" "-140 464 8"
+}
+{
+"classname" "path_corner"
+"targetname" "t370"
+"target" "t371"
+"origin" "-140 636 8"
+}
+{
+"classname" "path_corner"
+"targetname" "t369"
+"target" "t370"
+"origin" "-112 632 8"
+}
+{
+"classname" "path_corner"
+"targetname" "t368"
+"target" "t369"
+"origin" "-112 432 8"
+}
+{
+"classname" "path_corner"
+"targetname" "t367"
+"target" "t368"
+"origin" "-272 432 8"
+}
+{
+"classname" "path_corner"
+"targetname" "t366"
+"target" "t367"
+"origin" "-324 376 8"
+}
+{
+"classname" "path_corner"
+"targetname" "t365"
+"target" "t366"
+"origin" "-324 508 8"
+}
+{
+"classname" "path_corner"
+"targetname" "t372"
+"target" "t365"
+"origin" "-276 464 8"
+}
+{
+"classname" "misc_insane"
+"spawnflags" "4"
+"target" "t365"
+"origin" "-308 520 24"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "4"
+"angle" "135"
+"origin" "-428 492 16"
+}
+{
+"classname" "misc_insane"
+"angle" "360"
+"spawnflags" "48"
+"origin" "-412 424 40"
+}
+{
+"_color" "1.000000 0.027451 0.027451"
+"light" "96"
+"classname" "light"
+"origin" "-416 488 120"
+}
+{
+"classname" "light"
+"light" "96"
+"_color" "1.000000 0.027451 0.027451"
+"origin" "-416 408 120"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_large"
+"origin" "-466 1784 -456"
+}
+{
+"classname" "item_health_large"
+"spawnflags" "2048"
+"origin" "-430 1784 -456"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_cells"
+"origin" "-732 1768 -456"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "2048"
+"origin" "-732 1732 -456"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2792 1164 -384"
+}
+{
+"origin" "-2792 1224 -384"
+"classname" "light"
+"light" "140"
+}
+{
+"origin" "-2792 1292 -384"
+"classname" "light"
+"light" "140"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2792 1292 -332"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2792 1224 -332"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_bullets"
+"origin" "-1388 192 8"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+"origin" "-1388 156 8"
+}
+{
+"classname" "ammo_shells"
+"origin" "-800 128 8"
+}
+{
+"classname" "ammo_grenades"
+"origin" "-760 128 8"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "76 -404 48"
+}
+{
+"classname" "item_health"
+"spawnflags" "3072"
+"origin" "40 -404 48"
+}
+{
+"origin" "-1696 1896 -416"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1696 1928 -392"
+"classname" "light"
+"light" "150"
+}
+{
+"model" "*15"
+"classname" "func_wall"
+"spawnflags" "2051"
+"targetname" "t267"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+"origin" "-536 976 -336"
+}
+{
+"model" "*16"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*17"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "-1548 400 -104"
+"classname" "ammo_shells"
+"spawnflags" "1792"
+}
+{
+"origin" "-1548 360 -104"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-1218 -780 24"
+"angles" "0 135 0"
+"classname" "info_player_intermission"
+}
+{
+"origin" "-952 1512 -488"
+"classname" "ammo_bullets"
+"spawnflags" "1536"
+}
+{
+"origin" "-952 1548 -488"
+"spawnflags" "1536"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-732 1772 -456"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "-732 1732 -456"
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+}
+{
+"origin" "-1300 1036 -488"
+"classname" "item_health"
+"spawnflags" "1792"
+}
+{
+"origin" "-780 1036 -488"
+"spawnflags" "1792"
+"classname" "item_health"
+}
+{
+"origin" "-1696 1916 -456"
+"classname" "ammo_cells"
+"spawnflags" "1792"
+}
+{
+"origin" "-1440 1908 -456"
+"spawnflags" "1792"
+"classname" "ammo_cells"
+}
+{
+"origin" "-1568 1620 -460"
+"spawnflags" "1792"
+"classname" "weapon_grenadelauncher"
+}
+{
+"origin" "-2080 1904 -432"
+"classname" "ammo_slugs"
+"spawnflags" "1792"
+}
+{
+"origin" "-2040 1904 -432"
+"spawnflags" "1792"
+"classname" "ammo_slugs"
+}
+{
+"origin" "-3240 1360 -328"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "-3240 1276 -328"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "-3240 1188 -328"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "-3240 1092 -328"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "-1816 628 8"
+}
+{
+"origin" "-1816 592 8"
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-2008 484 72"
+"spawnflags" "1792"
+"classname" "weapon_bfg"
+}
+{
+"origin" "-2000 524 84"
+"target" "t364"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"origin" "-1924 516 100"
+"target" "t364"
+"targetname" "t190"
+"classname" "trigger_relay"
+}
+{
+"model" "*18"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "-872 784 16"
+"target" "t363"
+"spawnflags" "1792"
+"angle" "180"
+"classname" "misc_teleporter"
+}
+{
+"origin" "-872 784 -444"
+"targetname" "t363"
+"spawnflags" "1792"
+"angle" "360"
+"classname" "misc_teleporter_dest"
+}
+{
+"origin" "-1612 792 16"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-1648 792 16"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-1716 956 -456"
+"classname" "item_health"
+"spawnflags" "1792"
+}
+{
+"origin" "-1716 920 -456"
+"spawnflags" "1792"
+"classname" "item_health"
+}
+{
+"origin" "-2312 716 -440"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "-2312 612 -440"
+"spawnflags" "1792"
+"classname" "item_health_small"
+}
+{
+"origin" "-3152 1328 -416"
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+}
+{
+"origin" "-3152 1288 -416"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-3044 1212 -420"
+"spawnflags" "1792"
+"classname" "item_armor_combat"
+}
+{
+"origin" "-2792 1164 -416"
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+}
+{
+"origin" "-2828 1164 -416"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-2988 852 -416"
+"classname" "item_health"
+"spawnflags" "1792"
+}
+{
+"origin" "-2988 892 -416"
+"spawnflags" "1792"
+"classname" "item_health"
+}
+{
+"origin" "-2700 912 -416"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "-2740 912 -416"
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+}
+{
+"origin" "-2084 260 8"
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "-1496 336 -96"
+"team" "doh1"
+"spawnflags" "1792"
+"classname" "item_health_mega"
+}
+{
+"origin" "-1496 336 -96"
+"team" "doh1"
+"spawnflags" "1792"
+"classname" "weapon_railgun"
+}
+{
+"origin" "-1214 360 20"
+"classname" "item_health_small"
+"spawnflags" "1792"
+}
+{
+"origin" "-1090 360 20"
+"spawnflags" "1792"
+"classname" "item_health_small"
+}
+{
+"origin" "-1344 -428 40"
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+}
+{
+"origin" "-1000 -492 8"
+"spawnflags" "1792"
+"classname" "item_health_small"
+}
+{
+"origin" "-1000 -536 8"
+"spawnflags" "1792"
+"classname" "item_health_small"
+}
+{
+"origin" "-1000 -448 8"
+"spawnflags" "1792"
+"classname" "item_health_small"
+}
+{
+"origin" "-384 -480 40"
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "-384 -544 48"
+"classname" "item_health"
+}
+{
+"origin" "0 -480 40"
+"spawnflags" "1792"
+"classname" "item_armor_combat"
+}
+{
+"origin" "64 -88 40"
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+}
+{
+"origin" "24 -88 40"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-668 44 8"
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+}
+{
+"origin" "-612 44 8"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-640 84 8"
+"spawnflags" "1792"
+"classname" "weapon_chaingun"
+}
+{
+"model" "*19"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "-320 1372 40"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "-356 1372 40"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "-284 1372 40"
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-128 780 8"
+"spawnflags" "1792"
+"team" "doh"
+"classname" "item_quad"
+}
+{
+"origin" "-128 780 8"
+"team" "doh"
+"spawnflags" "1792"
+"classname" "weapon_railgun"
+}
+{
+"origin" "272 840 -24"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "224 828 -24"
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+}
+{
+"model" "*20"
+"_minlight" ".2"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"angle" "90"
+"targetname" "t362"
+"origin" "64 672 16"
+"classname" "misc_teleporter_dest"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "1792"
+"targetname" "t361"
+"origin" "-1448 -432 48"
+"angle" "315"
+"classname" "misc_teleporter_dest"
+}
+{
+"angle" "90"
+"origin" "-448 1760 -448"
+"target" "t359"
+"classname" "misc_teleporter"
+"spawnflags" "1792"
+}
+{
+"origin" "-928 88 16"
+"target" "t243"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"spawnflags" "1792"
+"origin" "-656 480 64"
+"target" "t256"
+"classname" "trigger_always"
+}
+{
+"origin" "-640 104 64"
+"target" "t240"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"origin" "64 1104 24"
+"target" "t255"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1760 424 140"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1760 552 140"
+}
+{
+"classname" "trigger_always"
+"spawnflags" "1792"
+"target" "t211"
+"origin" "-976 -656 48"
+}
+{
+"spawnflags" "1792"
+"target" "t362"
+"classname" "misc_teleporter"
+"origin" "-1248 256 -96"
+}
+{
+"spawnflags" "1792"
+"targetname" "t360"
+"classname" "misc_teleporter_dest"
+"angle" "90"
+"origin" "-1792 184 -96"
+}
+{
+"spawnflags" "1792"
+"target" "t358"
+"classname" "misc_teleporter"
+"origin" "-1696 1392 -440"
+}
+{
+"spawnflags" "1792"
+"targetname" "t359"
+"classname" "misc_teleporter_dest"
+"angle" "90"
+"origin" "-3240 992 -320"
+}
+{
+"spawnflags" "1792"
+"target" "t360"
+"classname" "misc_teleporter"
+"origin" "-2656 1416 -320"
+}
+{
+"angle" "315"
+"classname" "info_player_deathmatch"
+"origin" "-920 1696 -448"
+}
+{
+"target" "t375"
+"classname" "trigger_always"
+"spawnflags" "1792"
+"origin" "-3032 1166 -400"
+}
+{
+"angle" "270"
+"classname" "info_player_deathmatch"
+"origin" "-1216 1736 -480"
+}
+{
+"angle" "180"
+"classname" "info_player_deathmatch"
+"origin" "-2800 1304 -408"
+}
+{
+"angle" "90"
+"classname" "info_player_deathmatch"
+"origin" "-2840 736 -408"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "-2712 536 -408"
+}
+{
+"classname" "info_player_deathmatch"
+"origin" "-1624 600 16"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"origin" "-1320 -808 16"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"origin" "-544 -480 48"
+}
+{
+"spawnflags" "1792"
+"classname" "trigger_always"
+"target" "t292"
+"origin" "16 -144 72"
+}
+{
+"classname" "trigger_always"
+"spawnflags" "1792"
+"target" "t296"
+"origin" "-544 -480 72"
+}
+{
+"angle" "270"
+"classname" "info_player_deathmatch"
+"origin" "-168 96 16"
+}
+{
+"targetname" "t358"
+"classname" "misc_teleporter_dest"
+"angle" "90"
+"spawnflags" "1792"
+"origin" "-128 656 16"
+}
+{
+"target" "t361"
+"classname" "misc_teleporter"
+"spawnflags" "1792"
+"origin" "-128 912 16"
+}
+{
+"angle" "180"
+"classname" "info_player_deathmatch"
+"origin" "352 784 -16"
+}
+{
+"origin" "-2968 1408 -320"
+"target" "t354"
+"classname" "misc_insane"
+"spawnflags" "4"
+"angle" "90"
+}
+{
+"origin" "-3116 1408 -320"
+"target" "t353"
+"classname" "misc_insane"
+"spawnflags" "4"
+"angle" "90"
+}
+{
+"origin" "-3236 1352 -320"
+"target" "t352"
+"classname" "misc_insane"
+"spawnflags" "4"
+"angle" "90"
+}
+{
+"origin" "-3236 1240 -320"
+"target" "t351"
+"classname" "misc_insane"
+"spawnflags" "4"
+"angle" "90"
+}
+{
+"origin" "-3236 1076 -320"
+"target" "t350"
+"classname" "misc_insane"
+"spawnflags" "4"
+"angle" "90"
+}
+{
+"origin" "-2800 1408 -320"
+"target" "t355"
+"angle" "90"
+"spawnflags" "4"
+"classname" "misc_insane"
+}
+{
+"origin" "-2752 1408 -336"
+"target" "t356"
+"targetname" "t355"
+"classname" "path_corner"
+"spawnflags" "0"
+}
+{
+"origin" "-2908 1408 -336"
+"target" "t355"
+"targetname" "t354"
+"classname" "path_corner"
+"spawnflags" "0"
+}
+{
+"origin" "-3072 1408 -336"
+"target" "t354"
+"targetname" "t353"
+"classname" "path_corner"
+"spawnflags" "0"
+}
+{
+"origin" "-3236 1408 -336"
+"target" "t353"
+"targetname" "t352"
+"classname" "path_corner"
+"spawnflags" "0"
+}
+{
+"origin" "-3236 1280 -336"
+"target" "t352"
+"targetname" "t351"
+"classname" "path_corner"
+"spawnflags" "0"
+}
+{
+"origin" "-3236 1152 -336"
+"target" "t351"
+"targetname" "t350"
+"classname" "path_corner"
+"spawnflags" "0"
+}
+{
+"targetname" "t357"
+"spawnflags" "1"
+"origin" "-3236 988 -336"
+"target" "t350"
+"classname" "path_corner"
+}
+{
+"target" "t357"
+"origin" "-2648 1408 -336"
+"targetname" "t356"
+"spawnflags" "0"
+"classname" "path_corner"
+}
+{
+"origin" "-2848 1408 -300"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.012658 0.012658"
+}
+{
+"origin" "-2976 1408 -300"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.012658 0.012658"
+}
+{
+"origin" "-3104 1408 -300"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.012658 0.012658"
+}
+{
+"origin" "-3236 1408 -300"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.012658 0.012658"
+}
+{
+"origin" "-3236 1280 -300"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.012658 0.012658"
+}
+{
+"origin" "-3236 1152 -300"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.012658 0.012658"
+}
+{
+"origin" "-3236 1020 -300"
+"classname" "light"
+"light" "200"
+"_color" "1.000000 0.012658 0.012658"
+}
+{
+"origin" "-2720 1408 -300"
+"_color" "1.000000 0.012658 0.012658"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-3048 992 -408"
+"classname" "monster_parasite"
+"angle" "360"
+}
+{
+"origin" "-2864 1008 -408"
+"angle" "270"
+"classname" "monster_parasite"
+}
+{
+"origin" "-636 672 -8"
+"dmg" "40"
+"targetname" "t258"
+"classname" "target_explosion"
+}
+{
+"origin" "-640 352 8"
+"dmg" "40"
+"targetname" "t257"
+"classname" "target_explosion"
+}
+{
+"classname" "point_combat"
+"targetname" "t348"
+"origin" "-156 1352 8"
+}
+{
+"classname" "point_combat"
+"targetname" "t347"
+"origin" "-200 1352 8"
+}
+{
+"classname" "point_combat"
+"targetname" "t349"
+"origin" "-112 1352 8"
+}
+{
+"classname" "point_combat"
+"targetname" "t345"
+"origin" "36 936 0"
+}
+{
+"classname" "point_combat"
+"targetname" "t346"
+"origin" "92 936 0"
+}
+{
+"model" "*21"
+"wait" "2"
+"classname" "func_button"
+"angle" "360"
+"target" "t343"
+"pathtarget" "e6"
+}
+{
+"model" "*22"
+"wait" "2"
+"classname" "func_button"
+"angle" "180"
+"target" "t343"
+"pathtarget" "e5"
+}
+{
+"model" "*23"
+"spawnflags" "2048"
+"classname" "func_button"
+"angle" "270"
+"target" "t341"
+"pathtarget" "e4"
+}
+{
+"model" "*24"
+"spawnflags" "2048"
+"classname" "func_button"
+"angle" "90"
+"target" "t341"
+"pathtarget" "e3"
+}
+{
+"model" "*25"
+"classname" "func_button"
+"target" "t339"
+"pathtarget" "e1"
+"angle" "360"
+}
+{
+"model" "*26"
+"classname" "func_button"
+"angle" "180"
+"target" "t339"
+"pathtarget" "e2"
+}
+{
+"model" "*27"
+"speed" "150"
+"classname" "func_train"
+"targetname" "t344"
+"target" "e5"
+}
+{
+"wait" "-1"
+"origin" "-956 704 -480"
+"classname" "path_corner"
+"targetname" "e4"
+}
+{
+"wait" "-1"
+"origin" "-956 704 -32"
+"classname" "path_corner"
+"targetname" "e3"
+}
+{
+"spawnflags" "2048"
+"origin" "-868 780 -432"
+"classname" "trigger_elevator"
+"targetname" "t341"
+"target" "t342"
+}
+{
+"model" "*28"
+"spawnflags" "2048"
+"speed" "150"
+"classname" "func_train"
+"targetname" "t342"
+"target" "e4"
+}
+{
+"wait" "-1"
+"origin" "-2128 -140 -480"
+"classname" "path_corner"
+"targetname" "e1"
+}
+{
+"origin" "-2044 -52 -432"
+"classname" "trigger_elevator"
+"targetname" "t339"
+"target" "t340"
+}
+{
+"wait" "-1"
+"origin" "-2128 -140 -32"
+"classname" "path_corner"
+"targetname" "e2"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-2048 144 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-2004 224 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1904 224 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1820 224 24"
+}
+{
+"classname" "path_corner"
+"origin" "-1744 1048 -480"
+"wait" "-1"
+"targetname" "e5"
+}
+{
+"classname" "path_corner"
+"origin" "-1744 1048 -32"
+"wait" "-1"
+"targetname" "e6"
+}
+{
+"classname" "trigger_elevator"
+"origin" "-1668 1124 -432"
+"targetname" "t343"
+"target" "t344"
+}
+{
+"model" "*29"
+"classname" "func_train"
+"speed" "150"
+"targetname" "t340"
+"target" "e2"
+}
+{
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"classname" "target_speaker"
+"targetname" "t190"
+"origin" "-2352 344 -404"
+}
+{
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"classname" "target_speaker"
+"targetname" "t190"
+"origin" "-2412 668 -404"
+}
+{
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"classname" "target_speaker"
+"targetname" "t190"
+"origin" "-1924 660 -404"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"targetname" "t190"
+"origin" "-2408 1100 -404"
+}
+{
+"classname" "point_combat"
+"spawnflags" "1"
+"targetname" "t338"
+"origin" "128 824 16"
+}
+{
+"classname" "monster_chick"
+"angle" "90"
+"target" "t338"
+"spawnflags" "2"
+"targetname" "t190"
+"origin" "128 768 32"
+}
+{
+"classname" "point_combat"
+"spawnflags" "1"
+"targetname" "t337"
+"origin" "20 692 16"
+}
+{
+"classname" "monster_chick"
+"angle" "90"
+"target" "t337"
+"spawnflags" "2"
+"targetname" "t190"
+"origin" "20 644 32"
+}
+{
+"classname" "point_combat"
+"targetname" "t336"
+"origin" "-640 212 4"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t198"
+"origin" "-1928 560 24"
+}
+{
+"classname" "trigger_relay"
+"target" "t190"
+"targetname" "t198"
+"origin" "-1924 536 100"
+}
+{
+"model" "*30"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t198"
+}
+{
+"classname" "path_corner"
+"targetname" "t334"
+"target" "t335"
+"origin" "-2428 468 -436"
+}
+{
+"classname" "path_corner"
+"target" "t333"
+"targetname" "t335"
+"origin" "-2404 656 -436"
+}
+{
+"classname" "path_corner"
+"targetname" "t333"
+"target" "t334"
+"origin" "-2436 836 -436"
+}
+{
+"classname" "target_explosion"
+"targetname" "t332"
+"origin" "-2428 616 -340"
+}
+{
+"model" "*31"
+"spawnflags" "768"
+"classname" "trigger_once"
+"target" "t331"
+}
+{
+"model" "*32"
+"classname" "func_explosive"
+"targetname" "t331"
+"target" "t332"
+}
+{
+"angle" "90"
+"origin" "-2408 536 -272"
+"classname" "monster_parasite"
+"spawnflags" "768"
+}
+{
+"classname" "monster_parasite"
+"spawnflags" "768"
+"origin" "-2408 588 -272"
+"angle" "90"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-832 1560 -456"
+}
+{
+"origin" "-832 1688 -410"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*33"
+"targetname" "t308"
+"classname" "func_explosive"
+"mass" "100"
+}
+{
+"classname" "func_group"
+}
+{
+"model" "*34"
+"classname" "func_wall"
+"spawnflags" "16"
+"_minlight" ".18"
+}
+{
+"model" "*35"
+"classname" "func_wall"
+"spawnflags" "16"
+"_minlight" ".18"
+}
+{
+"model" "*36"
+"spawnflags" "2048"
+"_minlight" ".18"
+"lip" "16"
+"wait" "-1"
+"angle" "90"
+"classname" "func_button"
+"target" "t42"
+}
+{
+"classname" "light"
+"light" "160"
+"origin" "-528 -480 -96"
+}
+{
+"classname" "path_corner"
+"targetname" "t324"
+"target" "t330"
+"origin" "-1788 176 -112"
+"spawnflags" "1"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "trigger_relay"
+"delay" "1.5"
+"targetname" "t328"
+"target" "t329"
+"origin" "-1424 -684 116"
+}
+{
+"classname" "light"
+"light" "170"
+"origin" "-1440 -608 -20"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-1224 -428 88"
+}
+{
+"model" "*37"
+"classname" "func_door"
+"angle" "-1"
+"wait" "-1"
+"speed" "50"
+"targetname" "t329"
+"_minlight" ".18"
+}
+{
+"model" "*38"
+"classname" "func_button"
+"angle" "360"
+"wait" "-1"
+"lip" "16"
+"_minlight" ".18"
+"spawnflags" "2048"
+"target" "t58"
+}
+{
+"model" "*39"
+"classname" "func_wall"
+"spawnflags" "16"
+}
+{
+"origin" "-1500 384 -64"
+"_color" "1.000000 0.015686 0.015686"
+"light" "160"
+"classname" "light"
+}
+{
+"origin" "-1332 384 -64"
+"_color" "1.000000 0.015686 0.015686"
+"light" "160"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "160"
+"_color" "1.000000 0.015686 0.015686"
+"origin" "-1500 264 -64"
+}
+{
+"classname" "misc_insane"
+"angle" "270"
+"spawnflags" "4"
+"target" "t327"
+"origin" "-1248 376 -96"
+}
+{
+"origin" "-1248 384 -112"
+"classname" "path_corner"
+"targetname" "t326"
+"target" "t327"
+}
+{
+"classname" "path_corner"
+"origin" "-1248 240 -112"
+"targetname" "t327"
+"target" "t324"
+}
+{
+"origin" "-1652 292 -64"
+"_color" "1.000000 0.015686 0.015686"
+"light" "160"
+"classname" "light"
+}
+{
+"classname" "path_corner"
+"targetname" "t325"
+"target" "t321"
+"origin" "-1648 288 -112"
+}
+{
+"spawnflags" "4"
+"classname" "misc_insane"
+"target" "t322"
+"origin" "-1496 328 -96"
+}
+{
+"classname" "misc_insane"
+"spawnflags" "4"
+"target" "t323"
+"origin" "-1428 384 -96"
+}
+{
+"classname" "misc_insane"
+"spawnflags" "4"
+"target" "t321"
+"origin" "-1548 288 -96"
+}
+{
+"classname" "path_corner"
+"origin" "-1496 384 -112"
+"targetname" "t322"
+"target" "t323"
+}
+{
+"classname" "path_corner"
+"origin" "-1496 288 -112"
+"targetname" "t321"
+"target" "t322"
+}
+{
+"classname" "path_corner"
+"origin" "-1792 288 -112"
+"spawnflags" "0"
+"target" "t325"
+"targetname" "t330"
+}
+{
+"classname" "path_corner"
+"spawnflags" "0"
+"origin" "-1332 384 -112"
+"targetname" "t323"
+"target" "t326"
+}
+{
+"classname" "misc_insane"
+"spawnflags" "4"
+"angle" "360"
+"origin" "-1680 288 -96"
+"target" "t325"
+}
+{
+"origin" "-1244 336 -64"
+"_color" "1.000000 0.015686 0.015686"
+"light" "160"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "160"
+"_color" "1.000000 0.015686 0.015686"
+"origin" "-1764 292 -64"
+}
+{
+"classname" "point_combat"
+"targetname" "t319"
+"origin" "-1108 536 0"
+}
+{
+"classname" "point_combat"
+"targetname" "t320"
+"origin" "-1196 536 0"
+}
+{
+"classname" "point_combat"
+"targetname" "t318"
+"origin" "-428 -480 36"
+"target" "t382"
+}
+{
+"classname" "path_corner"
+"targetname" "t316"
+"target" "t317"
+"origin" "-660 -216 12"
+}
+{
+"classname" "path_corner"
+"targetname" "t317"
+"target" "t316"
+"origin" "-228 -216 12"
+}
+{
+"classname" "misc_insane"
+"angle" "360"
+"target" "t316"
+"origin" "-688 -216 28"
+"deathtarget" "marduk"
+}
+{
+"classname" "path_corner"
+"targetname" "t314"
+"target" "t304"
+"origin" "-2676 776 -416"
+}
+{
+"classname" "path_corner"
+"targetname" "t304"
+"target" "t311"
+"origin" "-2356 776 -416"
+}
+{
+"classname" "path_corner"
+"targetname" "t313"
+"target" "t314"
+"origin" "-2356 776 -416"
+}
+{
+"classname" "path_corner"
+"targetname" "t311"
+"target" "t312"
+"origin" "-2356 1064 -416"
+}
+{
+"classname" "path_corner"
+"targetname" "t312"
+"target" "t313"
+"origin" "-2356 1064 -416"
+}
+{
+"model" "*40"
+"classname" "func_explosive"
+"mass" "100"
+"targetname" "t184"
+}
+{
+"model" "*41"
+"classname" "trigger_once"
+"target" "t310"
+}
+{
+"spawnflags" "3"
+"angle" "180"
+"classname" "monster_brain"
+"origin" "-2108 1184 -428"
+"targetname" "t310"
+}
+{
+"spawnflags" "3"
+"angle" "180"
+"classname" "monster_brain"
+"origin" "-2108 1236 -428"
+"targetname" "t310"
+}
+{
+"classname" "monster_brain"
+"angle" "180"
+"spawnflags" "3"
+"origin" "-2032 1212 -428"
+"targetname" "t310"
+}
+{
+"target" "t375"
+"classname" "trigger_relay"
+"targetname" "t308"
+"delay" "1.2"
+"origin" "-2928 1020 -412"
+}
+{
+"model" "*42"
+"classname" "trigger_once"
+"spawnflags" "260"
+"targetname" "t267"
+"target" "t308"
+}
+{
+"classname" "monster_medic"
+"spawnflags" "256"
+"angle" "315"
+"origin" "-3044 1212 -488"
+"target" "t379"
+}
+{
+"classname" "path_corner"
+"targetname" "t303"
+"target" "t304"
+"origin" "-2664 776 -416"
+}
+{
+"classname" "misc_insane"
+"spawnflags" "4"
+"angle" "360"
+"target" "t303"
+"origin" "-2704 776 -400"
+"deathtarget" "marduk"
+}
+{
+"classname" "path_corner"
+"targetname" "t301"
+"target" "t302"
+"origin" "-2408 1176 -448"
+}
+{
+"classname" "path_corner"
+"targetname" "t302"
+"target" "t301"
+"origin" "-2408 344 -448"
+}
+{
+"classname" "misc_insane"
+"angle" "270"
+"spawnflags" "32"
+"target" "t301"
+"origin" "-2408 1208 -432"
+"deathtarget" "marduk"
+}
+{
+"classname" "monster_brain"
+"spawnflags" "1"
+"angle" "360"
+"origin" "-2296 344 -432"
+}
+{
+"angle" "360"
+"classname" "monster_parasite"
+"spawnflags" "2"
+"targetname" "t299"
+"origin" "-1504 528 28"
+"target" "t319"
+}
+{
+"classname" "monster_parasite"
+"angle" "360"
+"spawnflags" "2"
+"targetname" "t299"
+"origin" "-1568 528 28"
+"target" "t320"
+}
+{
+"origin" "-1616 596 16"
+"spawnflags" "1"
+"classname" "point_combat"
+"targetname" "t298"
+}
+{
+"origin" "-1152 596 20"
+"spawnflags" "1"
+"classname" "monster_medic"
+"target" "t298"
+"angle" "270"
+}
+{
+"model" "*43"
+"classname" "trigger_once"
+"target" "t299"
+}
+{
+"model" "*44"
+"target" "t238"
+"spawnflags" "4"
+"classname" "trigger_once"
+"targetname" "t328"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "-1424 -448 72"
+"targetname" "t211"
+"classname" "monster_brain"
+"angle" "270"
+"spawnflags" "259"
+}
+{
+"origin" "-1240 -592 32"
+"targetname" "t211"
+"classname" "monster_brain"
+"angle" "270"
+"spawnflags" "3"
+}
+{
+"origin" "-1296 -656 48"
+"targetname" "t211"
+"spawnflags" "3"
+"angle" "360"
+"classname" "monster_brain"
+}
+{
+"model" "*45"
+"targetname" "t297"
+"classname" "func_explosive"
+}
+{
+"targetname" "t328"
+"target" "t297"
+"origin" "-544 -376 56"
+"classname" "trigger_relay"
+}
+{
+"origin" "-560 -416 56"
+"target" "t296"
+"delay" ".5"
+"classname" "trigger_relay"
+"targetname" "t297"
+}
+{
+"origin" "-1028 -376 32"
+"targetname" "t67"
+"spawnflags" "3"
+"angle" "90"
+"classname" "monster_parasite"
+}
+{
+"origin" "-972 -408 24"
+"targetname" "t67"
+"spawnflags" "3"
+"angle" "90"
+"classname" "monster_parasite"
+}
+{
+"angle" "45"
+"origin" "-528 -480 -48"
+"classname" "monster_medic"
+"target" "t318"
+"targetname" "t297"
+}
+{
+"origin" "-352 40 8"
+"target" "t292"
+"delay" "3.3"
+"targetname" "t289"
+"classname" "trigger_relay"
+}
+{
+"origin" "-352 64 24"
+"target" "t291"
+"delay" "3.2"
+"targetname" "t289"
+"classname" "trigger_relay"
+}
+{
+"origin" "-352 96 24"
+"target" "t290"
+"delay" "3"
+"targetname" "t289"
+"classname" "trigger_relay"
+}
+{
+"model" "*46"
+"spawnflags" "2048"
+"target" "t289"
+"classname" "trigger_once"
+}
+{
+"targetname" "t291"
+"origin" "0 -480 -64"
+"spawnflags" "2"
+"angle" "135"
+"classname" "monster_chick"
+}
+{
+"origin" "0 -480 -88"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "16 -144 -88"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*47"
+"targetname" "t292"
+"_minlight" ".18"
+"target" "t287"
+"classname" "func_train"
+}
+{
+"origin" "-48 -528 -96"
+"target" "t288"
+"targetname" "t287"
+"classname" "path_corner"
+}
+{
+"origin" "-48 -528 16"
+"targetname" "t288"
+"classname" "path_corner"
+}
+{
+"model" "*48"
+"targetname" "t290"
+"mass" "50"
+"classname" "func_explosive"
+}
+{
+"model" "*49"
+"targetname" "t290"
+"classname" "func_explosive"
+"mass" "50"
+}
+{
+"origin" "-32 -192 -104"
+"target" "t286"
+"targetname" "t285"
+"classname" "path_corner"
+}
+{
+"origin" "-32 -192 16"
+"targetname" "t286"
+"classname" "path_corner"
+}
+{
+"model" "*50"
+"targetname" "t292"
+"target" "t285"
+"speed" "120"
+"_minlight" ".18"
+"classname" "func_train"
+}
+{
+"item" "ammo_rockets"
+"targetname" "t291"
+"origin" "16 -144 -56"
+"angle" "225"
+"spawnflags" "2"
+"classname" "monster_chick"
+}
+{
+"origin" "-504 64 16"
+"target" "t284"
+"classname" "monster_chick"
+"spawnflags" "2"
+"angle" "135"
+"targetname" "t315"
+}
+{
+"origin" "-616 120 0"
+"targetname" "t284"
+"classname" "point_combat"
+"spawnflags" "1"
+}
+{
+"origin" "-664 152 0"
+"targetname" "t283"
+"spawnflags" "1"
+"classname" "point_combat"
+}
+{
+"origin" "-764 64 16"
+"target" "t283"
+"angle" "45"
+"spawnflags" "2"
+"classname" "monster_chick"
+"targetname" "t315"
+}
+{
+"model" "*51"
+"classname" "trigger_once"
+"target" "t315"
+}
+{
+"item" "ammo_rockets"
+"origin" "-732 816 24"
+"classname" "monster_chick"
+"angle" "360"
+"spawnflags" "257"
+}
+{
+"origin" "-640 676 24"
+"spawnflags" "257"
+"angle" "45"
+"classname" "monster_chick"
+}
+{
+"origin" "-296 1368 0"
+"target" "t280"
+"targetname" "t281"
+"classname" "path_corner"
+}
+{
+"target" "t281"
+"targetname" "t280"
+"origin" "80 1368 0"
+"classname" "path_corner"
+}
+{
+"target" "t280"
+"origin" "60 1364 16"
+"angle" "180"
+"spawnflags" "4"
+"classname" "misc_insane"
+"deathtarget" "marduk"
+}
+{
+"model" "*52"
+"target" "t221"
+"spawnflags" "0"
+"classname" "trigger_once"
+}
+{
+"origin" "92 1188 20"
+"targetname" "t255"
+"angle" "270"
+"classname" "monster_parasite"
+"target" "t346"
+}
+{
+"origin" "36 1188 20"
+"targetname" "t255"
+"angle" "270"
+"classname" "monster_parasite"
+"target" "t345"
+}
+{
+"origin" "64 1296 20"
+"targetname" "t255"
+"angle" "270"
+"spawnflags" "768"
+"classname" "monster_parasite"
+}
+{
+"origin" "388 816 36"
+"target" "t279"
+"targetname" "t278"
+"classname" "trigger_relay"
+}
+{
+"origin" "24 -344 88"
+"spawnflags" "20"
+"classname" "misc_insane"
+"deathtarget" "marduk"
+}
+{
+"model" "*53"
+"classname" "func_button"
+"angle" "270"
+"wait" "-1"
+"lip" "16"
+"_minlight" ".18"
+"target" "t64"
+"spawnflags" "2048"
+}
+{
+"model" "*54"
+"classname" "func_wall"
+"spawnflags" "16"
+}
+{
+"model" "*55"
+"target" "t62"
+"_minlight" ".18"
+"lip" "16"
+"wait" "-1"
+"angle" "360"
+"classname" "func_button"
+"spawnflags" "2048"
+}
+{
+"origin" "-1692 692 -320"
+"targetname" "t117"
+"classname" "target_speaker"
+"noise" "world/brkglas.wav"
+}
+{
+"origin" "-2032 696 -320"
+"targetname" "t115"
+"noise" "world/brkglas.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-440 -216 128"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-224 -208 128"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-224 -40 128"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-344 64 128"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-536 64 128"
+}
+{
+"style" "32"
+"origin" "-304 -488 184"
+"targetname" "t64"
+"classname" "light"
+"spawnflags" "1"
+"light" "300"
+"_color" "1.000000 0.016949 0.016949"
+}
+{
+"style" "32"
+"origin" "-304 -552 184"
+"targetname" "t64"
+"_color" "1.000000 0.016949 0.016949"
+"light" "300"
+"spawnflags" "1"
+"classname" "light"
+}
+{
+"style" "33"
+"origin" "8 -344 184"
+"targetname" "t62"
+"classname" "light"
+"spawnflags" "1"
+"light" "300"
+"_color" "1.000000 0.016949 0.016949"
+}
+{
+"style" "33"
+"origin" "72 -344 184"
+"targetname" "t62"
+"_color" "1.000000 0.016949 0.016949"
+"light" "300"
+"spawnflags" "1"
+"classname" "light"
+}
+{
+"origin" "-1568 1608 -392"
+"classname" "target_speaker"
+"noise" "world/amb23.wav"
+}
+{
+"origin" "-1816 1616 -392"
+"classname" "target_speaker"
+"noise" "world/amb23.wav"
+}
+{
+"origin" "-1296 1608 -392"
+"noise" "world/amb23.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2768 1288 -312"
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "target_goal"
+"spawnflags" "2048"
+"targetname" "t267"
+"origin" "-2824 1240 -368"
+}
+{
+"classname" "key_blue_key"
+"origin" "-1440 -608 -24"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t58"
+"delay" "5.5"
+"killtarget" "t276"
+"origin" "-1380 -748 80"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t58"
+"delay" "5.5"
+"killtarget" "t277"
+"origin" "-1384 -728 80"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t58"
+"delay" ".5"
+"target" "t277"
+"origin" "-1408 -704 80"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t58"
+"delay" "5"
+"target" "t276"
+"origin" "-1416 -680 80"
+}
+{
+"model" "*56"
+"classname" "trigger_hurt"
+"spawnflags" "3"
+"dmg" "500"
+"targetname" "t276"
+}
+{
+"style" "34"
+"_color" "1.000000 0.003922 0.003922"
+"light" "300"
+"classname" "light"
+"spawnflags" "1"
+"targetname" "t277"
+"origin" "-1312 -268 184"
+}
+{
+"style" "34"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 0.003922 0.003922"
+"spawnflags" "1"
+"targetname" "t277"
+"origin" "-1384 -268 184"
+}
+{
+"style" "34"
+"_color" "1.000000 0.003922 0.003922"
+"light" "300"
+"classname" "light"
+"spawnflags" "1"
+"targetname" "t277"
+"origin" "-1384 -368 184"
+}
+{
+"style" "34"
+"classname" "light"
+"light" "300"
+"_color" "1.000000 0.003922 0.003922"
+"spawnflags" "1"
+"targetname" "t277"
+"origin" "-1312 -368 184"
+}
+{
+"classname" "misc_insane"
+"spawnflags" "20"
+"angle" "270"
+"origin" "-1320 -328 88"
+"deathtarget" "marduk"
+}
+{
+"classname" "trigger_always"
+"spawnflags" "1792"
+"target" "t275"
+"origin" "-1796 204 92"
+}
+{
+"classname" "trigger_key"
+"targetname" "t274"
+"target" "t275"
+"item" "key_blue_key"
+"spawnflags" "2048"
+"origin" "-1804 248 92"
+}
+{
+"model" "*57"
+"classname" "trigger_multiple"
+"target" "t274"
+"spawnflags" "2048"
+}
+{
+"origin" "-3068 1228 -424"
+"target" "t273"
+"targetname" "t272"
+"classname" "path_corner"
+}
+{
+"origin" "-2840 1224 -424"
+"target" "t272"
+"targetname" "t271"
+"classname" "path_corner"
+}
+{
+"origin" "-2848 1304 -424"
+"target" "t271"
+"targetname" "t270"
+"classname" "path_corner"
+}
+{
+"origin" "-3108 1304 -424"
+"target" "t270"
+"targetname" "t269"
+"classname" "path_corner"
+}
+{
+"origin" "-3104 1064 -424"
+"target" "t269"
+"targetname" "t268"
+"classname" "path_corner"
+}
+{
+"origin" "-2968 1108 -424"
+"target" "t268"
+"targetname" "t273"
+"classname" "path_corner"
+}
+{
+"origin" "-3104 1024 -408"
+"target" "t268"
+"spawnflags" "4"
+"classname" "misc_insane"
+"deathtarget" "marduk"
+}
+{
+"model" "*58"
+"spawnflags" "2048"
+"target" "t267"
+"wait" "-1"
+"speed" "130"
+"message" "Maintenence bridge\nactivated."
+"angle" "360"
+"classname" "func_button"
+}
+{
+"origin" "-1500 416 108"
+"classname" "target_speaker"
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+}
+{
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"classname" "target_speaker"
+"origin" "-1500 516 108"
+}
+{
+"origin" "-1592 516 108"
+"classname" "target_speaker"
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+}
+{
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"classname" "target_speaker"
+"origin" "-1592 416 108"
+}
+{
+"origin" "-1592 416 156"
+"classname" "target_speaker"
+"noise" "world/comp_hum3.wav"
+"spawnflags" "1"
+}
+{
+"spawnflags" "1"
+"noise" "world/comp_hum3.wav"
+"classname" "target_speaker"
+"origin" "-1592 516 156"
+}
+{
+"origin" "-1500 516 156"
+"classname" "target_speaker"
+"noise" "world/comp_hum3.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1412 160 76"
+"classname" "target_speaker"
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-3112 1152 -384"
+"spawnflags" "1"
+"noise" "world/amb23.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-3012 1060 -384"
+"spawnflags" "1"
+"noise" "world/amb23.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2916 964 -384"
+"spawnflags" "1"
+"noise" "world/amb23.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2752 828 -396"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2688 780 -396"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2792 1164 -332"
+"classname" "light"
+"light" "140"
+}
+{
+"origin" "-2808 1208 -264"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-3008 1096 -264"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-2824 1008 -264"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-2960 848 -264"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-2832 720 -264"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-2696 896 -264"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-2856 1304 -312"
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"origin" "-2856 1192 -312"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+"origin" "-2856 1304 -376"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"origin" "-2768 1200 -312"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"origin" "-2812 732 -312"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"origin" "-2572 780 -280"
+}
+{
+"model" "*59"
+"target" "t184"
+"classname" "trigger_multiple"
+"spawnflags" "1792"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1440 1896 -432"
+}
+{
+"origin" "-1356 -324 104"
+"target" "t266"
+"random" "6"
+"wait" "7"
+"classname" "func_timer"
+"spawnflags" "1793"
+}
+{
+"origin" "-1356 -344 104"
+"targetname" "t266"
+"classname" "target_speaker"
+"noise" "insane/insane7.wav"
+}
+{
+"origin" "-196 60 104"
+"classname" "func_timer"
+"spawnflags" "1"
+}
+{
+"origin" "-196 40 104"
+"classname" "target_speaker"
+"noise" "insane/insane7.wav"
+}
+{
+"origin" "24 -308 104"
+"wait" "10"
+"random" "8"
+"target" "t261"
+"spawnflags" "1793"
+"classname" "func_timer"
+}
+{
+"origin" "24 -328 104"
+"targetname" "t261"
+"classname" "target_speaker"
+"noise" "insane/insane5.wav"
+}
+{
+"origin" "-4 -308 104"
+"random" "7.5"
+"wait" "9"
+"target" "t262"
+"spawnflags" "1793"
+"classname" "func_timer"
+}
+{
+"origin" "-4 -328 104"
+"targetname" "t262"
+"noise" "insane/insane7.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-320 -476 104"
+"targetname" "t264"
+"classname" "target_speaker"
+"noise" "insane/insane7.wav"
+}
+{
+"origin" "-292 -476 104"
+"targetname" "t263"
+"noise" "insane/insane5.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-320 -456 104"
+"target" "t264"
+"wait" "11"
+"random" "8"
+"classname" "func_timer"
+"spawnflags" "1793"
+}
+{
+"origin" "-168 40 104"
+"classname" "target_speaker"
+"noise" "insane/insane5.wav"
+}
+{
+"origin" "-1336 -344 104"
+"targetname" "t265"
+"noise" "insane/insane5.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-292 -456 104"
+"target" "t263"
+"wait" "9.5"
+"random" "6"
+"classname" "func_timer"
+"spawnflags" "1793"
+}
+{
+"origin" "-1336 -324 104"
+"target" "t265"
+"random" "6.5"
+"wait" "9.5"
+"spawnflags" "1793"
+"classname" "func_timer"
+}
+{
+"model" "*60"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"model" "*61"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"model" "*62"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "-1496 1672 -400"
+"target" "t32"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"model" "*63"
+"spawnflags" "2048"
+"target" "t201"
+"classname" "trigger_once"
+}
+{
+"origin" "-640 624 72"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"classname" "target_speaker"
+"targetname" "t190"
+}
+{
+"origin" "-152 1336 72"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"classname" "target_speaker"
+"targetname" "t190"
+}
+{
+"origin" "-792 64 72"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"classname" "target_speaker"
+"targetname" "t190"
+}
+{
+"origin" "-1128 88 72"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"classname" "target_speaker"
+"targetname" "t190"
+}
+{
+"origin" "-1128 376 72"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"classname" "target_speaker"
+"targetname" "t190"
+}
+{
+"origin" "-1312 576 72"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"classname" "target_speaker"
+"targetname" "t190"
+}
+{
+"origin" "-1600 536 72"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"classname" "target_speaker"
+"targetname" "t190"
+}
+{
+"classname" "target_speaker"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"origin" "-1792 536 72"
+"targetname" "t190"
+}
+{
+"origin" "-1600 344 72"
+"spawnflags" "2"
+"noise" "world/klaxon1.wav"
+"classname" "target_speaker"
+"targetname" "t190"
+}
+{
+"spawnflags" "2048"
+"classname" "target_help"
+"targetname" "t190"
+"message" "Return to Hangar.\nUse Commander's head to\ngain further access."
+"origin" "-1896 460 40"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-640 352 -112"
+}
+{
+"classname" "light"
+"light" "160"
+"origin" "-640 672 -112"
+}
+{
+"style" "1"
+"classname" "func_areaportal"
+"targetname" "t259"
+}
+{
+"classname" "target_speaker"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2"
+"targetname" "t190"
+"origin" "-1880 624 72"
+}
+{
+"style" "2"
+"classname" "func_areaportal"
+"targetname" "t258"
+}
+{
+"style" "3"
+"classname" "func_areaportal"
+"targetname" "t257"
+}
+{
+"model" "*64"
+"classname" "trigger_once"
+"spawnflags" "2052"
+"target" "t256"
+"targetname" "t190"
+}
+{
+"spawnflags" "1"
+"angle" "90"
+"classname" "monster_chick"
+"origin" "-640 352 -84"
+"item" "ammo_rockets"
+}
+{
+"classname" "monster_chick"
+"angle" "270"
+"spawnflags" "1"
+"origin" "-640 672 -76"
+}
+{
+"model" "*65"
+"classname" "func_door"
+"angle" "-1"
+"spawnflags" "8"
+"wait" "-1"
+"lip" "-104"
+"targetname" "t256"
+"speed" "200"
+}
+{
+"model" "*66"
+"classname" "func_explosive"
+"dmg" "5"
+"targetname" "t256"
+"target" "t258"
+}
+{
+"model" "*67"
+"classname" "func_door"
+"angle" "-1"
+"spawnflags" "8"
+"lip" "-104"
+"wait" "-1"
+"targetname" "t256"
+"speed" "200"
+}
+{
+"model" "*68"
+"classname" "func_explosive"
+"targetname" "t256"
+"dmg" "5"
+"target" "t257"
+}
+{
+"style" "4"
+"classname" "func_areaportal"
+"targetname" "t255"
+}
+{
+"style" "5"
+"classname" "func_areaportal"
+"targetname" "t57"
+}
+{
+"origin" "-112 860 64"
+"wait" "10"
+"random" "6"
+"spawnflags" "1"
+"classname" "func_timer"
+"target" "t247"
+}
+{
+"origin" "-56 840 64"
+"noise" "insane/insane5.wav"
+"classname" "target_speaker"
+"targetname" "t247"
+}
+{
+"spawnflags" "1"
+"wait" "8"
+"random" "5"
+"classname" "func_timer"
+"target" "t246"
+"origin" "-116 720 64"
+}
+{
+"classname" "func_timer"
+"wait" "8.5"
+"random" "5"
+"spawnflags" "1"
+"target" "t245"
+"origin" "-144 836 64"
+}
+{
+"noise" "insane/insane7.wav"
+"classname" "target_speaker"
+"targetname" "t245"
+"origin" "-72 784 64"
+}
+{
+"noise" "insane/insane7.wav"
+"classname" "target_speaker"
+"targetname" "t246"
+"origin" "-56 704 64"
+}
+{
+"style" "6"
+"classname" "func_areaportal"
+"targetname" "t243"
+}
+{
+"model" "*69"
+"classname" "func_door"
+"angle" "-1"
+"speed" "120"
+"_minlight" ".2"
+"dmg" "5"
+"target" "t243"
+"spawnflags" "2048"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-28 1344 24"
+}
+{
+"classname" "path_corner"
+"targetname" "t241"
+"target" "t242"
+"origin" "-96 904 0"
+}
+{
+"classname" "path_corner"
+"targetname" "t242"
+"target" "t241"
+"origin" "-96 760 0"
+}
+{
+"classname" "misc_insane"
+"angle" "270"
+"spawnflags" "32"
+"target" "t241"
+"origin" "-96 932 16"
+}
+{
+"spawnflags" "2048"
+"classname" "item_armor_combat"
+"origin" "-128 1516 16"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_bullets"
+"origin" "-2700 616 -412"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_shells"
+"origin" "-2648 692 -412"
+}
+{
+"classname" "target_speaker"
+"noise" "world/lite_out.wav"
+"targetname" "t32"
+"origin" "-1568 1640 -400"
+"attenuation" "-1"
+}
+{
+"origin" "-640 72 -112"
+"light" "200"
+"classname" "light"
+}
+{
+"model" "*70"
+"target" "t240"
+"classname" "trigger_once"
+}
+{
+"origin" "-640 64 -88"
+"angle" "90"
+"classname" "monster_medic"
+"target" "t336"
+}
+{
+"model" "*71"
+"targetname" "t240"
+"classname" "func_explosive"
+}
+{
+"model" "*72"
+"targetname" "t240"
+"spawnflags" "8"
+"lip" "-104"
+"angle" "-1"
+"classname" "func_door"
+"wait" "-1"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"angle" "360"
+"classname" "monster_parasite"
+"origin" "-752 76 208"
+}
+{
+"classname" "monster_parasite"
+"angle" "360"
+"origin" "-792 52 208"
+}
+{
+"model" "*73"
+"classname" "func_explosive"
+"mass" "75"
+"dmg" "5"
+"targetname" "t238"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-176 1516 8"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-80 1516 8"
+}
+{
+"classname" "monster_parasite"
+"angle" "270"
+"spawnflags" "0"
+"origin" "-128 1480 16"
+"targetname" "t221"
+"target" "t348"
+}
+{
+"spawnflags" "0"
+"classname" "monster_parasite"
+"angle" "270"
+"origin" "-176 1480 16"
+"targetname" "t221"
+"target" "t347"
+}
+{
+"classname" "monster_parasite"
+"angle" "270"
+"origin" "-80 1480 16"
+"targetname" "t221"
+"target" "t349"
+"spawnflags" "768"
+}
+{
+"model" "*74"
+"classname" "func_explosive"
+"mass" "50"
+"dmg" "20"
+"targetname" "t221"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_large"
+"origin" "392 896 8"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_large"
+"origin" "352 896 8"
+}
+{
+"spawnflags" "2048"
+"origin" "-1910 546 28"
+"targetname" "t190"
+"classname" "target_goal"
+}
+{
+"message" "You have found a secret."
+"spawnflags" "2048"
+"classname" "target_secret"
+"targetname" "t234"
+"origin" "-1724 1380 -448"
+}
+{
+"origin" "-800 1656 -456"
+"spawnflags" "1"
+"noise" "world/amb23.wav"
+"classname" "target_speaker"
+"volume" "1"
+"attenuation" "3"
+}
+{
+"spawnflags" "1"
+"noise" "world/comp_hum3.wav"
+"classname" "target_speaker"
+"origin" "-1500 416 156"
+}
+{
+"origin" "-1372 -304 200"
+"classname" "target_speaker"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-304 -528 200"
+"classname" "target_speaker"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+}
+{
+"origin" "56 -344 200"
+"classname" "target_speaker"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1316 -304 200"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"classname" "target_speaker"
+"origin" "-216 -504 92"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"classname" "target_speaker"
+"origin" "20 -256 92"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+"classname" "target_speaker"
+"origin" "20 -256 104"
+}
+{
+"model" "*75"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"targetname" "t57"
+"target" "t233"
+}
+{
+"origin" "-2572 556 -280"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "-2572 552 -280"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+}
+{
+"origin" "-2572 776 -280"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+}
+{
+"origin" "-2856 1192 -376"
+"noise" "world/comp_hum1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1664 992 -388"
+"noise" "world/force1.wav"
+"targetname" "for1"
+"spawnflags" "2049"
+"classname" "target_speaker"
+}
+{
+"origin" "-748 784 96"
+"targetname" "for1"
+"spawnflags" "2049"
+"noise" "world/force1.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"origin" "-546 1704 -320"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+}
+{
+"classname" "target_speaker"
+"origin" "-650 1704 -320"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-468 812 -412"
+"noise" "world/amb22.wav"
+"spawnflags" "1"
+"volume" ".7"
+"classname" "target_speaker"
+}
+{
+"origin" "-464 984 -396"
+"noise" "world/amb22.wav"
+"spawnflags" "1"
+"volume" ".7"
+"classname" "target_speaker"
+}
+{
+"origin" "-464 1176 -408"
+"noise" "world/amb15.wav"
+"spawnflags" "1"
+"volume" ".5"
+"classname" "target_speaker"
+}
+{
+"origin" "-464 1392 -456"
+"noise" "world/amb22.wav"
+"spawnflags" "1"
+"volume" ".7"
+"classname" "target_speaker"
+}
+{
+"origin" "-1248 1496 -456"
+"noise" "world/amb15.wav"
+"spawnflags" "1"
+"volume" ".6"
+"classname" "target_speaker"
+}
+{
+"origin" "-2004 672 100"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1816 844 140"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1664 948 140"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-2036 372 -408"
+"noise" "world/amb22.wav"
+"spawnflags" "1"
+"volume" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2268 380 -408"
+"noise" "world/amb22.wav"
+"spawnflags" "1"
+"volume" "1"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-2048 120 160"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-1908 224 160"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-1800 224 196"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-1424 344 72"
+}
+{
+"origin" "-1000 -552 120"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1000 -324 120"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-844 -216 120"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-696 -216 44"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+"origin" "-1000 -684 44"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+"origin" "-304 -408 188"
+}
+{
+"volume" ".5"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+"origin" "-1828 1688 -372"
+}
+{
+"volume" ".5"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+"origin" "-1564 1692 -372"
+}
+{
+"volume" ".5"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+"origin" "-1312 1688 -372"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+"origin" "-1344 -384 72"
+}
+{
+"origin" "-1472 168 76"
+"classname" "target_speaker"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1408 292 92"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1152 572 52"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1152 328 192"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-948 64 192"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-756 64 128"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-584 -216 128"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-640 556 144"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-624 796 144"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"spawnflags" "2048"
+"origin" "-1424 1928 -344"
+"killtarget" "tr2"
+"target" "t31"
+"targetname" "t229"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1712 1924 -328"
+"target" "t31"
+"killtarget" "tr1"
+"targetname" "t228"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "1"
+"targetname" "tr2"
+"origin" "-1668 1812 -392"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"targetname" "tr1"
+"origin" "-1624 1712 -392"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"targetname" "tr2"
+"origin" "-1564 1684 -392"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"targetname" "tr1"
+"origin" "-1512 1712 -392"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"targetname" "tr2"
+"origin" "-1464 1812 -392"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+}
+{
+"spawnflags" "1"
+"targetname" "tr2"
+"origin" "-1724 1812 -392"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+}
+{
+"spawnflags" "1"
+"targetname" "tr1"
+"origin" "-1776 1712 -392"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"targetname" "tr2"
+"origin" "-1828 1684 -392"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-1888 1712 -392"
+"targetname" "tr1"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"targetname" "tr2"
+"origin" "-1932 1812 -392"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"targetname" "tr1"
+"origin" "-1260 1720 -392"
+"classname" "target_speaker"
+"noise" "world/amb10.wav"
+}
+{
+"spawnflags" "1"
+"targetname" "tr2"
+"origin" "-1312 1692 -392"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+}
+{
+"spawnflags" "1"
+"targetname" "tr1"
+"origin" "-1372 1720 -392"
+"classname" "target_speaker"
+"noise" "world/amb10.wav"
+}
+{
+"spawnflags" "1"
+"targetname" "tr2"
+"origin" "-1416 1820 -392"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+}
+{
+"spawnflags" "1"
+"targetname" "tr2"
+"origin" "-1212 1820 -392"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"volume" "1"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-2228 1216 -408"
+}
+{
+"classname" "target_speaker"
+"volume" "1"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-2408 1040 -408"
+}
+{
+"classname" "target_speaker"
+"volume" "1"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-2040 132 -408"
+}
+{
+"classname" "target_speaker"
+"volume" "1"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-2408 568 -408"
+}
+{
+"classname" "target_speaker"
+"volume" "1"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-2404 748 -408"
+}
+{
+"classname" "target_speaker"
+"volume" "1"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-2260 664 -408"
+}
+{
+"classname" "target_speaker"
+"volume" ".7"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-2104 664 -408"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+"origin" "-2988 1260 -384"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-380 784 144"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-320 968 144"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-320 1160 132"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-284 1344 132"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "-72 1344 132"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "64 1236 132"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "64 1040 8"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+"origin" "64 896 144"
+}
+{
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+"classname" "target_speaker"
+"origin" "336 836 8"
+}
+{
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"classname" "target_speaker"
+"origin" "404 836 8"
+}
+{
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"classname" "target_speaker"
+"origin" "404 732 8"
+}
+{
+"origin" "336 732 8"
+"classname" "target_speaker"
+"noise" "world/comp_hum1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "408 784 52"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-368 -504 116"
+"targetname" "t65"
+"spawnflags" "2"
+"noise" "world/l_hum1.wav"
+"attenuation" "3"
+"volume" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "24 -408 104"
+"targetname" "t63"
+"volume" "1"
+"attenuation" "3"
+"spawnflags" "2"
+"noise" "world/l_hum1.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t25"
+"volume" ".8"
+"origin" "-1388 -332 100"
+"attenuation" "2"
+"spawnflags" "0"
+"noise" "world/spark1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1388 -332 100"
+"spawnflags" "1"
+"noise" "world/turbine1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1484 -544 144"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1484 -620 144"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1440 -744 88"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1352 -444 188"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1484 -472 144"
+"classname" "target_speaker"
+"noise" "world/amb16.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-216 -504 104"
+"classname" "target_speaker"
+"noise" "world/comp_hum1.wav"
+"spawnflags" "1"
+}
+{
+"volume" ".7"
+"origin" "-1440 -744 92"
+"classname" "target_speaker"
+"noise" "world/comp_hum1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-64 -348 188"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2096 424 128"
+"targetname" "mac2"
+"spawnflags" "0"
+"classname" "target_speaker"
+"volume" ".8"
+"attenuation" "2"
+"noise" "world/turbine1.wav"
+}
+{
+"origin" "-1880 424 72"
+"targetname" "mac1"
+"noise" "world/turbine1.wav"
+"attenuation" "2"
+"volume" ".8"
+"classname" "target_speaker"
+}
+{
+"origin" "-2144 424 144"
+"targetname" "mac2"
+"volume" ".8"
+"attenuation" "2"
+"noise" "world/spark2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".2"
+"origin" "-592 1648 -372"
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1424 528 72"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2448 664 -384"
+"spawnflags" "1"
+"noise" "world/amb16.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1704 664 -408"
+"noise" "world/amb22.wav"
+"spawnflags" "1"
+"volume" ".7"
+"classname" "target_speaker"
+}
+{
+"origin" "-2032 1340 -408"
+"noise" "world/amb22.wav"
+"spawnflags" "1"
+"volume" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1568 1552 -456"
+"noise" "world/amb15.wav"
+"spawnflags" "1"
+"volume" ".6"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"volume" ".5"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-1664 960 -408"
+}
+{
+"classname" "target_speaker"
+"volume" ".7"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-664 784 -412"
+}
+{
+"classname" "target_speaker"
+"volume" ".7"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-1248 1312 -456"
+}
+{
+"classname" "target_speaker"
+"volume" ".7"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-1248 1184 -456"
+}
+{
+"classname" "target_speaker"
+"volume" ".7"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-1112 1088 -456"
+}
+{
+"classname" "target_speaker"
+"volume" ".7"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-928 1088 -456"
+}
+{
+"classname" "target_speaker"
+"volume" ".7"
+"spawnflags" "2048"
+"noise" "world/amb22.wav"
+"origin" "-832 1232 -456"
+}
+{
+"classname" "target_speaker"
+"volume" "1"
+"spawnflags" "1"
+"noise" "world/amb15.wav"
+"origin" "-832 1432 -456"
+}
+{
+"classname" "target_speaker"
+"volume" ".6"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"origin" "-648 1608 -456"
+}
+{
+"model" "*76"
+"targetname" "t226"
+"spawnflags" "2051"
+"classname" "func_wall"
+}
+{
+"model" "*77"
+"targetname" "t225"
+"spawnflags" "2051"
+"classname" "func_wall"
+}
+{
+"model" "*78"
+"targetname" "t225"
+"spawnflags" "2071"
+"classname" "func_wall"
+}
+{
+"origin" "-752 1628 -432"
+"target" "t226"
+"delay" "7"
+"targetname" "t42"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-776 1636 -432"
+"target" "t225"
+"delay" "6.5"
+"targetname" "t42"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-800 1496 -456"
+"spawnflags" "1"
+"noise" "world/amb22.wav"
+"classname" "target_speaker"
+"volume" "1"
+"attenuation" "3"
+}
+{
+"origin" "-496 1496 -456"
+"classname" "target_speaker"
+"noise" "world/amb22.wav"
+"spawnflags" "1"
+"attenuation" "3"
+"volume" "1"
+}
+{
+"model" "*79"
+"targetname" "t226"
+"classname" "func_wall"
+"spawnflags" "2071"
+}
+{
+"spawnflags" "0"
+"noise" "world/l_hum1.wav"
+"classname" "target_speaker"
+"targetname" "t44"
+"origin" "-546 1760 -370"
+"volume" "1"
+"attenuation" "3"
+}
+{
+"spawnflags" "0"
+"noise" "world/l_hum1.wav"
+"classname" "target_speaker"
+"targetname" "t43"
+"origin" "-650 1760 -370"
+"volume" "1"
+"attenuation" "3"
+}
+{
+"volume" "1"
+"attenuation" "3"
+"spawnflags" "1"
+"noise" "world/amb23.wav"
+"classname" "target_speaker"
+"origin" "-496 1656 -456"
+}
+{
+"attenuation" "3"
+"volume" "1"
+"classname" "target_speaker"
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+"origin" "-836 1720 -432"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-546 1704 -452"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-650 1704 -452"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-490 1704 -452"
+}
+{
+"origin" "-1624 960 16"
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"origin" "-868 1248 -472"
+"classname" "weapon_supershotgun"
+}
+{
+"spawnflags" "2048"
+"targetname" "t40"
+"classname" "target_spawner"
+"angle" "225"
+"origin" "-840 1204 -428"
+"target" "misc_gib_leg"
+}
+{
+"spawnflags" "2048"
+"targetname" "t40"
+"classname" "target_spawner"
+"angle" "225"
+"origin" "-820 1232 -428"
+"target" "misc_gib_leg"
+}
+{
+"spawnflags" "2048"
+"targetname" "t40"
+"classname" "target_spawner"
+"angle" "225"
+"origin" "-896 1108 -428"
+"target" "misc_gib_arm"
+}
+{
+"spawnflags" "2048"
+"targetname" "t40"
+"target" "misc_gib_head"
+"origin" "-824 1264 -428"
+"angle" "225"
+"classname" "target_spawner"
+}
+{
+"spawnflags" "2048"
+"targetname" "t40"
+"origin" "-928 1076 -428"
+"angle" "135"
+"target" "misc_gib_arm"
+"classname" "target_spawner"
+}
+{
+"origin" "-824 1316 -504"
+"classname" "misc_deadsoldier"
+"spawnflags" "2050"
+"angle" "45"
+}
+{
+"origin" "-868 1264 -504"
+"angle" "90"
+"spawnflags" "2049"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-1712 1280 -440"
+"classname" "ammo_slugs"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-288 64 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-384 64 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-544 64 24"
+}
+{
+"origin" "-470 944 -420"
+"targetname" "t46"
+"spawnflags" "769"
+"classname" "monster_parasite"
+}
+{
+"spawnflags" "2048"
+"origin" "-2028 1904 -432"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-2064 1904 -432"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-2728 520 -416"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-2728 808 -416"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-2304 704 -440"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-2328 688 -456"
+"spawnflags" "2048"
+"angle" "45"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-1640 976 0"
+"classname" "misc_deadsoldier"
+"angle" "270"
+"spawnflags" "2050"
+}
+{
+"spawnflags" "0"
+"origin" "-1468 -828 40"
+"classname" "ammo_shells"
+}
+{
+"origin" "-1000 -216 0"
+"target" "t214"
+"targetname" "t213"
+"classname" "path_corner"
+}
+{
+"origin" "-856 -216 0"
+"target" "t213"
+"targetname" "t212"
+"classname" "path_corner"
+}
+{
+"origin" "-1000 -464 0"
+"target" "t213"
+"targetname" "t214"
+"classname" "path_corner"
+}
+{
+"origin" "-824 -216 16"
+"target" "t212"
+"spawnflags" "4"
+"angle" "180"
+"classname" "misc_insane"
+"deathtarget" "marduk"
+}
+{
+"spawnflags" "0"
+"origin" "-512 132 12"
+"classname" "item_health"
+}
+{
+"spawnflags" "0"
+"origin" "-476 132 12"
+"classname" "item_health"
+}
+{
+"spawnflags" "2048"
+"origin" "-328 1204 16"
+"classname" "weapon_grenadelauncher"
+}
+{
+"origin" "-1764 192 -8"
+"angle" "225"
+"spawnflags" "2049"
+"classname" "misc_deadsoldier"
+}
+{
+"style" "7"
+"targetname" "t211"
+"classname" "func_areaportal"
+}
+{
+"model" "*80"
+"target" "t211"
+"dmg" "5"
+"spawnflags" "2052"
+"_minlight" ".18"
+"speed" "120"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"origin" "-2008 472 32"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-2106 422 108"
+"light" "86"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "86"
+"origin" "-2058 422 120"
+}
+{
+"origin" "-1886 428 92"
+"light" "86"
+"classname" "light"
+}
+{
+"model" "*81"
+"targetname" "t364"
+"_minlight" ".18"
+"sounds" "1"
+"speed" "10"
+"classname" "func_train"
+"target" "t196"
+}
+{
+"spawnflags" "2048"
+"angle" "135"
+"origin" "-1896 510 28"
+"target" "t2"
+"classname" "key_commander_head"
+}
+{
+"origin" "-1508 576 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1408 576 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1472 512 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1472 416 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1472 320 24"
+"classname" "light"
+"light" "120"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1728 224 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1632 224 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1564 224 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1472 224 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1664 320 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1664 416 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1664 512 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1600 576 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1312 576 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1216 576 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1152 544 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1152 448 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1152 352 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1152 256 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1152 160 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1120 64 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1024 64 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-924 64 24"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-824 64 24"
+}
+{
+"origin" "-2048 64 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-732 64 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-192 64 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-640 64 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-640 160 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-640 240 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-600 416 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-640 448 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-640 544 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-640 640 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-640 720 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-704 784 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-604 784 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-512 784 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "440 872 116"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "440 784 116"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "-416 784 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-320 780 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-320 864 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-320 960 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-320 1060 24"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-320 1152 24"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-320 1252 24"
+"classname" "light"
+"light" "100"
+}
+{
+"classname" "light"
+"light" "94"
+"origin" "-320 1216 132"
+}
+{
+"origin" "-320 1344 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-220 1344 24"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-128 1344 24"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "64 1344 24"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "64 1248 24"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "64 1152 24"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "64 1060 24"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "64 924 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "64 832 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "64 736 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "64 640 24"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "64 640 104"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-2204 344 -424"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2252 664 -380"
+"classname" "light"
+"light" "130"
+}
+{
+"light" "82"
+"classname" "light"
+"origin" "-2672 592 -300"
+}
+{
+"light" "82"
+"classname" "light"
+"origin" "-2672 736 -300"
+}
+{
+"light" "82"
+"classname" "light"
+"origin" "-2616 736 -300"
+}
+{
+"origin" "-1664 836 -436"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1664 748 -436"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1664 664 -436"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1772 664 -436"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1892 664 -436"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1984 664 -436"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2088 664 -436"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2184 664 -436"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2312 664 -424"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2408 664 -424"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2408 564 -424"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2052 180 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2052 264 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2052 344 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2128 344 -424"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2308 344 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2408 344 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2408 460 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1664 924 -436"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2512 564 -412"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2584 564 -396"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2688 564 -396"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2688 664 -396"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2800 872 -396"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2584 780 -396"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2512 780 -412"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2408 784 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2408 880 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2408 968 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2408 1064 -412"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2408 1136 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2408 1216 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2304 1216 -424"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-2204 1216 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2116 1216 -424"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2032 1216 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2032 1292 -424"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2032 1372 -424"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-2032 1480 -412"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1824 1600 -440"
+}
+{
+"origin" "-1248 1536 -456"
+"classname" "light"
+"light" "120"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1728 1600 -456"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1600 1600 -456"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1472 1600 -456"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1344 1600 -456"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1248 1600 -456"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1248 1452 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1280 1300 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1280 1220 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1280 1152 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1280 1060 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1152 1060 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1040 1060 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-928 1060 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-800 1060 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-800 1160 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-800 1248 -456"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-800 1328 -456"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-832 1452 -456"
+}
+{
+"origin" "-464 1472 -456"
+"classname" "light"
+"light" "140"
+}
+{
+"origin" "-464 1560 -456"
+"classname" "light"
+"light" "140"
+}
+{
+"origin" "-588 1560 -456"
+"classname" "light"
+"light" "140"
+}
+{
+"origin" "-708 1560 -456"
+"classname" "light"
+"light" "140"
+}
+{
+"origin" "-832 1656 -456"
+"classname" "light"
+"light" "140"
+}
+{
+"origin" "-2052 96 -404"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-832 1416 -388"
+"classname" "light"
+"light" "120"
+}
+{
+"classname" "light"
+"light" "96"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-960 1680 -288"
+}
+{
+"origin" "-884 1464 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-920 1516 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-960 1584 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-776 1480 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "-744 1512 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "125"
+"classname" "light"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-464 1392 -364"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-464 1488 -364"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-832 1488 -388"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-464 1372 -456"
+}
+{
+"light" "190"
+"classname" "light"
+"origin" "-1696 424 116"
+}
+{
+"light" "190"
+"classname" "light"
+"origin" "-1696 548 116"
+}
+{
+"classname" "path_corner"
+"targetname" "t196"
+"origin" "-2064 384 -132"
+"target" "t197"
+}
+{
+"classname" "path_corner"
+"origin" "-2064 384 -88"
+"targetname" "t197"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2048"
+"angle" "135"
+"origin" "-2048 232 -8"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_shells"
+"origin" "-2084 260 16"
+}
+{
+"spawnflags" "3"
+"angle" "0"
+"classname" "monster_parasite"
+"origin" "-1940 1588 -424"
+"targetname" "t195"
+}
+{
+"spawnflags" "3"
+"angle" "0"
+"classname" "monster_parasite"
+"origin" "-1940 1636 -424"
+"targetname" "t195"
+}
+{
+"classname" "monster_parasite"
+"angle" "0"
+"spawnflags" "771"
+"origin" "-2016 1612 -412"
+"targetname" "t195"
+}
+{
+"model" "*82"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t195"
+}
+{
+"origin" "-2692 816 -288"
+"classname" "light"
+"light" "90"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "-2648 816 -288"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "-2692 512 -288"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "-2736 816 -288"
+}
+{
+"origin" "-1716 716 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"model" "*83"
+"classname" "func_explosive"
+"target" "t184"
+"health" "110"
+"mass" "200"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-2200 592 16"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-2200 556 16"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-2200 628 16"
+}
+{
+"angle" "90"
+"classname" "misc_insane"
+"spawnflags" "2068"
+"origin" "-304 -504 104"
+"deathtarget" "marduk"
+}
+{
+"style" "8"
+"targetname" "t188"
+"classname" "func_areaportal"
+}
+{
+"model" "*84"
+"target" "t188"
+"speed" "120"
+"spawnflags" "4"
+"_minlight" ".18"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1176 1160 -384"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1176 1248 -384"
+}
+{
+"origin" "-1568 1428 -384"
+"angle" "180"
+"spawnflags" "2049"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-1680 1280 -440"
+"classname" "item_quad"
+}
+{
+"model" "*85"
+"speed" "120"
+"wait" "-1"
+"targetname" "t184"
+"angle" "-1"
+"classname" "func_door"
+"target" "t234"
+}
+{
+"origin" "-1696 1284 -432"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*86"
+"spawnflags" "2048"
+"angle" "90"
+"classname" "trigger_monsterjump"
+}
+{
+"origin" "-1444 -264 96"
+"classname" "light"
+"light" "140"
+}
+{
+"spawnflags" "2048"
+"origin" "-1444 -272 40"
+"classname" "item_health"
+}
+{
+"spawnflags" "2048"
+"origin" "-1444 -308 40"
+"classname" "item_health"
+}
+{
+"item" "ammo_shells"
+"origin" "-904 64 20"
+"spawnflags" "48"
+"angle" "360"
+"classname" "misc_insane"
+"deathtarget" "marduk"
+}
+{
+"origin" "-2168 656 144"
+"classname" "light"
+"light" "110"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1848 656 144"
+}
+{
+"origin" "-1448 -800 96"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1444 -696 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-140 -512 100"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "44 -176 100"
+"light" "82"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-640 276 112"
+}
+{
+"origin" "-592 408 12"
+"targetname" "t173"
+"target" "t172"
+"classname" "path_corner"
+}
+{
+"origin" "-688 408 12"
+"target" "t173"
+"targetname" "t172"
+"classname" "path_corner"
+}
+{
+"origin" "468 896 40"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "468 676 40"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1696 1956 -320"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-1440 1956 -320"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-1896 510 60"
+"light" "120"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "84"
+"origin" "-800 -216 132"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-896 64 220"
+}
+{
+"origin" "-1152 320 220"
+"light" "110"
+"classname" "light"
+}
+{
+"classname" "path_corner"
+"targetname" "t138"
+"target" "t139"
+"origin" "-2048 656 -456"
+}
+{
+"classname" "path_corner"
+"targetname" "t139"
+"origin" "-1656 664 -456"
+"target" "t335"
+}
+{
+"classname" "misc_insane"
+"angle" "0"
+"spawnflags" "16"
+"origin" "-88 728 16"
+}
+{
+"classname" "path_corner"
+"targetname" "t135"
+"target" "t136"
+"origin" "-156 696 0"
+}
+{
+"classname" "path_corner"
+"targetname" "t136"
+"target" "t135"
+"origin" "-156 912 0"
+}
+{
+"classname" "misc_insane"
+"angle" "90"
+"target" "t135"
+"origin" "-156 672 16"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-216 768 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-336 680 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-128 880 52"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-128 688 52"
+}
+{
+"origin" "64 504 228"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "64 440 228"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "64 384 228"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "64 344 180"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "64 320 132"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-1712 648 -432"
+"target" "t134"
+"targetname" "t28"
+"classname" "trigger_relay"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1216 512 204"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1444 -292 76"
+}
+{
+"classname" "light"
+"light" "160"
+"origin" "-1248 -290 96"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-396 64 100"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-612 -496 208"
+}
+{
+"spawnflags" "32"
+"target" "t173"
+"classname" "misc_insane"
+"angle" "90"
+"origin" "-640 476 28"
+"deathtarget" "marduk"
+}
+{
+"targetname" "t46"
+"classname" "monster_parasite"
+"angle" "90"
+"spawnflags" "1"
+"origin" "-496 980 -420"
+}
+{
+"targetname" "t46"
+"classname" "monster_parasite"
+"angle" "90"
+"spawnflags" "1"
+"origin" "-444 980 -420"
+}
+{
+"classname" "target_explosion"
+"dmg" "120"
+"targetname" "t118"
+"origin" "-1884 664 -228"
+}
+{
+"classname" "target_explosion"
+"dmg" "50"
+"targetname" "t117"
+"origin" "-1664 660 -228"
+}
+{
+"classname" "target_explosion"
+"dmg" "120"
+"targetname" "t116"
+"origin" "-1664 868 -228"
+}
+{
+"spawnflags" "20"
+"angle" "180"
+"classname" "misc_insane"
+"origin" "-1664 660 -232"
+"deathtarget" "marduk"
+}
+{
+"spawnflags" "16"
+"angle" "90"
+"classname" "misc_insane"
+"origin" "-1884 664 -232"
+"deathtarget" "marduk"
+}
+{
+"classname" "misc_insane"
+"angle" "270"
+"spawnflags" "4"
+"origin" "-1664 868 -232"
+"deathtarget" "marduk"
+}
+{
+"classname" "misc_insane"
+"spawnflags" "4"
+"angle" "180"
+"origin" "-2084 660 -236"
+"target" "t138"
+"deathtarget" "marduk"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2050"
+"angle" "90"
+"origin" "-2672 552 -432"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-440 1076 -332"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-440 1016 -332"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-440 956 -332"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-440 904 -332"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-440 844 -332"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-448 784 -332"
+}
+{
+"spawnflags" "2048"
+"classname" "weapon_hyperblaster"
+"origin" "-1248 -320 48"
+}
+{
+"spawnflags" "2048"
+"classname" "item_armor_body"
+"target" "t97"
+"origin" "-1248 -272 48"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2052"
+"origin" "-352 1216 -8"
+"angle" "45"
+}
+{
+"origin" "116 704 12"
+"target" "t77"
+"targetname" "t78"
+"classname" "path_corner"
+}
+{
+"origin" "68 872 20"
+"target" "t78"
+"targetname" "t77"
+"classname" "path_corner"
+}
+{
+"origin" "64 644 28"
+"target" "t77"
+"angle" "90"
+"classname" "misc_insane"
+"item" "ammo_slugs"
+"deathtarget" "marduk"
+}
+{
+"spawnflags" "2048"
+"origin" "64 680 92"
+"message" "Locate Repair facility.\nSteal Commander's head."
+"classname" "target_help"
+"targetname" "t233"
+}
+{
+"origin" "-1488 -544 144"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-1488 -620 144"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-1488 -472 144"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "32 -232 92"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-200 -504 92"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1436 -744 92"
+"light" "150"
+"classname" "light"
+}
+{
+"delay" "1.5"
+"origin" "-1592 1660 -344"
+"message" "Forcefields deactivated."
+"targetname" "t32"
+"classname" "trigger_relay"
+}
+{
+"style" "9"
+"targetname" "t67"
+"classname" "func_areaportal"
+}
+{
+"model" "*87"
+"spawnflags" "2048"
+"killtarget" "for1"
+"targetname" "t31"
+"target" "t32"
+"classname" "trigger_counter"
+}
+{
+"spawnflags" "2048"
+"origin" "-1416 -744 72"
+"killtarget" "p2"
+"targetname" "t58"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-140 -472 168"
+"target" "t66"
+"targetname" "t65"
+"classname" "trigger_relay"
+}
+{
+"origin" "-20 -160 168"
+"target" "t66"
+"targetname" "t63"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-168 -472 168"
+"target" "t65"
+"targetname" "t64"
+"classname" "trigger_relay"
+}
+{
+"origin" "4 -160 168"
+"target" "t63"
+"targetname" "t62"
+"classname" "trigger_relay"
+}
+{
+"model" "*88"
+"spawnflags" "4"
+"target" "t67"
+"_minlight" ".18"
+"angle" "-1"
+"classname" "func_door"
+"speed" "120"
+}
+{
+"origin" "-1696 624 -436"
+"target" "t55"
+"targetname" "t54"
+"delay" ".6"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1656 624 -436"
+"target" "t54"
+"targetname" "t28"
+"delay" ".6"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1732 624 -436"
+"target" "t56"
+"targetname" "t55"
+"delay" ".6"
+"classname" "trigger_relay"
+}
+{
+"light" "82"
+"classname" "light"
+"origin" "-2616 592 -300"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "-2736 712 -288"
+}
+{
+"origin" "-2736 512 -288"
+"classname" "light"
+"light" "90"
+}
+{
+"origin" "-2736 568 -288"
+"classname" "light"
+"light" "90"
+}
+{
+"origin" "-2736 616 -288"
+"classname" "light"
+"light" "90"
+}
+{
+"origin" "-2736 664 -288"
+"classname" "light"
+"light" "90"
+}
+{
+"origin" "-2684 664 -300"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-2736 760 -288"
+"classname" "light"
+"light" "90"
+}
+{
+"origin" "-2648 512 -288"
+"classname" "light"
+"light" "90"
+}
+{
+"origin" "-2664 776 -188"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-2688 732 -188"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-2688 664 -188"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-2688 604 -188"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-2672 552 -188"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-2408 624 -332"
+"classname" "light"
+"light" "92"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2592 776 -240"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2480 784 -336"
+}
+{
+"angle" "90"
+"origin" "-1368 -320 56"
+"classname" "misc_deadsoldier"
+"spawnflags" "2049"
+}
+{
+"origin" "24 -408 166"
+"angle" "-2"
+"targetname" "t51"
+"sounds" "1"
+"classname" "target_splash"
+}
+{
+"origin" "-368 -504 166"
+"angle" "-2"
+"targetname" "t52"
+"sounds" "1"
+"classname" "target_splash"
+}
+{
+"dmg" "7"
+"origin" "-368 -504 168"
+"targetname" "t65"
+"spawnflags" "2"
+"target" "t50"
+"classname" "target_laser"
+}
+{
+"model" "*89"
+"spawnflags" "1"
+"targetname" "t50"
+"target" "t48"
+"classname" "func_train"
+}
+{
+"origin" "-304 -452 48"
+"target" "t49"
+"targetname" "t48"
+"classname" "path_corner"
+}
+{
+"origin" "-304 -570 48"
+"target" "t48"
+"targetname" "t49"
+"classname" "path_corner"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1688 1848 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1688 1800 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1676 1756 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1652 1728 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1620 1704 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1568 1700 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1508 1704 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1476 1728 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1440 1800 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1440 1848 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1452 1756 -328"
+}
+{
+"origin" "-1948 1900 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1948 1848 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1948 1800 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1936 1756 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1912 1728 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1880 1704 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1828 1700 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1768 1704 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1736 1728 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1700 1800 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1700 1848 -328"
+}
+{
+"light" "74"
+"classname" "light"
+"origin" "-1712 1756 -328"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1948 1900 -268"
+"classname" "light"
+"light" "120"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "95"
+"classname" "light"
+"origin" "-1948 1800 -268"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "95"
+"classname" "light"
+"origin" "-1912 1728 -268"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "95"
+"classname" "light"
+"origin" "-1828 1700 -268"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "95"
+"classname" "light"
+"origin" "-1736 1728 -268"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "95"
+"classname" "light"
+"origin" "-1700 1800 -268"
+}
+{
+"light" "82"
+"classname" "light"
+"origin" "-832 1088 -388"
+}
+{
+"style" "10"
+"targetname" "t47"
+"classname" "func_areaportal"
+}
+{
+"model" "*90"
+"target" "t47"
+"_minlight" ".18"
+"angle" "-1"
+"spawnflags" "0"
+"classname" "func_door"
+"speed" "120"
+}
+{
+"model" "*91"
+"target" "t46"
+"_minlight" ".18"
+"angle" "-1"
+"spawnflags" "8"
+"classname" "func_door"
+"speed" "120"
+}
+{
+"style" "11"
+"targetname" "t46"
+"classname" "func_areaportal"
+}
+{
+"model" "*92"
+"targetname" "t56"
+"classname" "func_explosive"
+"mass" "50"
+"target" "t115"
+}
+{
+"model" "*93"
+"targetname" "t55"
+"classname" "func_explosive"
+"mass" "50"
+"target" "t118"
+}
+{
+"model" "*94"
+"targetname" "t54"
+"classname" "func_explosive"
+"mass" "50"
+"target" "t117"
+}
+{
+"light" "70"
+"classname" "light"
+"origin" "-1936 752 116"
+}
+{
+"light" "70"
+"classname" "light"
+"origin" "-1948 888 116"
+}
+{
+"light" "70"
+"classname" "light"
+"origin" "-2028 888 116"
+}
+{
+"light" "70"
+"classname" "light"
+"origin" "-2080 888 116"
+}
+{
+"light" "70"
+"classname" "light"
+"origin" "-2080 832 116"
+}
+{
+"classname" "light"
+"light" "94"
+"origin" "-512 64 132"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "64 224 100"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "64 256 132"
+}
+{
+"origin" "-2032 1384 -332"
+"classname" "light"
+"light" "92"
+}
+{
+"classname" "trigger_relay"
+"delay" "7"
+"targetname" "t42"
+"target" "t44"
+"origin" "-750 1656 -438"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"delay" "6.5"
+"targetname" "t42"
+"target" "t43"
+"origin" "-776 1668 -438"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-876 1696 -410"
+}
+{
+"classname" "trigger_relay"
+"delay" "2"
+"targetname" "t42"
+"target" "t44"
+"origin" "-750 1684 -432"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"delay" "1"
+"targetname" "t42"
+"target" "t43"
+"origin" "-776 1698 -432"
+"spawnflags" "2048"
+}
+{
+"dmg" "5"
+"angle" "-2"
+"spawnflags" "2114"
+"classname" "target_laser"
+"origin" "-546 1760 -340"
+"targetname" "t44"
+}
+{
+"dmg" "5"
+"angle" "-2"
+"spawnflags" "2114"
+"classname" "target_laser"
+"origin" "-650 1760 -340"
+"targetname" "t43"
+}
+{
+"origin" "-546 1759 -404"
+"classname" "misc_insane"
+"spawnflags" "16"
+"angle" "270"
+"deathtarget" "marduk"
+}
+{
+"origin" "-650 1760 -412"
+"classname" "misc_insane"
+"spawnflags" "16"
+"angle" "270"
+"deathtarget" "marduk"
+}
+{
+"style" "12"
+"targetname" "t41"
+"classname" "func_areaportal"
+}
+{
+"model" "*95"
+"target" "t41"
+"spawnflags" "8"
+"angle" "-1"
+"_minlight" ".18"
+"classname" "func_door"
+"speed" "120"
+}
+{
+"model" "*96"
+"target" "t40"
+"spawnflags" "8"
+"_minlight" ".18"
+"angle" "-1"
+"classname" "func_door"
+"speed" "120"
+}
+{
+"style" "13"
+"targetname" "t40"
+"classname" "func_areaportal"
+}
+{
+"origin" "-1568 1396 -368"
+"classname" "light"
+"light" "195"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-1440 1396 -368"
+"_color" "1.000000 0.000000 0.000000"
+"light" "195"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "195"
+"classname" "light"
+"origin" "-1696 1396 -368"
+}
+{
+"angle" "90"
+"origin" "-1696 1436 -464"
+"spawnflags" "2064"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-1568 1436 -436"
+"angle" "90"
+"spawnflags" "16"
+"classname" "misc_insane"
+"deathtarget" "marduk"
+}
+{
+"origin" "-1696 1416 -340"
+"classname" "misc_insane"
+"spawnflags" "20"
+"angle" "90"
+}
+{
+"origin" "-1440 1436 -436"
+"angle" "90"
+"spawnflags" "20"
+"classname" "misc_insane"
+"deathtarget" "marduk"
+}
+{
+"model" "*97"
+"wait" "-1"
+"_minlight" ".2"
+"dmg" "15"
+"sounds" "3"
+"speed" "120"
+"angle" "-1"
+"classname" "func_door"
+"target" "t259"
+"targetname" "t275"
+"spawnflags" "16"
+}
+{
+"style" "14"
+"targetname" "t37"
+"classname" "func_areaportal"
+}
+{
+"model" "*98"
+"targetname" "t35"
+"target" "t34"
+"spawnflags" "1"
+"speed" "100"
+"classname" "func_train"
+}
+{
+"origin" "-28 -344 48"
+"target" "t34"
+"targetname" "t33"
+"classname" "path_corner"
+}
+{
+"origin" "88 -344 48"
+"target" "t33"
+"targetname" "t34"
+"classname" "path_corner"
+}
+{
+"targetname" "t63"
+"origin" "24 -408 168"
+"target" "t35"
+"spawnflags" "2050"
+"classname" "target_laser"
+"dmg" "7"
+}
+{
+"model" "*99"
+"spawnflags" "2055"
+"classname" "func_wall"
+"targetname" "t32"
+}
+{
+"model" "*100"
+"classname" "func_wall"
+"spawnflags" "2055"
+"targetname" "t32"
+}
+{
+"origin" "-584 1760 -268"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-546 1722 -268"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-508 1762 -268"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "110"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-546 1800 -268"
+}
+{
+"origin" "-688 1760 -268"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-650 1722 -268"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-612 1762 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "82"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "110"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-698 1800 -268"
+}
+{
+"origin" "-856 1640 -312"
+"light" "85"
+"classname" "light"
+}
+{
+"model" "*101"
+"classname" "trigger_multiple"
+"target" "t30"
+"angle" "270"
+}
+{
+"classname" "target_changelevel"
+"map" "hangar1$lab"
+"targetname" "t30"
+"origin" "16 240 112"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-624 -496 108"
+}
+{
+"origin" "-544 -568 108"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-516 -548 208"
+"classname" "light"
+"light" "100"
+}
+{
+"model" "*102"
+"origin" "-1290 -301 100"
+"_minlight" ".18"
+"classname" "func_door_rotating"
+"spawnflags" "2208"
+"distance" "64"
+"speed" "96"
+"targetname" "t27"
+}
+{
+"model" "*103"
+"classname" "func_explosive"
+"dmg" "15"
+"targetname" "t28"
+"mass" "50"
+"target" "t116"
+}
+{
+"model" "*104"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t28"
+"delay" "0"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-624 -368 108"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-456 -616 200"
+}
+{
+"model" "*105"
+"origin" "-1290 -285 100"
+"_minlight" ".18"
+"targetname" "t26"
+"speed" "96"
+"distance" "64"
+"spawnflags" "2208"
+"classname" "func_door_rotating"
+}
+{
+"wait" "8"
+"origin" "-1326 -274 98"
+"spawnflags" "2049"
+"target" "t26"
+"classname" "func_timer"
+"random" "7"
+}
+{
+"wait" "10"
+"origin" "-1326 -308 98"
+"spawnflags" "2049"
+"target" "t27"
+"random" "9"
+"classname" "func_timer"
+}
+{
+"spawnflags" "2048"
+"origin" "-1388 -332 104"
+"targetname" "t25"
+"angle" "-2"
+"sounds" "1"
+"classname" "target_splash"
+}
+{
+"wait" "5"
+"origin" "-1440 -396 112"
+"target" "t25"
+"spawnflags" "2049"
+"random" "4"
+"classname" "func_timer"
+}
+{
+"model" "*106"
+"origin" "-1388 -332 112"
+"dmg" "60"
+"speed" "350"
+"spawnflags" "2075"
+"classname" "func_rotating"
+"_minlight" ".3"
+}
+{
+"origin" "-1432 1852 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"origin" "92 -344 224"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-304 -572 224"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-24 688 236"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-24 880 236"
+"classname" "light"
+"light" "120"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"classname" "light"
+"light" "165"
+"origin" "-546 1760 -400"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"classname" "light"
+"light" "165"
+"origin" "-650 1760 -400"
+}
+{
+"origin" "-404 1740 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-404 1344 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-404 1600 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-404 1480 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-384 1536 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "130"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "125"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-520 1480 -288"
+}
+{
+"classname" "light"
+"light" "125"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-552 1512 -288"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-544 1408 -288"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-384 1408 -288"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-384 1664 -288"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1000 1680 -288"
+}
+{
+"classname" "light"
+"light" "130"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1000 1584 -288"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-904 1248 -384"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-464 1288 -276"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-464 1344 -276"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-464 1400 -276"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-464 1456 -276"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-464 1512 -276"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-464 1568 -276"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-464 1632 -276"
+}
+{
+"origin" "-464 1248 -276"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-832 1608 -276"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-832 1544 -276"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-832 1480 -276"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-832 1416 -276"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-832 1416 -324"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-832 1344 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-464 1292 -364"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-832 1368 -388"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-536 1072 -336"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-1248 1368 -388"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1248 1416 -388"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-832 1280 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-832 1216 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-832 1152 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-888 1088 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-952 1088 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1024 1088 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1096 1088 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1168 1088 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1248 1088 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1248 1160 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1248 1224 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1248 1288 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1248 1352 -388"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1248 1528 -252"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-648 1512 -288"
+"_color" "1.000000 0.000000 0.000000"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "-992 1160 -384"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1088 1160 -384"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-904 1160 -384"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1176 1344 -384"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2200 1288 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1960 1384 -336"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-1824 1600 -392"
+}
+{
+"origin" "-1696 1864 -252"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1952 1936 -392"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-1888 1600 -372"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-1960 1600 -356"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-2032 1600 -348"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-2032 1528 -340"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-2032 1464 -340"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "75"
+"classname" "light"
+"origin" "-1696 1864 -248"
+}
+{
+"classname" "light"
+"light" "75"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1440 1864 -248"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "120"
+"classname" "light"
+"origin" "-2120 1696 -256"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "120"
+"classname" "light"
+"origin" "-2120 1568 -256"
+}
+{
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2120 1824 -256"
+}
+{
+"origin" "-1688 1800 -268"
+"classname" "light"
+"light" "95"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-1652 1728 -268"
+"classname" "light"
+"light" "95"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-1568 1700 -268"
+"classname" "light"
+"light" "95"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-1476 1728 -268"
+"classname" "light"
+"light" "95"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-1440 1800 -268"
+"classname" "light"
+"light" "95"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-1432 1804 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"origin" "-1420 1760 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"origin" "-1364 1708 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"origin" "-1396 1732 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"origin" "-1312 1704 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"origin" "-1252 1708 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"origin" "-1220 1732 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"origin" "-1196 1760 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"origin" "-1184 1804 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"origin" "-1184 1852 -328"
+"classname" "light"
+"light" "74"
+}
+{
+"light" "95"
+"classname" "light"
+"origin" "-1184 1804 -268"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"light" "95"
+"classname" "light"
+"origin" "-1432 1804 -268"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"light" "95"
+"classname" "light"
+"origin" "-1220 1732 -268"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"light" "95"
+"classname" "light"
+"origin" "-1396 1732 -268"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"light" "95"
+"classname" "light"
+"origin" "-1312 1704 -268"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1976 1532 -268"
+}
+{
+"origin" "-1400 1600 -252"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-1568 1472 -284"
+"classname" "light"
+"light" "165"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-1696 1472 -284"
+"classname" "light"
+"light" "165"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-1696 1408 -444"
+"classname" "light"
+"light" "160"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1440 1864 -252"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-1440 1928 -408"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-464 1248 -332"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1248 1424 -308"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1248 1424 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1248 1464 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1248 1568 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1280 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1248 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1336 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1464 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1528 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1592 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1656 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1720 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1776 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1832 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1896 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1960 1600 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-2032 1848 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-2032 1784 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-2032 1720 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-2032 1656 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-2032 1592 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-2032 1528 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-2032 1472 -252"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-2032 1388 -352"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2032 1328 -332"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "160"
+"classname" "light"
+"origin" "-1568 1408 -444"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "165"
+"classname" "light"
+"origin" "-1440 1472 -284"
+}
+{
+"classname" "light"
+"light" "160"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1440 1408 -444"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1960 1288 -336"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-904 1344 -384"
+}
+{
+"origin" "-1152 448 220"
+"light" "110"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1960 1192 -336"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2008 1144 -336"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2032 1280 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2032 1216 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2080 1216 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2144 1216 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2208 1216 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2272 1216 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2336 1216 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2408 1216 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2408 1144 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2408 1072 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2408 1008 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2408 936 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2408 864 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2408 792 -332"
+}
+{
+"origin" "-1664 1120 -392"
+"classname" "light"
+"light" "130"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-1664 1120 56"
+}
+{
+"origin" "-536 856 -336"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-656 856 -336"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-2120 160 -336"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1976 160 -336"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1976 256 -336"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1976 352 -336"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2048 224 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2048 288 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2048 344 -332"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2048 416 -336"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2048 160 -332"
+}
+{
+"light" "92"
+"classname" "light"
+"origin" "-2048 80 -332"
+}
+{
+"spawnflags" "2048"
+"angle" "90"
+"origin" "-2008 480 53"
+"targetname" "t2"
+"classname" "monster_commander_body"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2296 1288 -336"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2392 1288 -336"
+}
+{
+"origin" "-2104 1384 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2480 1200 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2336 1104 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2336 1008 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-864 784 -392"
+}
+{
+"origin" "-864 784 56"
+"classname" "light"
+"light" "130"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2104 1144 -336"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2200 1144 -336"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2296 1144 -336"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2336 912 -336"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2336 816 -336"
+}
+{
+"origin" "-2480 1104 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2480 1008 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2480 912 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2592 552 -240"
+"_color" "1.000000 0.000000 0.000000"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-2048 -48 -392"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1664 1052 -324"
+"classname" "light"
+"light" "120"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-2184 664 -380"
+}
+{
+"origin" "-2320 664 -332"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1984 712 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1984 612 -312"
+}
+{
+"origin" "-1712 884 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1612 884 -312"
+}
+{
+"origin" "-1712 824 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1612 824 -312"
+}
+{
+"origin" "-1712 764 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1612 764 -312"
+}
+{
+"origin" "-1716 616 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1764 716 -312"
+}
+{
+"origin" "-1820 616 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1820 716 -312"
+}
+{
+"origin" "-1900 612 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1900 712 -312"
+}
+{
+"origin" "-2064 612 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-2064 712 -312"
+}
+{
+"origin" "-1612 944 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.015686 0.015686"
+"origin" "-1984 664 -308"
+"light" "85"
+"classname" "light"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-2048 -48 56"
+}
+{
+"_color" "1.000000 0.015686 0.015686"
+"classname" "light"
+"light" "85"
+"origin" "-1664 760 -308"
+}
+{
+"_color" "1.000000 0.015686 0.015686"
+"classname" "light"
+"light" "85"
+"origin" "-1776 664 -308"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1712 944 -312"
+}
+{
+"_color" "1.000000 0.015686 0.015686"
+"light" "85"
+"classname" "light"
+"origin" "-1664 968 -308"
+}
+{
+"origin" "-1660 656 -236"
+"_color" "1.000000 0.000000 0.000000"
+"light" "240"
+"classname" "light"
+}
+{
+"origin" "-1884 664 -236"
+"_color" "1.000000 0.000000 0.000000"
+"light" "240"
+"classname" "light"
+}
+{
+"origin" "-2080 664 -236"
+"_color" "1.000000 0.000000 0.000000"
+"light" "240"
+"classname" "light"
+}
+{
+"light" "70"
+"classname" "light"
+"origin" "-2080 752 116"
+}
+{
+"light" "82"
+"classname" "light"
+"origin" "-1860 840 136"
+}
+{
+"origin" "-1780 840 104"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-1664 1012 104"
+"classname" "light"
+"light" "130"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-1664 1092 252"
+}
+{
+"origin" "-1724 1088 268"
+"classname" "light"
+"light" "105"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1604 1088 268"
+}
+{
+"origin" "-1604 1160 268"
+"classname" "light"
+"light" "105"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1724 1160 268"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-1664 1052 184"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-1664 1052 252"
+}
+{
+"origin" "-1728 1136 -144"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-1600 1136 -144"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-1664 988 -324"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1664 972 136"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1664 912 136"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1744 840 136"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1664 840 136"
+"classname" "light"
+"light" "82"
+}
+{
+"origin" "-1960 840 136"
+"classname" "light"
+"light" "95"
+}
+{
+"origin" "-1912 840 136"
+"classname" "light"
+"light" "95"
+}
+{
+"origin" "-2008 840 136"
+"classname" "light"
+"light" "95"
+}
+{
+"origin" "-1768 1600 -408"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "-2408 704 -332"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-2408 536 -332"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-2408 440 -332"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-2408 344 -332"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-2312 344 -332"
+"classname" "light"
+"light" "92"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2336 512 -336"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-2240 416 -336"
+}
+{
+"origin" "-2480 544 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2480 416 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2480 320 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2432 272 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2336 272 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2240 272 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-2200 344 -332"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-2120 344 -332"
+"classname" "light"
+"light" "92"
+}
+{
+"origin" "-512 760 -332"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-440 1136 -332"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-576 760 -332"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-640 760 -332"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-720 760 -332"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-2144 416 -336"
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "150"
+"classname" "light"
+"origin" "-536 1168 -336"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-2448 664 -348"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-2048 20 -324"
+}
+{
+"classname" "light"
+"light" "240"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1664 864 -236"
+}
+{
+"model" "*107"
+"spawnflags" "0"
+"target" "t37"
+"classname" "func_door"
+"angle" "-1"
+"speed" "120"
+"sounds" "3"
+"dmg" "15"
+"_minlight" ".2"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-2048 88 136"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1888 224 136"
+}
+{
+"origin" "-2048 96 164"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-2048 96 220"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-2048 160 220"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-2048 224 220"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-1984 224 220"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-1920 224 220"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-1664 224 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-904 844 268"
+"classname" "light"
+"light" "115"
+}
+{
+"light" "115"
+"classname" "light"
+"origin" "-832 844 268"
+}
+{
+"light" "115"
+"classname" "light"
+"origin" "-904 724 268"
+}
+{
+"origin" "-832 724 268"
+"classname" "light"
+"light" "115"
+}
+{
+"classname" "light"
+"light" "74"
+"origin" "-796 784 252"
+}
+{
+"classname" "light"
+"light" "74"
+"origin" "-836 784 252"
+}
+{
+"classname" "light"
+"light" "74"
+"origin" "-796 784 184"
+}
+{
+"origin" "-880 720 -144"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-880 848 -144"
+"light" "120"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.022727 0.022727"
+"light" "150"
+"classname" "light"
+"origin" "-2104 352 208"
+}
+{
+"origin" "-2008 668 220"
+"classname" "light"
+"light" "85"
+}
+{
+"origin" "-2008 372 144"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-2132 426 148"
+"sounds" "1"
+"targetname" "mac2"
+"classname" "target_splash"
+}
+{
+"origin" "-1848 600 220"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.022727 0.022727"
+}
+{
+"origin" "-1848 424 220"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.022727 0.022727"
+}
+{
+"targetname" "t201"
+"spawnflags" "2048"
+"origin" "-2172 504 130"
+"random" "4"
+"target" "mac2"
+"classname" "func_timer"
+"wait" "5"
+}
+{
+"model" "*108"
+"origin" "-2132 425 136"
+"_minlight" ".18"
+"targetname" "mac2"
+"speed" "78"
+"distance" "64"
+"spawnflags" "162"
+"classname" "func_door_rotating"
+}
+{
+"model" "*109"
+"origin" "-1872 422 78"
+"_minlight" ".18"
+"distance" "-64"
+"speed" "96"
+"targetname" "mac1"
+"spawnflags" "32"
+"classname" "func_door_rotating"
+}
+{
+"targetname" "t201"
+"origin" "-1848 576 72"
+"target" "mac1"
+"random" "4"
+"spawnflags" "2048"
+"classname" "func_timer"
+"wait" "5"
+}
+{
+"origin" "-2080 688 116"
+"classname" "light"
+"light" "70"
+}
+{
+"origin" "-1868 888 116"
+"classname" "light"
+"light" "70"
+}
+{
+"origin" "-1896 792 116"
+"classname" "light"
+"light" "70"
+}
+{
+"origin" "-2008 736 136"
+"classname" "light"
+"light" "95"
+}
+{
+"_color" "1.000000 0.022727 0.022727"
+"light" "150"
+"classname" "light"
+"origin" "-1912 352 208"
+}
+{
+"_color" "1.000000 0.022727 0.022727"
+"light" "150"
+"classname" "light"
+"origin" "-2168 600 220"
+}
+{
+"origin" "-2168 424 220"
+"_color" "1.000000 0.022727 0.022727"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "86"
+"origin" "-1918 408 108"
+}
+{
+"origin" "-2106 422 156"
+"light" "86"
+"classname" "light"
+}
+{
+"origin" "-1968 424 16"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-2048 424 16"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-1968 512 -8"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-2048 512 -8"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-2008 608 216"
+"classname" "light"
+"light" "85"
+}
+{
+"light" "85"
+"classname" "light"
+"origin" "-2008 544 216"
+}
+{
+"light" "85"
+"classname" "light"
+"origin" "-2008 696 172"
+}
+{
+"light" "70"
+"classname" "light"
+"origin" "-1936 688 116"
+}
+{
+"light" "95"
+"classname" "light"
+"origin" "-2008 800 136"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-1836 840 104"
+}
+{
+"origin" "-2008 480 216"
+"classname" "light"
+"light" "85"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-1696 560 220"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1984 -64 -144"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-2112 -64 -144"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-796 784 112"
+}
+{
+"origin" "-1472 224 220"
+"light" "110"
+"classname" "light"
+}
+{
+"light" "88"
+"classname" "light"
+"origin" "-1520 136 92"
+}
+{
+"origin" "-1424 136 92"
+"classname" "light"
+"light" "88"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-1592 484 228"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-1592 572 228"
+}
+{
+"light" "96"
+"classname" "light"
+"origin" "-1696 400 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1792 224 220"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1152 432 112"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-8 688 164"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-8 880 164"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1152 368 112"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1728 224 220"
+}
+{
+"classname" "light"
+"light" "94"
+"origin" "-1904 224 164"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1600 224 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1536 224 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1472 320 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1472 384 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1472 448 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1472 512 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1472 576 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1408 576 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1344 576 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1280 576 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1216 576 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1152 576 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1152 512 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1088 64 220"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "-1184 -40 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "-1256 32 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "-1256 160 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "-1056 264 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"origin" "-2048 -20 252"
+"light" "76"
+"classname" "light"
+}
+{
+"origin" "-2048 20 252"
+"light" "76"
+"classname" "light"
+}
+{
+"origin" "-2048 20 184"
+"light" "76"
+"classname" "light"
+}
+{
+"origin" "-556 784 220"
+"light" "110"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-760 784 112"
+}
+{
+"origin" "-2108 -16 268"
+"classname" "light"
+"light" "115"
+}
+{
+"light" "115"
+"classname" "light"
+"origin" "-2108 -88 268"
+}
+{
+"origin" "-1988 -88 268"
+"classname" "light"
+"light" "115"
+}
+{
+"origin" "-536 608 212"
+"classname" "light"
+"light" "120"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-880 64 112"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-816 64 112"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "124 432 164"
+}
+{
+"origin" "-1152 256 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-1152 192 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-1152 128 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-1152 64 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-1792 224 172"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-1024 64 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-960 64 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-888 64 176"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-768 64 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-1056 -40 212"
+"classname" "light"
+"light" "175"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"origin" "-960 160 212"
+"light" "175"
+"classname" "light"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"origin" "-1468 -640 220"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-1468 -704 220"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-1468 -768 220"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-1216 -880 196"
+"classname" "light"
+"light" "115"
+}
+{
+"origin" "-1040 -880 196"
+"classname" "light"
+"light" "115"
+}
+{
+"origin" "-896 -744 196"
+"classname" "light"
+"light" "115"
+}
+{
+"origin" "-612 -368 208"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-716 -216 128"
+"light" "74"
+"classname" "light"
+}
+{
+"origin" "-96 48 200"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1212 -312 180"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1212 -384 180"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1212 -456 180"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1212 -520 180"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1212 -584 180"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1212 -648 180"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1188 -696 180"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1132 -696 180"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1076 -696 180"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1200 -428 216"
+"light" "140"
+"classname" "light"
+}
+{
+"origin" "-1272 -468 216"
+"light" "140"
+"classname" "light"
+}
+{
+"origin" "-1424 -468 216"
+"light" "140"
+"classname" "light"
+}
+{
+"origin" "-1352 -468 216"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1344 -712 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1344 -776 220"
+}
+{
+"origin" "-1064 -776 220"
+"light" "110"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1128 -776 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1192 -776 220"
+}
+{
+"origin" "-1000 -648 220"
+"light" "110"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1000 -712 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1000 -776 220"
+}
+{
+"origin" "-1344 -648 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-1000 -544 132"
+"light" "130"
+"classname" "light"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-1348 -340 72"
+}
+{
+"light" "56"
+"classname" "light"
+"origin" "-1308 -304 224"
+}
+{
+"classname" "light"
+"light" "56"
+"origin" "-1388 -304 224"
+}
+{
+"light" "56"
+"classname" "light"
+"origin" "-1308 -364 224"
+}
+{
+"classname" "light"
+"light" "56"
+"origin" "-1388 -364 224"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-92 -80 200"
+}
+{
+"origin" "-1000 -480 132"
+"light" "84"
+"classname" "light"
+}
+{
+"origin" "-1000 -416 132"
+"light" "84"
+"classname" "light"
+}
+{
+"origin" "-1000 -352 132"
+"light" "84"
+"classname" "light"
+}
+{
+"origin" "-1000 -288 132"
+"light" "84"
+"classname" "light"
+}
+{
+"origin" "-1000 -216 132"
+"light" "84"
+"classname" "light"
+}
+{
+"origin" "-936 -216 132"
+"light" "84"
+"classname" "light"
+}
+{
+"origin" "-872 -216 132"
+"light" "84"
+"classname" "light"
+}
+{
+"origin" "-800 -216 100"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-512 -216 220"
+"light" "110"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1000 -632 128"
+}
+{
+"classname" "light"
+"light" "84"
+"origin" "-976 -216 220"
+}
+{
+"classname" "light"
+"light" "84"
+"origin" "-896 -216 220"
+}
+{
+"classname" "light"
+"light" "84"
+"origin" "-832 -216 220"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1468 -576 220"
+}
+{
+"classname" "light"
+"light" "132"
+"origin" "-228 -564 68"
+}
+{
+"classname" "light"
+"light" "132"
+"origin" "88 -268 68"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-72 -348 216"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-224 -172 220"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "28 -80 200"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-92 -560 200"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "136 -192 200"
+}
+{
+"origin" "-208 168 200"
+"classname" "light"
+"light" "100"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-224 -488 212"
+}
+{
+"origin" "-228 -408 212"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-304 -404 216"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-380 -408 212"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-384 -488 212"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-72 -268 212"
+"light" "135"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "135"
+"origin" "8 -264 212"
+}
+{
+"origin" "-72 -420 212"
+"light" "135"
+"classname" "light"
+}
+{
+"origin" "8 -424 212"
+"light" "135"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-1496 -428 216"
+}
+{
+"origin" "-336 168 200"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "28 -560 200"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-224 -216 220"
+"light" "110"
+"classname" "light"
+}
+{
+"light" "140"
+"origin" "-1348 -256 104"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-304 -568 104"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "88 -344 104"
+"light" "130"
+"classname" "light"
+}
+{
+"light" "56"
+"classname" "light"
+"origin" "-304 -488 224"
+}
+{
+"light" "56"
+"classname" "light"
+"origin" "8 -344 224"
+}
+{
+"origin" "-152 -616 200"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-600 -256 148"
+}
+{
+"classname" "light"
+"light" "84"
+"origin" "-768 -216 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-704 -216 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-640 -216 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-576 -216 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1264 -776 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-448 -216 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-384 -216 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-320 -216 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-264 -216 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-224 -128 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-224 -64 220"
+}
+{
+"origin" "-1308 -240 224"
+"classname" "light"
+"light" "56"
+}
+{
+"origin" "-1388 -240 224"
+"light" "56"
+"classname" "light"
+}
+{
+"origin" "-536 480 212"
+"classname" "light"
+"light" "120"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"origin" "-716 -216 100"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-224 0 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-224 64 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-308 64 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-384 64 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-640 400 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-744 480 212"
+"classname" "light"
+"light" "120"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"origin" "-1808 224 112"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-640 200 112"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-704 64 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-576 64 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-640 64 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-640 128 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-640 192 132"
+"light" "94"
+"classname" "light"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-464 680 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-536 352 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "136 -496 200"
+}
+{
+"light" "115"
+"classname" "light"
+"origin" "-1988 -16 268"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-744 608 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-688 888 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-560 888 212"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"origin" "-1592 396 228"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-744 352 212"
+"classname" "light"
+"light" "120"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"origin" "-756 784 172"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-728 784 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-640 784 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-796 784 -348"
+"light" "130"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-1152 368 192"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-640 476 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-640 552 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-640 624 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-640 696 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-640 276 172"
+}
+{
+"classname" "light"
+"light" "74"
+"origin" "-892 784 252"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-480 784 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-404 784 220"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-320 784 220"
+}
+{
+"origin" "-640 312 220"
+"light" "110"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "-320 992 220"
+}
+{
+"origin" "-320 856 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-320 924 220"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-320 992 168"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-320 1088 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-216 896 212"
+"classname" "light"
+"light" "120"
+"_color" "0.989189 0.989189 1.000000"
+}
+{
+"model" "*110"
+"spawnflags" "8"
+"target" "t57"
+"sounds" "3"
+"speed" "120"
+"angle" "-1"
+"classname" "func_door"
+"_minlight" ".2"
+}
+{
+"origin" "-320 1152 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-320 1280 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-320 1344 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-256 1344 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-192 1344 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-128 1344 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "-64 1344 132"
+"light" "94"
+"classname" "light"
+}
+{
+"origin" "64 536 100"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "64 1344 132"
+"classname" "light"
+"light" "94"
+}
+{
+"light" "94"
+"classname" "light"
+"origin" "0 1344 132"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "64 520 180"
+}
+{
+"light" "94"
+"classname" "light"
+"origin" "64 1280 132"
+}
+{
+"light" "94"
+"classname" "light"
+"origin" "64 1216 132"
+}
+{
+"light" "94"
+"classname" "light"
+"origin" "64 1152 132"
+}
+{
+"light" "94"
+"classname" "light"
+"origin" "64 1088 132"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-464 64 96"
+}
+{
+"model" "*111"
+"target" "t278"
+"spawnflags" "2048"
+"_minlight" ".18"
+"classname" "func_button"
+"angle" "0"
+"speed" "75"
+"wait" "-1"
+"sounds" "1"
+"message" "Access granted to\nResearch Lab."
+}
+{
+"model" "*112"
+"targetname" "t279"
+"classname" "func_door"
+"angle" "-1"
+"sounds" "3"
+"speed" "160"
+"spawnflags" "2088"
+"_minlight" ".2"
+"target" "t255"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "64 952 240"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "64 896 248"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "64 832 248"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "64 768 248"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "64 704 248"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "64 640 180"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "64 640 240"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "64 936 112"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "208 716 112"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-456 64 24"
+}
+{
+"origin" "404 784 16"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "400 864 48"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "400 704 48"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "208 852 112"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "64 952 184"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "352 864 124"
+"classname" "light"
+"light" "130"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "240 680 260"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "240 896 260"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "440 696 116"
+}
+{
+"angle" "90"
+"origin" "64 504 40"
+"classname" "info_player_start"
+"targetname" "lstart"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "352 704 124"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-88 704 108"
+}
+{
+"origin" "240 784 260"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-24 368 236"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-24 432 236"
+"light" "120"
+"classname" "light"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-88 864 108"
+}
+{
+"origin" "-24 496 236"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "4 432 164"
+"classname" "light"
+"light" "90"
+}
+{
+"origin" "4 368 164"
+"classname" "light"
+"light" "90"
+}
+{
+"origin" "124 368 164"
+"light" "90"
+"classname" "light"
+}
+{
+"origin" "152 496 236"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "152 432 236"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "152 368 236"
+"classname" "light"
+"light" "120"
+}
+{
+"classname" "func_group"
+}
+{
+"model" "*113"
+"classname" "func_wall"
+}
+{
+"model" "*114"
+"spawnflags" "2048"
+"_minlight" ".18"
+"wait" "-1"
+"angle" "180"
+"classname" "func_button"
+"target" "t328"
+}
+{
+"origin" "-1471 -756 44"
+"light" "48"
+"classname" "light"
+}
+{
+"origin" "-1471 -732 44"
+"classname" "light"
+"light" "48"
+}
+{
+"model" "*115"
+"classname" "func_wall"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-188 -539 44"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-212 -539 44"
+}

--- a/stuff/mapfixes/baseq2/train.ent
+++ b/stuff/mapfixes/baseq2/train.ent
@@ -1,0 +1,6937 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Fixed spawnflags of DM-only weapon_supershotgun (1180)
+//
+// Was set to spawn in SP and co-op but is inaccessible due to
+// func_wall (1190).
+{
+"message" "Lost Station"
+"classname" "worldspawn"
+"spawnflags" "0"
+"sky" "unit1_"
+"sounds" "10"
+"nextmap" "fact3"
+}
+{
+"spawnflags" "2048"
+"origin" "-1720 -632 1032"
+"killtarget" "dullsign"
+"targetname" "t433"
+"classname" "trigger_relay"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "2048"
+"origin" "256 -600 112"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "2048"
+"origin" "256 -680 112"
+}
+{
+"classname" "item_health_small"
+"origin" "256 -720 112"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "2048"
+"origin" "256 -640 112"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "1024"
+"origin" "216 -720 112"
+}
+{
+"classname" "item_health_small"
+"origin" "256 -560 112"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "1024"
+"origin" "216 -560 112"
+}
+{
+"origin" "-752 -832 904"
+"classname" "monster_infantry"
+"angle" "90"
+"item" "ammo_bullets"
+}
+{
+"origin" "-624 -832 904"
+"angle" "90"
+"classname" "monster_infantry"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-848 -288 176"
+"spawnflags" "3584"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_bullets"
+"origin" "-848 -232 176"
+}
+{
+"classname" "weapon_grenadelauncher"
+"spawnflags" "1792"
+"origin" "-1328 760 192"
+}
+{
+"origin" "-96 -1952 864"
+"classname" "item_armor_jacket"
+"spawnflags" "3072"
+}
+{
+"classname" "trigger_relay"
+"target" "BLR"
+"targetname" "t444"
+"origin" "-1096 -272 244"
+}
+{
+"model" "*1"
+"classname" "trigger_once"
+"target" "t443"
+"targetname" "t444"
+}
+{
+"model" "*2"
+"origin" "-1088 -316 88"
+"classname" "func_train"
+"target" "t442"
+"noise" "world/mach1.wav"
+"spawnflags" "2048"
+"speed" "50"
+"_minlight" "0.4"
+"targetname" "t443"
+}
+{
+"classname" "path_corner"
+"target" "t441"
+"targetname" "t442"
+"origin" "-1120 -332 32"
+}
+{
+"classname" "path_corner"
+"targetname" "t441"
+"target" "t442"
+"origin" "-1120 -311 192"
+"wait" "-1"
+}
+{
+"targetname" "t269"
+"classname" "trigger_relay"
+"killtarget" "trigbut"
+"origin" "-828 -368 -126"
+"spawnflags" "2048"
+}
+{
+"item" "item_armor_shard"
+"classname" "monster_soldier_light"
+"origin" "-692 -772 116"
+"spawnflags" "769"
+"targetname" "t377"
+"angle" "270"
+}
+{
+"classname" "point_combat"
+"targetname" "t440"
+"origin" "-728 -1128 -24"
+}
+{
+"classname" "monster_soldier_light"
+"origin" "-692 -884 68"
+"spawnflags" "257"
+"targetname" "t377"
+"target" "t440"
+"angle" "270"
+}
+{
+"classname" "monster_soldier"
+"spawnflags" "769"
+"origin" "-1380 -944 -40"
+"angle" "45"
+}
+{
+"model" "*3"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-1508 568 -164"
+}
+{
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+"attenuation" "3"
+"origin" "-600 -728 -72"
+}
+{
+"targetname" "corner0"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+"attenuation" "3"
+"origin" "-536 -552 -104"
+}
+{
+"targetname" "corner8"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+"attenuation" "3"
+"origin" "8 -744 -584"
+}
+{
+"targetname" "corner7"
+"classname" "target_speaker"
+"volume" "0.6"
+"noise" "world/train2.wav"
+"attenuation" "3"
+"origin" "40 -744 -536"
+}
+{
+"targetname" "corner7"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+"attenuation" "3"
+"origin" "40 -536 -536"
+}
+{
+"targetname" "corner8"
+"classname" "target_speaker"
+"volume" "0.6"
+"noise" "world/train2.wav"
+"attenuation" "3"
+"origin" "8 -536 -584"
+}
+{
+"targetname" "close_out"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+"attenuation" "3"
+"origin" "8 -744 1080"
+}
+{
+"targetname" "corner6"
+"classname" "target_speaker"
+"volume" "0.6"
+"noise" "world/train2.wav"
+"attenuation" "3"
+"origin" "40 -744 1032"
+}
+{
+"targetname" "corner6"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+"attenuation" "3"
+"origin" "40 -536 1032"
+}
+{
+"targetname" "close_out"
+"classname" "target_speaker"
+"volume" "0.6"
+"noise" "world/train2.wav"
+"attenuation" "3"
+"origin" "8 -536 1080"
+}
+{
+"targetname" "open_in"
+"origin" "-1672 -744 1080"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+"attenuation" "3"
+}
+{
+"targetname" "corner3"
+"origin" "-1704 -744 1032"
+"classname" "target_speaker"
+"volume" "0.6"
+"noise" "world/train2.wav"
+"attenuation" "3"
+}
+{
+"targetname" "corner3"
+"origin" "-1704 -536 1032"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+"attenuation" "3"
+}
+{
+"targetname" "open_in"
+"origin" "-1672 -536 1080"
+"classname" "target_speaker"
+"volume" "0.6"
+"noise" "world/train2.wav"
+"attenuation" "3"
+}
+{
+"targetname" "corner1"
+"origin" "-1672 -744 -72"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+"attenuation" "3"
+}
+{
+"targetname" "corner2"
+"origin" "-1704 -744 -24"
+"classname" "target_speaker"
+"volume" "0.6"
+"noise" "world/train2.wav"
+"attenuation" "3"
+}
+{
+"targetname" "corner2"
+"origin" "-1704 -536 -24"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+"attenuation" "3"
+}
+{
+"targetname" "corner1"
+"origin" "-1672 -536 -72"
+"classname" "target_speaker"
+"volume" "0.6"
+"noise" "world/train2.wav"
+"attenuation" "3"
+}
+{
+"targetname" "corner9"
+"origin" "-520 -760 -584"
+"attenuation" "3"
+"classname" "target_speaker"
+"volume" "0.6"
+"noise" "world/train2.wav"
+}
+{
+"targetname" "corner0"
+"origin" "-536 -624 -144"
+"attenuation" "3"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+}
+{
+"targetname" "corner0B"
+"origin" "-600 -520 -72"
+"attenuation" "3"
+"classname" "target_speaker"
+"volume" "0.6"
+"noise" "world/train2.wav"
+}
+{
+"targetname" "corner9"
+"origin" "-520 -552 -584"
+"attenuation" "3"
+"noise" "world/train2.wav"
+"volume" "0.6"
+"classname" "target_speaker"
+}
+{
+"model" "*4"
+"origin" "420 388 -64"
+"speed" "290"
+"dmg" "10"
+"_minlight" "0.2"
+"team" "train1"
+"spawnflags" "1"
+"target" "t20"
+"classname" "func_train"
+}
+{
+"model" "*5"
+"origin" "36 388 -76"
+"noise" "world/train1.wav"
+"target" "t3"
+"team" "train1"
+"speed" "290"
+"dmg" "10"
+"spawnflags" "1"
+"classname" "func_train"
+"_minlight" "0.2"
+}
+{
+"spawnflags" "1"
+"classname" "func_timer"
+"random" "3"
+"wait" "8"
+"origin" "-1350 756 2"
+"target" "t439"
+}
+{
+"noise" "world/drip1.wav"
+"spawnflags" "0"
+"classname" "target_speaker"
+"attenuation" "2"
+"volume" "0.6"
+"origin" "-1330 774 2"
+"targetname" "t439"
+}
+{
+"noise" "world/drip3.wav"
+"spawnflags" "0"
+"classname" "target_speaker"
+"attenuation" "2"
+"volume" "0.7"
+"origin" "-1382 732 2"
+"targetname" "t438"
+}
+{
+"spawnflags" "1"
+"classname" "func_timer"
+"random" "4"
+"wait" "12"
+"origin" "-1350 724 2"
+"target" "t438"
+}
+{
+"classname" "info_player_deathmatch"
+"origin" "-616 -616 88"
+}
+{
+"model" "*6"
+"origin" "-772 -1526 916"
+"classname" "func_door_rotating"
+"spawnflags" "2048"
+"distance" "90"
+"message" "ACCESS DENIED\nDoor is opened elsewhere."
+"wait" "4"
+"speed" "40"
+"targetname" "access_panel"
+"_minlight" "0.2"
+}
+{
+"origin" "-1414 812 2"
+"volume" "0.3"
+"attenuation" "2"
+"classname" "target_speaker"
+"spawnflags" "0"
+"noise" "world/drip2.wav"
+"targetname" "t437"
+}
+{
+"origin" "-1382 804 2"
+"wait" "6"
+"random" "3"
+"classname" "func_timer"
+"spawnflags" "1"
+"target" "t437"
+}
+{
+"origin" "-1286 796 -30"
+"wait" "6"
+"random" "4"
+"target" "t435"
+"classname" "func_timer"
+"spawnflags" "1"
+"volume" "0.5"
+}
+{
+"origin" "-1266 814 -30"
+"volume" "0.5"
+"attenuation" "2"
+"targetname" "t435"
+"classname" "target_speaker"
+"spawnflags" "0"
+"noise" "world/drip1.wav"
+}
+{
+"_color" "1.000000 0.880000 0.192000"
+"classname" "light"
+"light" "80"
+"origin" "-1144 -1120 -104"
+}
+{
+"origin" "-1064 -1120 -104"
+"light" "80"
+"classname" "light"
+"_color" "1.000000 0.880000 0.192000"
+}
+{
+"model" "*7"
+"spawnflags" "2049"
+"target" "t433"
+"count" "13"
+"targetname" "goons1"
+"classname" "trigger_counter"
+}
+{
+"model" "*8"
+"targetname" "t433"
+"spawnflags" "2051"
+"classname" "func_wall"
+}
+{
+"model" "*9"
+"spawnflags" "0"
+"targetname" "dullsign"
+"classname" "func_wall"
+}
+{
+"light" "170"
+"angle" "90"
+"origin" "-912 -1182 -36"
+"classname" "light_mine2"
+}
+{
+"classname" "ammo_shells"
+"origin" "-1360 724 -60"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_slugs"
+"origin" "-1336 668 -60"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "2048"
+"origin" "-1864 918 178"
+"classname" "ammo_shells"
+}
+{
+"model" "*10"
+"classname" "func_button"
+"angle" "90"
+"_minlight" "0.8"
+"lip" "3"
+"target" "water_secret"
+"spawnflags" "2048"
+}
+{
+"model" "*11"
+"classname" "func_wall"
+"spawnflags" "2048"
+"_minlight" "0.2"
+}
+{
+"model" "*12"
+"classname" "func_wall"
+"spawnflags" "2048"
+"_minlight" "0.2"
+}
+{
+"origin" "-672 -616 688"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-624 -624 688"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-480 -848 888"
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "-528 -1488 872"
+"spawnflags" "1792"
+"classname" "weapon_shotgun"
+}
+{
+"origin" "-544 -1184 896"
+"classname" "info_player_deathmatch"
+}
+{
+"angle" "45"
+"origin" "-96 -1680 880"
+"targetname" "base3c"
+"classname" "info_player_coop"
+}
+{
+"angle" "90"
+"origin" "-112 -1736 880"
+"targetname" "base3c"
+"classname" "info_player_coop"
+}
+{
+"origin" "-128 -1800 880"
+"targetname" "base3c"
+"classname" "info_player_coop"
+}
+{
+"origin" "-1472 -528 816"
+"spawnflags" "1792"
+"classname" "weapon_grenadelauncher"
+}
+{
+"origin" "-1360 -528 816"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-1152 -528 824"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1440 -536 -328"
+"angle" "315"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1120 -976 -256"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-976 -752 -176"
+"noise" "world/amb2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"targetname" "hiss"
+"classname" "target_speaker"
+"spawnflags" "0"
+"noise" "world/steam2.wav"
+"origin" "-976 -752 -272"
+"attenuation" "2"
+"volume" "1"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb2.wav"
+"origin" "-676 -760 976"
+}
+{
+"targetname" "hiss2"
+"volume" "1"
+"attenuation" "2"
+"origin" "-700 -752 884"
+"noise" "world/steam2.wav"
+"spawnflags" "0"
+"classname" "target_speaker"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-996 -572 -256"
+}
+{
+"style" "1"
+"classname" "func_areaportal"
+"targetname" "t432"
+}
+{
+"origin" "424 416 -200"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "40 416 -200"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "336 368 -216"
+"light" "48"
+"classname" "light"
+}
+{
+"origin" "336 464 -216"
+"classname" "light"
+"light" "48"
+}
+{
+"origin" "-48 368 -216"
+"classname" "light"
+"light" "48"
+}
+{
+"origin" "-48 464 -216"
+"light" "48"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "72 552 -8"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-8 552 -8"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-8 216 -8"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "72 216 -8"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "456 216 -8"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "376 216 -8"
+}
+{
+"classname" "light"
+"light" "135"
+"origin" "104 392 -8"
+}
+{
+"light" "135"
+"classname" "light"
+"origin" "552 392 -8"
+}
+{
+"light" "135"
+"classname" "light"
+"origin" "456 392 -8"
+}
+{
+"light" "135"
+"classname" "light"
+"origin" "360 392 -8"
+}
+{
+"light" "160"
+"classname" "light"
+"origin" "224 392 -8"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "456 552 -8"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "376 552 -8"
+}
+{
+"light" "135"
+"classname" "light"
+"origin" "24 392 -8"
+}
+{
+"light" "135"
+"classname" "light"
+"origin" "-72 392 -8"
+}
+{
+"light" "135"
+"classname" "light"
+"origin" "-152 392 -8"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"origin" "-636 -640 808"
+"classname" "light"
+"light" "120"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"origin" "-508 -640 808"
+"classname" "light"
+"light" "120"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"origin" "-380 -640 808"
+"classname" "light"
+"light" "120"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-568 -640 744"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-632 -640 744"
+"classname" "light"
+"light" "120"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-504 -640 744"
+"_color" "1.000000 0.517647 0.223529"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-760 -640 712"
+"_color" "1.000000 0.517647 0.223529"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-888 -640 680"
+"_color" "1.000000 0.517647 0.223529"
+}
+{
+"model" "*13"
+"team" "door1"
+"lip" "12"
+"angle" "0"
+"speed" "100"
+"wait" "4"
+"sounds" "0"
+"classname" "func_door"
+"light" "64"
+"_minlight" "0.2"
+}
+{
+"model" "*14"
+"team" "door1"
+"lip" "12"
+"classname" "func_door"
+"sounds" "2"
+"wait" "4"
+"speed" "100"
+"angle" "180"
+"light" "64"
+"_minlight" "0.2"
+}
+{
+"model" "*15"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*16"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"classname" "info_player_intermission"
+"origin" "-1044 416 256"
+"angles" "20 135 0"
+}
+{
+"target" "t431"
+"targetname" "t430"
+"spawnflags" "2048"
+"classname" "point_combat"
+"origin" "-1664 1084 -64"
+}
+{
+"targetname" "t431"
+"classname" "point_combat"
+"origin" "-1656 320 140"
+"spawnflags" "2048"
+}
+{
+"origin" "-1088 -952 -272"
+"target" "t293"
+"targetname" "t239"
+"classname" "path_corner"
+}
+{
+"model" "*17"
+"spawnflags" "2048"
+"message" "This item must be activated to use it."
+"targetname" "t428"
+"classname" "trigger_once"
+}
+{
+"delay" "0.5"
+"killtarget" "redkeygate"
+"spawnflags" "2048"
+"origin" "-1584 976 184"
+"targetname" "rusty_gate"
+"classname" "trigger_relay"
+}
+{
+"model" "*18"
+"wait" "1"
+"targetname" "redkeygate"
+"target" "keyhole1"
+"spawnflags" "2048"
+"classname" "trigger_multiple"
+}
+{
+"origin" "-1164 -1172 -96"
+"light" "110"
+"classname" "light"
+"_color" "1.000000 0.880000 0.192000"
+}
+{
+"origin" "-1224 -1120 -104"
+"light" "80"
+"classname" "light"
+"_color" "1.000000 0.880000 0.192000"
+}
+{
+"origin" "-1304 -1120 -104"
+"light" "120"
+"classname" "light"
+"_color" "1.000000 0.880000 0.192000"
+}
+{
+"light" "115"
+"classname" "light"
+"origin" "-992 -1648 936"
+}
+{
+"light" "115"
+"classname" "light"
+"origin" "-992 -1520 936"
+}
+{
+"spawnflags" "1"
+"classname" "monster_parasite"
+"target" "t364"
+"origin" "-324 -714 -288"
+}
+{
+"model" "*19"
+"classname" "func_wall"
+"_minlight" "0.2"
+"spawnflags" "2048"
+}
+{
+"classname" "misc_teleporter_dest"
+"angle" "90"
+"targetname" "t427"
+"origin" "-1064 230 166"
+"spawnflags" "1792"
+}
+{
+"classname" "misc_teleporter"
+"spawnflags" "1792"
+"angle" "90"
+"target" "t426"
+"origin" "-1920 904 180"
+}
+{
+"classname" "misc_teleporter_dest"
+"origin" "-992 -536 824"
+"targetname" "t426"
+"angle" "270"
+"spawnflags" "1792"
+}
+{
+"classname" "misc_teleporter_dest"
+"origin" "-160 -536 824"
+"targetname" "t426"
+"angle" "270"
+"spawnflags" "1792"
+}
+{
+"classname" "misc_teleporter"
+"origin" "-384 -928 896"
+"target" "t427"
+"spawnflags" "1792"
+}
+{
+"classname" "target_secret"
+"targetname" "t425"
+"spawnflags" "2048"
+"origin" "-968 -1120 -248"
+}
+{
+"model" "*20"
+"classname" "trigger_once"
+"target" "t425"
+"message" "You have found a secret area."
+"spawnflags" "2048"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-720 -1424 960"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-760 -1424 960"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-752 -1384 960"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-736 -1408 960"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-672 -1408 960"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_slugs"
+"team" "ammoland"
+"origin" "-1360 712 184"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_rockets"
+"team" "ammoland"
+"origin" "-1272 680 184"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+"team" "ammoland"
+"origin" "-1240 752 184"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_cells"
+"team" "ammoland"
+"origin" "-1280 824 184"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+"team" "ammoland"
+"origin" "-1384 824 184"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_shells"
+"team" "ammoland"
+"origin" "-1416 744 184"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_shells"
+"origin" "-1632 1184 -64"
+}
+{
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+"origin" "-1672 1144 -64"
+}
+{
+"classname" "weapon_railgun"
+"spawnflags" "1792"
+"origin" "-888 -928 -440"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1792"
+"origin" "-384 -968 968"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_large"
+"origin" "-232 -920 888"
+}
+{
+"origin" "-1310 328 168"
+"angle" "180"
+"classname" "info_player_deathmatch"
+}
+{
+"model" "*21"
+"_minlight" "0.1"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-1400 440 -40"
+}
+{
+"classname" "weapon_machinegun"
+"spawnflags" "1792"
+"origin" "-1352 440 -40"
+}
+{
+"spawnflags" "2048"
+"origin" "-928 -392 -176"
+"classname" "item_armor_shard"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-888 -392 -176"
+"spawnflags" "2048"
+}
+{
+"light" "160"
+"classname" "light"
+"origin" "-952 -640 212"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-888 -640 212"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1280 -848 0"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1792"
+"origin" "-976 -1152 -256"
+"classname" "weapon_hyperblaster"
+}
+{
+"spawnflags" "1792"
+"origin" "-1024 -1152 -256"
+"classname" "ammo_cells"
+}
+{
+"classname" "item_health_large"
+"origin" "-972 -1084 -264"
+}
+{
+"origin" "-304 -416 -304"
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+}
+{
+"origin" "-304 -368 -304"
+"classname" "weapon_machinegun"
+"spawnflags" "1792"
+}
+{
+"origin" "-304 -464 -304"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-512 -256 -698"
+"_color" "1.000000 0.796078 0.003922"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-448 -256 -698"
+"_color" "1.000000 0.796078 0.003922"
+"light" "64"
+"classname" "light"
+}
+{
+"classname" "item_armor_shard"
+"origin" "104 -588 -1000"
+"spawnflags" "2048"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-944 -1856 888"
+"spawnflags" "2048"
+}
+{
+"origin" "-56 -1808 872"
+"angle" "45"
+"classname" "info_player_deathmatch"
+}
+{
+"spawnflags" "1"
+"item" "ammo_bullets"
+"classname" "monster_infantry"
+"angle" "270"
+"origin" "-897 -485 190"
+}
+{
+"spawnflags" "1792"
+"origin" "-1020 -1084 -264"
+"classname" "ammo_rockets"
+}
+{
+"model" "*22"
+"_minlight" "0.8"
+"target" "wallramp"
+"lip" "8"
+"angle" "0"
+"classname" "func_button"
+}
+{
+"model" "*23"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"model" "*24"
+"sounds" "2"
+"wait" "5"
+"spawnflags" "2049"
+"height" "684"
+"speed" "250"
+"classname" "func_plat"
+}
+{
+"origin" "-480 -280 -792"
+"classname" "weapon_supershotgun"
+"spawnflags" "1792"
+}
+{
+"origin" "-480 -232 -792"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"model" "*25"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-896 -896 -144"
+"spawnflags" "1792"
+"classname" "weapon_shotgun"
+}
+{
+"spawnflags" "1792"
+"origin" "-1152 560 -128"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-1568 768 -144"
+"classname" "ammo_slugs"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "1792"
+"origin" "-1088 896 -144"
+"classname" "ammo_cells"
+}
+{
+"model" "*26"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "-1056 -532 96"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"classname" "light"
+"light" "100"
+"spawnflags" "1792"
+"origin" "-1864 -640 728"
+}
+{
+"model" "*27"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"classname" "item_quad"
+"origin" "-1864 -640 680"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "2048"
+"classname" "item_silencer"
+"origin" "-216 -1112 952"
+}
+{
+"spawnflags" "2048"
+"classname" "weapon_machinegun"
+"origin" "-320 -976 888"
+}
+{
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+"origin" "-640 -1448 1168"
+}
+{
+"classname" "item_armor_combat"
+"origin" "-1008 -1840 944"
+"spawnflags" "1792"
+}
+{
+"classname" "item_armor_jacket"
+"spawnflags" "1792"
+"origin" "-640 -648 -1008"
+}
+{
+"classname" "info_player_deathmatch"
+"origin" "-313 -1245 -312"
+"angle" "180"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "-624 -1144 -24"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "270"
+"origin" "-1416 -896 -40"
+}
+{
+"origin" "-1520 1060 144"
+"spawnflags" "1792"
+"classname" "item_armor_combat"
+}
+{
+"model" "*28"
+"_minlight" "0.1"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "-1224 640 -64"
+"classname" "info_player_deathmatch"
+"angle" "315"
+}
+{
+"origin" "-1232 880 -64"
+"classname" "info_player_deathmatch"
+"angle" "45"
+}
+{
+"origin" "-1520 1144 144"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-980 284 68"
+"spawnflags" "1792"
+"classname" "ammo_rockets"
+}
+{
+"origin" "-1304 440 -40"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-912 716 -24"
+"angle" "135"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1944 744 184"
+"classname" "ammo_shells"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"origin" "-1328 772 -60"
+"classname" "ammo_shells"
+}
+{
+"team" "dm1"
+"origin" "-1340 836 32"
+"spawnflags" "1792"
+"classname" "item_health_mega"
+}
+{
+"origin" "-840 -436 184"
+"classname" "info_player_deathmatch"
+"angle" "180"
+}
+{
+"origin" "-680 -800 -24"
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "-1920 792 236"
+"spawnflags" "1792"
+"classname" "weapon_rocketlauncher"
+}
+{
+"model" "*29"
+"spawnflags" "1792"
+"speed" "200"
+"lip" "24"
+"classname" "func_plat"
+}
+{
+"model" "*30"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-232 -920 928"
+"classname" "item_power_shield"
+"spawnflags" "1792"
+}
+{
+"origin" "-32 -1272 984"
+"spawnflags" "1792"
+"classname" "item_invulnerability"
+}
+{
+"model" "*31"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-888 -256 -160"
+"spawnflags" "1792"
+"classname" "weapon_chaingun"
+}
+{
+"model" "*32"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"spawnflags" "1792"
+"origin" "-1056 -272 88"
+"target" "BLR"
+"classname" "trigger_always"
+}
+{
+"spawnflags" "1792"
+"origin" "-1520 904 160"
+"target" "rusty_gate"
+"classname" "trigger_always"
+}
+{
+"origin" "-648 -1384 1148"
+"angle" "180"
+"classname" "info_player_deathmatch"
+}
+{
+"model" "*33"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-848 -392 -176"
+}
+{
+"classname" "weapon_grenadelauncher"
+"spawnflags" "1792"
+"origin" "-1216 -928 96"
+}
+{
+"classname" "ammo_cells"
+"origin" "168 -712 112"
+"spawnflags" "1792"
+}
+{
+"classname" "weapon_bfg"
+"spawnflags" "1792"
+"origin" "152 -560 112"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "180"
+"origin" "238 -638 112"
+}
+{
+"origin" "-328 -1084 920"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-328 -1164 920"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-400 -1164 920"
+"classname" "light"
+"light" "110"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-512 -1076 928"
+}
+{
+"light" "135"
+"classname" "light"
+"origin" "-656 -844 984"
+}
+{
+"origin" "-544 -908 984"
+"classname" "light"
+"light" "110"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"light" "80"
+"classname" "light"
+"origin" "-480 -1204 888"
+}
+{
+"origin" "-352 -1204 888"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.156863 0.125490"
+}
+{
+"origin" "-408 -988 888"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.388235 0.239216"
+}
+{
+"origin" "-568 -1116 888"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.388235 0.239216"
+}
+{
+"origin" "-608 -1004 888"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.388235 0.239216"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"origin" "196 -544 128"
+"classname" "light"
+"light" "105"
+}
+{
+"origin" "196 -648 128"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"origin" "148 -640 64"
+"classname" "light"
+"light" "105"
+}
+{
+"model" "*34"
+"sounds" "2"
+"lip" "0"
+"spawnflags" "0"
+"wait" "1"
+"_minlight" "0.2"
+"speed" "150"
+"classname" "func_plat"
+}
+{
+"spawnflags" "2048"
+"origin" "-1344 756 -84"
+"targetname" "t424"
+"classname" "target_secret"
+}
+{
+"model" "*35"
+"spawnflags" "2048"
+"message" "You have found a secret area."
+"target" "t424"
+"classname" "trigger_once"
+}
+{
+"spawnflags" "2"
+"origin" "-978 -894 -14"
+"targetname" "Response_troops"
+"classname" "monster_flyer"
+"angle" "0"
+}
+{
+"spawnflags" "2"
+"origin" "-1026 -922 -14"
+"targetname" "Response_troops"
+"classname" "monster_flyer"
+"angle" "225"
+}
+{
+"spawnflags" "2"
+"origin" "-1022 -874 -14"
+"targetname" "Response_troops"
+"angle" "135"
+"classname" "monster_flyer"
+}
+{
+"spawnflags" "2"
+"origin" "-1136 548 124"
+"targetname" "Response_troops"
+"angle" "180"
+"classname" "monster_flyer"
+}
+{
+"spawnflags" "2"
+"origin" "-1324 1124 124"
+"targetname" "Response_troops"
+"angle" "180"
+"classname" "monster_flyer"
+}
+{
+"spawnflags" "2"
+"origin" "-1520 536 116"
+"targetname" "Response_troops"
+"angle" "180"
+"classname" "monster_flyer"
+}
+{
+"spawnflags" "2"
+"origin" "-640 -1352 1156"
+"targetname" "Response_troops"
+"classname" "monster_flyer"
+"angle" "180"
+}
+{
+"spawnflags" "2"
+"origin" "-640 -1308 1160"
+"targetname" "Response_troops"
+"angle" "180"
+"classname" "monster_flyer"
+}
+{
+"spawnflags" "2"
+"origin" "-640 -1444 1156"
+"targetname" "Response_troops"
+"angle" "180"
+"classname" "monster_flyer"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-764 -1132 984"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-752 -908 984"
+}
+{
+"origin" "-656 -908 984"
+"classname" "light"
+"light" "110"
+}
+{
+"target" "monster_soldier"
+"origin" "-744 -1112 900"
+"angle" "90"
+"targetname" "goons2"
+"classname" "target_spawner"
+}
+{
+"target" "monster_soldier"
+"origin" "-788 -1080 904"
+"angle" "90"
+"targetname" "goons2"
+"classname" "target_spawner"
+}
+{
+"light" "200"
+"classname" "light_mine2"
+"angle" "270"
+"origin" "-1343 366 244"
+}
+{
+"angle" "180"
+"light" "200"
+"classname" "light_mine2"
+"origin" "-1222 258 316"
+}
+{
+"light" "200"
+"classname" "light_mine2"
+"angle" "0"
+"origin" "-1466 257 316"
+}
+{
+"light" "200"
+"classname" "light_mine2"
+"angle" "270"
+"origin" "-1283 366 244"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"origin" "-926 -239 93"
+"target" "BLRguns"
+"targetname" "t423"
+}
+{
+"spawnflags" "2048"
+"classname" "target_help"
+"targetname" "t422"
+"message" "Locate a powerful weapon."
+"origin" "-216 -1832 896"
+}
+{
+"model" "*36"
+"spawnflags" "2048"
+"classname" "trigger_once"
+"target" "t422"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_body"
+"origin" "-96 -1952 904"
+}
+{
+"classname" "light"
+"light" "90"
+"origin" "-1048 -1664 960"
+"_color" "1.000000 0.517647 0.223529"
+}
+{
+"classname" "light"
+"light" "90"
+"origin" "-1048 -1792 960"
+"_color" "1.000000 0.517647 0.223529"
+}
+{
+"classname" "info_notnull"
+"targetname" "t419"
+"origin" "-728 -1416 884"
+}
+{
+"classname" "info_notnull"
+"targetname" "t421"
+"origin" "-728 -1392 884"
+}
+{
+"classname" "info_notnull"
+"targetname" "t420"
+"origin" "-752 -1392 884"
+}
+{
+"classname" "info_notnull"
+"targetname" "t418"
+"origin" "-752 -1416 884"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"origin" "98 -574 -832"
+"light" "120"
+"classname" "light"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "148 -640 -832"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"origin" "96 -708 -832"
+"classname" "light"
+"light" "120"
+}
+{
+"spawnflags" "2048"
+"origin" "-324 -360 -184"
+"targetname" "t417"
+"target" "t345"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-308 -384 -184"
+"killtarget" "lsecret"
+"targetname" "t416"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-324 -384 -184"
+"target" "t345"
+"targetname" "t416"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-308 -360 -184"
+"targetname" "t417"
+"killtarget" "hsecret"
+"classname" "trigger_relay"
+}
+{
+"origin" "-392 -976 992"
+"classname" "weapon_supershotgun"
+"spawnflags" "1792"
+}
+{
+"origin" "-296 -912 872"
+"spawnflags" "2064"
+"angle" "270"
+"classname" "misc_deadsoldier"
+}
+{
+"spawnflags" "2048"
+"origin" "-312 -984 976"
+"targetname" "t415"
+"classname" "target_secret"
+}
+{
+"model" "*37"
+"spawnflags" "2048"
+"message" "You have found a secret."
+"target" "t415"
+"classname" "trigger_once"
+}
+{
+"origin" "-1320 -848 -8"
+"classname" "item_armor_shard"
+}
+{
+"classname" "item_health_small"
+"origin" "104 -632 -1000"
+}
+{
+"origin" "-492 -508 -972"
+"spawnflags" "1"
+"classname" "monster_flipper"
+"angle" "270"
+}
+{
+"origin" "-448 -484 -972"
+"spawnflags" "1"
+"angle" "270"
+"classname" "monster_flipper"
+}
+{
+"origin" "-832 -244 64"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-876 -212 64"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-872 -260 48"
+"spawnflags" "2050"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "0 -1764 864"
+"classname" "item_armor_shard"
+}
+{
+"team" "dm1"
+"target" "t428"
+"spawnflags" "2048"
+"classname" "item_invulnerability"
+"origin" "-1340 836 -68"
+}
+{
+"origin" "-1404 984 184"
+"classname" "path_corner"
+"targetname" "t392"
+"target" "t393"
+"spawnflags" "2048"
+}
+{
+"origin" "-1584 272 184"
+"classname" "path_corner"
+"target" "t386"
+"targetname" "t400"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1640 376 184"
+"targetname" "t399"
+"target" "t400"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1600 544 184"
+"targetname" "t395"
+"target" "t396"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1464 592 184"
+"targetname" "t398"
+"target" "t399"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1448 504 184"
+"targetname" "t397"
+"target" "t398"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1520 496 184"
+"targetname" "t396"
+"target" "t397"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1616 696 184"
+"targetname" "t394"
+"target" "t395"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1536 1000 184"
+"targetname" "t393"
+"target" "t394"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1212 880 184"
+"targetname" "t391"
+"target" "t392"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1104 792 184"
+"targetname" "t390"
+"target" "t391"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1112 640 184"
+"targetname" "t389"
+"target" "t390"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1056 424 184"
+"targetname" "t388"
+"target" "t389"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1088 256 184"
+"targetname" "t387"
+"target" "t388"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1392 272 184"
+"targetname" "t386"
+"target" "t387"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1056 944 88"
+"targetname" "t385"
+"target" "t313"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1080 664 88"
+"targetname" "t384"
+"target" "t385"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1176 520 88"
+"targetname" "t383"
+"target" "t384"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1512 528 88"
+"targetname" "t382"
+"target" "t383"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1592 720 88"
+"targetname" "t381"
+"target" "t382"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1568 952 88"
+"targetname" "t380"
+"target" "t381"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1432 1032 88"
+"targetname" "t305"
+"target" "t380"
+"spawnflags" "2048"
+}
+{
+"origin" "-1000 -648 -360"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2048"
+"origin" "-906 -275 81"
+"target" "BLR"
+"targetname" "t379"
+"classname" "trigger_relay"
+"delay" "1"
+}
+{
+"origin" "-926 -218 97"
+"targetname" "t379"
+"delay" "1"
+"target" "BLRguns"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-679 -800 -62"
+"classname" "item_health"
+}
+{
+"origin" "-1256 -936 64"
+"targetname" "t378"
+"classname" "target_goal"
+"spawnflags" "2048"
+}
+{
+"model" "*38"
+"target" "t377"
+"classname" "trigger_once"
+}
+{
+"origin" "-676 -1116 -36"
+"targetname" "t376"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"origin" "-1408 704 -72"
+"classname" "item_health_large"
+}
+{
+"spawnflags" "2048"
+"origin" "-1292 676 -72"
+"classname" "item_health_large"
+}
+{
+"angle" "90"
+"targetname" "t347"
+"origin" "-1312 752 -144"
+"classname" "monster_flipper"
+}
+{
+"angle" "90"
+"targetname" "t347"
+"origin" "-1372 784 -152"
+"classname" "monster_flipper"
+}
+{
+"spawnflags" "2048"
+"origin" "-1300 836 -68"
+"classname" "item_armor_jacket"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-928 -392 -112"
+"spawnflags" "1792"
+}
+{
+"origin" "-888 -320 -152"
+"noise" "world/curnt2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"origin" "-1536 552 -88"
+"noise" "world/curnt2.wav"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"origin" "-1568 736 -88"
+"noise" "world/curnt2.wav"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"origin" "-1496 952 -88"
+"noise" "world/curnt2.wav"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"origin" "-1280 984 -88"
+"noise" "world/curnt2.wav"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"origin" "-1096 928 -88"
+"noise" "world/curnt2.wav"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"origin" "-1056 736 -88"
+"noise" "world/curnt2.wav"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"origin" "-1136 520 -88"
+"noise" "world/curnt2.wav"
+}
+{
+"noise" "world/curnt2.wav"
+"origin" "-1344 536 -88"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2560"
+"origin" "-1288 440 -72"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-1328 440 -72"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-1368 440 -72"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2560"
+"origin" "-1408 440 -72"
+"classname" "item_health_small"
+}
+{
+"origin" "-1336 776 216"
+"target" "t261"
+"classname" "monster_infantry"
+"spawnflags" "0"
+}
+{
+"item" "ammo_bullets"
+"target" "t258"
+"origin" "-1336 720 216"
+"classname" "monster_infantry"
+"spawnflags" "0"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1361 784 -50"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1368 784 -152"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1304 784 -152"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1304 720 -152"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"origin" "-1432 -536 256"
+"classname" "target_speaker"
+"noise" "world/short1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1448 -648 256"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-61 -1240 944"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-45 -1976 944"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"noise" "world/short1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "35 -1784 944"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "40 -1776 928"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"origin" "35 -1416 944"
+}
+{
+"targetname" "Response_troops"
+"origin" "-280 -1422 888"
+"spawnflags" "3"
+"angle" "180"
+"classname" "monster_infantry"
+}
+{
+"origin" "-1916 900 204"
+"message" "Resume previous mission."
+"targetname" "Response_troops"
+"classname" "target_help"
+}
+{
+"origin" "-1888 812 188"
+"targetname" "Response_troops"
+"classname" "target_goal"
+}
+{
+"model" "*39"
+"target" "t372"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"targetname" "t370"
+"classname" "point_combat"
+"origin" "-1672 320 140"
+"spawnflags" "2048"
+}
+{
+"target" "t430"
+"targetname" "t372"
+"origin" "-1516 1148 -52"
+"spawnflags" "0"
+"angle" "270"
+"classname" "monster_soldier_light"
+}
+{
+"targetname" "t372"
+"target" "t370"
+"origin" "-1660 924 0"
+"spawnflags" "0"
+"angle" "135"
+"classname" "monster_soldier_light"
+}
+{
+"targetname" "t372"
+"origin" "-1332 1168 -52"
+"spawnflags" "0"
+"angle" "225"
+"classname" "monster_soldier_light"
+}
+{
+"angle" "270"
+"spawnflags" "769"
+"classname" "monster_soldier"
+"origin" "-1316 -232 184"
+}
+{
+"origin" "-884 -236 -176"
+"target" "t269"
+"classname" "item_adrenaline"
+"spawnflags" "2048"
+}
+{
+"origin" "-1216 -928 4"
+"targetname" "t369"
+"classname" "info_notnull"
+"spawnflags" "2048"
+}
+{
+"origin" "-1216 -928 80"
+"_cone" "30"
+"light" "200"
+"target" "t369"
+"classname" "light"
+"spawnflags" "2048"
+}
+{
+"target" "t378"
+"origin" "-1216 -928 56"
+"classname" "key_red_key"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "270"
+"spawnflags" "0"
+"origin" "-744 -1320 896"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_cells"
+"origin" "-1944 744 224"
+}
+{
+"spawnflags" "1536"
+"classname" "item_health_large"
+"origin" "-1904 704 176"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_large"
+"origin" "-1944 704 176"
+}
+{
+"origin" "-1848 656 172"
+"_color" "1.000000 0.858268 0.279528"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1904 656 172"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.858268 0.279528"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1376 -200 168"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1384 16 168"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1376 -384 168"
+}
+{
+"classname" "path_corner"
+"targetname" "t365"
+"origin" "-332 -600 -304"
+"target" "t364"
+}
+{
+"classname" "path_corner"
+"targetname" "t364"
+"target" "t365"
+"origin" "-332 -904 -312"
+}
+{
+"origin" "-768 -1120 -464"
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.432000 0.268000"
+}
+{
+"origin" "-768 -1056 -464"
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.432000 0.268000"
+}
+{
+"origin" "-768 -992 -464"
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.432000 0.268000"
+}
+{
+"origin" "-768 -928 -464"
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.432000 0.268000"
+}
+{
+"origin" "-768 -864 -464"
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.432000 0.268000"
+}
+{
+"origin" "-768 -800 -464"
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.432000 0.268000"
+}
+{
+"_color" "1.000000 0.432000 0.268000"
+"light" "90"
+"classname" "light"
+"origin" "-768 -736 -464"
+}
+{
+"origin" "-792 -640 -464"
+"light" "90"
+"classname" "light"
+"_color" "1.000000 0.517647 0.223529"
+}
+{
+"origin" "-768 -1184 -464"
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.432000 0.268000"
+}
+{
+"origin" "-768 -1248 -464"
+"classname" "light"
+"light" "75"
+"_color" "1.000000 0.432000 0.268000"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-1024 -636 -228"
+}
+{
+"style" "2"
+"classname" "func_areaportal"
+"targetname" "t356"
+}
+{
+"style" "3"
+"classname" "func_areaportal"
+"targetname" "t355"
+}
+{
+"classname" "trigger_relay"
+"targetname" "close_out"
+"target" "t354"
+"origin" "-88 -664 824"
+}
+{
+"classname" "trigger_relay"
+"targetname" "open_in"
+"target" "t353"
+"origin" "-1768 -696 824"
+}
+{
+"origin" "-760 -680 888"
+"classname" "trigger_relay"
+"targetname" "close_in"
+"delay" "4"
+"target" "t354"
+}
+{
+"classname" "trigger_relay"
+"targetname" "close_in"
+"target" "t353"
+"origin" "-744 -664 824"
+}
+{
+"origin" "-848 -760 832"
+"classname" "path_corner"
+"targetname" "t151"
+"target" "t352"
+"pathtarget" "close_in"
+}
+{
+"model" "*40"
+"sounds" "4"
+"angle" "270"
+"classname" "func_door"
+"team" "in"
+"targetname" "t353"
+"spawnflags" "44"
+"speed" "100"
+"target" "t355"
+"_minlight" "0.2"
+}
+{
+"model" "*41"
+"angle" "90"
+"classname" "func_door"
+"team" "in"
+"targetname" "t353"
+"spawnflags" "44"
+"speed" "100"
+"target" "t355"
+"_minlight" "0.2"
+}
+{
+"model" "*42"
+"sounds" "4"
+"classname" "func_door"
+"angle" "270"
+"team" "out"
+"targetname" "t354"
+"target" "t356"
+"spawnflags" "32"
+}
+{
+"model" "*43"
+"classname" "func_door"
+"angle" "90"
+"team" "out"
+"targetname" "t354"
+"target" "t356"
+"spawnflags" "32"
+}
+{
+"classname" "path_corner"
+"origin" "-292 -1399 867"
+"targetname" "t351"
+"target" "t244"
+}
+{
+"origin" "-225 -1433 867"
+"classname" "path_corner"
+"targetname" "t350"
+"target" "t351"
+}
+{
+"origin" "-632 -1456 864"
+"classname" "path_corner"
+"targetname" "t349"
+"target" "t244"
+}
+{
+"classname" "item_health_small"
+"origin" "-746 -560 88"
+}
+{
+"classname" "item_health_small"
+"origin" "-712 -560 88"
+}
+{
+"classname" "item_health_small"
+"origin" "-780 -560 88"
+}
+{
+"style" "4"
+"classname" "func_areaportal"
+"targetname" "t348"
+}
+{
+"model" "*44"
+"classname" "func_door"
+"angle" "90"
+"team" "sgundoor"
+"speed" "100"
+"sounds" "2"
+"wait" "3"
+"spawnflags" "12"
+"target" "t348"
+"_minlight" "0.2"
+}
+{
+"model" "*45"
+"classname" "func_door"
+"angle" "270"
+"team" "sgundoor"
+"speed" "100"
+"sounds" "2"
+"wait" "3"
+"spawnflags" "12"
+"target" "t348"
+"_minlight" "0.2"
+}
+{
+"model" "*46"
+"wait" "-1"
+"health" "5"
+"classname" "func_door"
+"angle" "-2"
+"spawnflags" "2056"
+"speed" "50"
+"sounds" "2"
+"lip" "12"
+"_minlight" "0.2"
+"target" "t347"
+}
+{
+"origin" "-1348 108 152"
+"classname" "path_corner"
+"target" "t346"
+"targetname" "t254"
+}
+{
+"classname" "monster_infantry"
+"target" "t266"
+"angle" "180"
+"origin" "-1328 248 172"
+"spawnflags" "1"
+}
+{
+"origin" "-976 -1008 8"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1016 -640 212"
+"classname" "light"
+"light" "160"
+}
+{
+"origin" "-1064 -640 212"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-296 -888 -292"
+"classname" "item_health"
+}
+{
+"spawnflags" "1536"
+"origin" "-292 -620 -292"
+"classname" "item_health"
+}
+{
+"origin" "-292 -580 -292"
+"classname" "item_health"
+}
+{
+"message" "You have found a secret area."
+"spawnflags" "2048"
+"origin" "-308 -408 -184"
+"targetname" "t345"
+"classname" "target_secret"
+}
+{
+"model" "*47"
+"spawnflags" "2048"
+"targetname" "hsecret"
+"target" "t416"
+"message" "You have found a secret area."
+"classname" "trigger_once"
+}
+{
+"spawnflags" "2048"
+"origin" "-864 -360 -172"
+"targetname" "t343"
+"classname" "target_secret"
+}
+{
+"model" "*48"
+"spawnflags" "2048"
+"message" "You have found a secret area."
+"target" "t343"
+"classname" "trigger_once"
+}
+{
+"style" "5"
+"targetname" "t342"
+"classname" "func_areaportal"
+}
+{
+"model" "*49"
+"_minlight" "0.2"
+"sounds" "0"
+"team" "door4"
+"wait" "4"
+"speed" "100"
+"angle" "90"
+"classname" "func_door"
+"lip" "12"
+}
+{
+"model" "*50"
+"_minlight" "0.2"
+"classname" "func_door"
+"angle" "270"
+"speed" "100"
+"wait" "4"
+"team" "door4"
+"sounds" "2"
+"lip" "12"
+}
+{
+"spawnflags" "2048"
+"origin" "-760 -888 952"
+"classname" "ammo_bullets"
+}
+{
+"spawnflags" "1792"
+"origin" "-944 -1856 928"
+"classname" "ammo_rockets"
+}
+{
+"spawnflags" "2048"
+"origin" "-952 -1408 916"
+"message" "You have found a secret area."
+"targetname" "t341"
+"classname" "target_secret"
+}
+{
+"model" "*51"
+"spawnflags" "2048"
+"target" "t341"
+"classname" "trigger_once"
+}
+{
+"origin" "100 -676 -1000"
+"classname" "item_health_small"
+}
+{
+"origin" "62 -632 -1000"
+"classname" "ammo_grenades"
+}
+{
+"spawnflags" "1792"
+"origin" "104 -588 -952"
+"classname" "ammo_rockets"
+}
+{
+"spawnflags" "1024"
+"origin" "-456 -636 -1008"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-384 -576 -828"
+"_minlight" "0.2"
+"spawnflags" "2080"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "0 -1648 864"
+"classname" "ammo_shells"
+}
+{
+"origin" "16 -1696 848"
+"angle" "180"
+"spawnflags" "2064"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-496 -1088 -288"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-258 -992 -234"
+"angle" "180"
+"classname" "light_mine2"
+}
+{
+"origin" "-258 -544 -234"
+"classname" "light_mine2"
+"angle" "180"
+}
+{
+"origin" "-258 -1184 -234"
+"angle" "180"
+"classname" "light_mine2"
+}
+{
+"light" "200"
+"angle" "0"
+"classname" "light_mine2"
+"origin" "-1470 -1088 -190"
+}
+{
+"light" "175"
+"angle" "0"
+"classname" "light_mine2"
+"origin" "-1470 -1088 2"
+}
+{
+"light" "175"
+"origin" "-1370 -1182 2"
+"classname" "light_mine2"
+}
+{
+"light" "175"
+"angle" "0"
+"origin" "-1470 -960 2"
+"classname" "light_mine2"
+}
+{
+"light" "200"
+"angle" "90"
+"origin" "-1370 -1182 -190"
+"classname" "light_mine2"
+}
+{
+"light" "170"
+"angle" "90"
+"origin" "-810 -1182 -4"
+"classname" "light_mine2"
+}
+{
+"light" "170"
+"angle" "90"
+"origin" "-682 -1182 28"
+"classname" "light_mine2"
+}
+{
+"light" "175"
+"angle" "180"
+"origin" "-578 -1120 28"
+"classname" "light_mine2"
+}
+{
+"light" "175"
+"angle" "180"
+"origin" "-578 -960 116"
+"classname" "light_mine2"
+}
+{
+"light" "175"
+"angle" "180"
+"origin" "-578 -832 188"
+"classname" "light_mine2"
+}
+{
+"light" "200"
+"angle" "0"
+"origin" "-1470 -960 -190"
+"classname" "light_mine2"
+}
+{
+"origin" "-864 -928 -440"
+"light" "64"
+"classname" "light"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1364 -848 -22"
+"spawnflags" "1024"
+}
+{
+"model" "*52"
+"targetname" "rusty_gate"
+"spawnflags" "2051"
+"classname" "func_wall"
+}
+{
+"origin" "-1876 740 176"
+"targetname" "t337"
+"classname" "point_combat"
+}
+{
+"origin" "-1872 872 192"
+"target" "t337"
+"spawnflags" "3"
+"angle" "270"
+"targetname" "rusty_gate"
+"classname" "monster_infantry"
+}
+{
+"origin" "-1952 812 192"
+"spawnflags" "2"
+"angle" "315"
+"targetname" "rusty_gate"
+"classname" "monster_infantry"
+}
+{
+"origin" "-1920 856 160"
+"targetname" "t336"
+"classname" "info_notnull"
+}
+{
+"origin" "-1920 856 268"
+"_cone" "25"
+"target" "t336"
+"classname" "light"
+}
+{
+"light" "150"
+"origin" "-1336 612 280"
+"_color" "0.000000 1.000000 1.000000"
+"classname" "light"
+}
+{
+"light" "150"
+"origin" "-1464 756 264"
+"_color" "0.000000 1.000000 1.000000"
+"classname" "light"
+}
+{
+"light" "150"
+"origin" "-1336 868 272"
+"_color" "0.000000 1.000000 1.000000"
+"classname" "light"
+}
+{
+"light" "150"
+"origin" "-1208 756 272"
+"_color" "0.000000 1.000000 1.000000"
+"classname" "light"
+}
+{
+"light" "200"
+"_cone" "15"
+"origin" "-1376 752 276"
+"target" "t334"
+"_color" "0.343874 0.707510 1.000000"
+"classname" "light"
+}
+{
+"origin" "-1080 -208 64"
+"classname" "item_health"
+}
+{
+"origin" "-1048 -1152 960"
+"light" "90"
+"classname" "light"
+"_color" "1.000000 0.517647 0.223529"
+}
+{
+"classname" "light"
+"light" "90"
+"origin" "-1048 -1280 960"
+"_color" "1.000000 0.517647 0.223529"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-64 -1664 984"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-48 -1536 984"
+}
+{
+"light" "175\"
+"classname" "light"
+"origin" "-1656 -640 944"
+"angle" "-2"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "175\"
+"classname" "light"
+"origin" "-1528 -640 944"
+"angle" "-2"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"classname" "light"
+"light" "150"
+"origin" "-896 -632 -384"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"light" "150"
+"classname" "light"
+"origin" "-1176 -640 -208"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"light" "175"
+"classname" "light"
+"origin" "-920 -632 -328"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"classname" "light"
+"light" "175"
+"origin" "-1560 -640 -208"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"light" "175"
+"classname" "light"
+"origin" "-1432 -640 -208"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"classname" "light"
+"light" "175"
+"origin" "-1304 -640 -208"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"light" "175"
+"classname" "light"
+"origin" "-1176 -640 -208"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"light" "130"
+"classname" "light"
+"origin" "-1432 -640 -336"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"classname" "light"
+"light" "130"
+"origin" "-1304 -640 -336"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"light" "130"
+"classname" "light"
+"origin" "-1176 -640 -336"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-596 -640 -664"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-508 -640 -664"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-124 -640 -664"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-252 -640 -664"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-184 -640 936"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"origin" "-380 -640 936"
+"classname" "light"
+"light" "175"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-380 -640 -664"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-504 -640 944"
+"classname" "light"
+"light" "175"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-632 -640 944"
+"classname" "light"
+"light" "175"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-760 -640 944"
+"classname" "light"
+"light" "175"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-888 -640 944"
+"classname" "light"
+"light" "175"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-748 -640 808"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-184 -640 808"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-888 -640 808"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1020 -640 808"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1144 -640 808"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1272 -640 808"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-1404 -640 808"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-608 -1408 960"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-544 -1408 960"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-480 -1408 960"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-416 -1408 960"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-352 -1408 960"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-288 -1408 960"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "90"
+"classname" "light"
+"origin" "-224 -1408 960"
+}
+{
+"origin" "-720 -1376 960"
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.929412 0.435294"
+}
+{
+"origin" "-64 -1416 960"
+"classname" "light"
+"light" "125"
+"_color" "1.000000 0.929412 0.435294"
+}
+{
+"origin" "-1288 616 4"
+"classname" "info_notnull"
+"targetname" "t320"
+}
+{
+"classname" "info_notnull"
+"origin" "-1288 888 4"
+"targetname" "t328"
+}
+{
+"classname" "info_notnull"
+"origin" "-1384 616 4"
+"targetname" "t322"
+}
+{
+"classname" "info_notnull"
+"origin" "-1336 616 4"
+"targetname" "t321"
+}
+{
+"classname" "info_notnull"
+"origin" "-1184 664 4"
+"targetname" "t319"
+}
+{
+"classname" "info_notnull"
+"origin" "-1384 888 4"
+"targetname" "t326"
+}
+{
+"classname" "info_notnull"
+"origin" "-1336 888 4"
+"targetname" "t327"
+}
+{
+"classname" "info_notnull"
+"origin" "-1184 840 4"
+"targetname" "t329"
+}
+{
+"classname" "info_notnull"
+"origin" "-1472 760 4"
+"targetname" "t324"
+}
+{
+"classname" "info_notnull"
+"origin" "-1472 712 4"
+"targetname" "t323"
+}
+{
+"classname" "info_notnull"
+"origin" "-1472 808 4"
+"targetname" "t325"
+}
+{
+"classname" "item_health_small"
+"origin" "-1384 1200 -16"
+}
+{
+"classname" "item_health_small"
+"origin" "-880 824 -24"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-888 784 -16"
+}
+{
+"classname" "item_health_small"
+"origin" "-1280 1200 -24"
+}
+{
+"origin" "-1224 1032 88"
+"classname" "path_corner"
+"target" "t305"
+"targetname" "t313"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_flyer"
+"origin" "-1176 1032 88"
+"angle" "180"
+"target" "t313"
+"spawnflags" "0"
+}
+{
+"target" "t391"
+"classname" "monster_flyer"
+"origin" "-1220 968 208"
+"angle" "180"
+"spawnflags" "0"
+}
+{
+"origin" "-1380 -316 184"
+"classname" "monster_soldier"
+"spawnflags" "257"
+"angle" "270"
+}
+{
+"spawnflags" "1"
+"classname" "monster_soldier"
+"angle" "0"
+"origin" "-1284 -936 12"
+}
+{
+"classname" "path_corner"
+"origin" "-896 -804 -256"
+"target" "t294"
+"targetname" "t295"
+}
+{
+"target" "t295"
+"origin" "-1080 -796 -272"
+"classname" "path_corner"
+"targetname" "t239"
+}
+{
+"angle" "135"
+"origin" "-968 -936 -240"
+"classname" "monster_infantry"
+"spawnflags" "256"
+"target" "t293"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-896 -896 -192"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2080"
+"origin" "-1760 -592 -368"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t291"
+"target" "t292"
+"origin" "-280 -664 -888"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t290"
+"target" "t291"
+"origin" "-184 -680 -888"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t289"
+"target" "t290"
+"origin" "-200 -616 -888"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t288"
+"target" "t289"
+"origin" "-328 -664 -888"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t292"
+"target" "t287"
+"origin" "-104 -600 -888"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"origin" "-232 -664 -888"
+"targetname" "t285"
+"target" "t286"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"origin" "-424 -600 -888"
+"targetname" "t284"
+"target" "t285"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"origin" "-600 -648 -888"
+"targetname" "t284"
+"target" "t288"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"origin" "-600 -600 -888"
+"targetname" "t283"
+"target" "t284"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"origin" "-472 -696 -888"
+"targetname" "t282"
+"target" "t283"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"origin" "-296 -616 -888"
+"targetname" "t281"
+"target" "t282"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"origin" "-88 -696 -888"
+"targetname" "t280"
+"target" "t281"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"origin" "40 -632 -888"
+"targetname" "t279"
+"target" "t280"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"origin" "56 -680 -888"
+"target" "t279"
+"targetname" "t287"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"origin" "-56 -600 -888"
+"targetname" "t286"
+"target" "t287"
+}
+{
+"classname" "monster_flipper"
+"origin" "-144 -624 -872"
+"target" "t290"
+}
+{
+"classname" "monster_flipper"
+"origin" "-32 -656 -872"
+"target" "t279"
+}
+{
+"spawnflags" "2048"
+"origin" "-32 -1272 916"
+"targetname" "t278"
+"classname" "info_notnull"
+}
+{
+"style" "32"
+"spawnflags" "2048"
+"targetname" "t338"
+"origin" "-32 -1272 1048"
+"_cone" "15"
+"target" "t278"
+"classname" "light"
+}
+{
+"origin" "-1408 -1088 -56"
+"targetname" "t224"
+"target" "t225"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_soldier"
+"target" "t249"
+"angle" "270"
+"origin" "-1352 -1056 -4"
+}
+{
+"targetname" "t377"
+"spawnflags" "1"
+"target" "t376"
+"origin" "-612 -880 68"
+"classname" "monster_soldier_light"
+"angle" "270"
+}
+{
+"spawnflags" "1792"
+"origin" "-1280 -848 48"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-1424 -880 -40"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1792"
+"origin" "-888 -392 -112"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-848 -232 216"
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "1792"
+"origin" "-848 -288 224"
+"classname" "ammo_shells"
+}
+{
+"origin" "-1088 -472 152"
+"targetname" "t277"
+"classname" "point_combat"
+}
+{
+"origin" "-1232 -856 28"
+"angle" "0"
+"classname" "monster_soldier"
+"spawnflags" "769"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"light" "80"
+"classname" "light"
+"origin" "-660 -640 -960"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"origin" "-660 -640 -832"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"origin" "-660 -640 -704"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"origin" "-660 -640 -576"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"light" "100"
+"classname" "light"
+"origin" "-660 -640 -448"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-856 -1856 888"
+}
+{
+"origin" "-896 -1856 888"
+"classname" "ammo_shells"
+}
+{
+"spawnflags" "1024"
+"origin" "-480 -1064 904"
+"classname" "item_health_small"
+}
+{
+"origin" "-480 -1016 904"
+"classname" "item_health_small"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.854902 0.278431"
+"origin" "40 -1408 960"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.854902 0.278431"
+"origin" "40 -1408 944"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.854902 0.278431"
+"origin" "40 -1408 928"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.854902 0.278431"
+"origin" "40 -1408 912"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.854902 0.278431"
+"origin" "40 -1792 960"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.854902 0.278431"
+"origin" "40 -1792 928"
+"_style" "10"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.854902 0.278431"
+"origin" "40 -1792 912"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.854902 0.278431"
+"origin" "-56 -1984 944"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.854902 0.278431"
+"origin" "-56 -1984 928"
+}
+{
+"origin" "-56 -1232 944"
+"_color" "1.000000 0.854902 0.278431"
+"light" "90"
+"classname" "light"
+}
+{
+"origin" "-56 -1232 928"
+"_color" "1.000000 0.854902 0.278431"
+"light" "90"
+"classname" "light"
+}
+{
+"origin" "-56 -1232 912"
+"_color" "1.000000 0.854902 0.278431"
+"light" "90"
+"classname" "light"
+}
+{
+"origin" "-56 -1232 960"
+"_color" "1.000000 0.854902 0.278431"
+"light" "90"
+"classname" "light"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-736 -832 -64"
+}
+{
+"classname" "item_health"
+"origin" "-596 -788 -64"
+}
+{
+"classname" "ammo_grenades"
+"origin" "-722 -799 -62"
+}
+{
+"classname" "item_health"
+"origin" "-816 -816 -464"
+}
+{
+"classname" "item_health"
+"origin" "-888 -928 -464"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_shells"
+"origin" "-1648 -688 -512"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-1696 -688 -528"
+}
+{
+"classname" "item_health_small"
+"origin" "-1792 -672 -528"
+}
+{
+"classname" "item_health"
+"origin" "-1680 -576 -528"
+}
+{
+"origin" "-1536 -640 -496"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-1664 -640 -528"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_infantry"
+"angle" "90"
+"targetname" "Response_troops"
+"spawnflags" "3"
+"origin" "-66 -1596 884"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_infantry"
+"targetname" "goons1"
+"angle" "90"
+"origin" "-504 -1128 904"
+"spawnflags" "3"
+}
+{
+"classname" "item_health"
+"origin" "24 -1256 864"
+}
+{
+"classname" "ammo_shells"
+"origin" "-96 -1256 864"
+"spawnflags" "0"
+}
+{
+"spawnflags" "1536"
+"classname" "ammo_shells"
+"origin" "-104 -1296 864"
+}
+{
+"spawnflags" "2048"
+"classname" "weapon_shotgun"
+"origin" "-32 -1272 936"
+}
+{
+"classname" "item_health_small"
+"origin" "-1024 -1608 888"
+}
+{
+"classname" "item_health_small"
+"origin" "-1024 -1552 888"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1024 -1504 888"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1024 -1448 888"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1024 -1392 888"
+}
+{
+"spawnflags" "2048"
+"classname" "item_breather"
+"origin" "-1004 -1843 902"
+}
+{
+"origin" "-1184 840 -76"
+"light" "200"
+"classname" "light"
+"_cone" "25"
+"target" "t329"
+}
+{
+"origin" "-1288 888 -76"
+"light" "200"
+"classname" "light"
+"_cone" "25"
+"target" "t328"
+}
+{
+"origin" "-1336 888 -76"
+"light" "200"
+"classname" "light"
+"_cone" "25"
+"target" "t327"
+}
+{
+"origin" "-1384 888 -76"
+"light" "200"
+"classname" "light"
+"_cone" "25"
+"target" "t326"
+}
+{
+"origin" "-1472 760 -76"
+"classname" "light"
+"light" "200"
+"_cone" "25"
+"target" "t324"
+}
+{
+"origin" "-1472 808 -76"
+"classname" "light"
+"light" "200"
+"_cone" "25"
+"target" "t325"
+}
+{
+"origin" "-1384 616 -76"
+"classname" "light"
+"light" "200"
+"_cone" "25"
+"target" "t322"
+}
+{
+"origin" "-1336 616 -76"
+"classname" "light"
+"light" "200"
+"_cone" "25"
+"target" "t321"
+}
+{
+"origin" "-1288 616 -76"
+"classname" "light"
+"light" "200"
+"_cone" "25"
+"target" "t320"
+}
+{
+"origin" "-1184 664 -76"
+"classname" "light"
+"light" "200"
+"_cone" "25"
+"target" "t319"
+}
+{
+"origin" "-1472 712 -76"
+"light" "200"
+"classname" "light"
+"_cone" "25"
+"target" "t323"
+}
+{
+"spawnflags" "2048"
+"origin" "-1136 -256 56"
+"targetname" "BL6"
+"sounds" "1"
+"classname" "target_splash"
+}
+{
+"spawnflags" "2048"
+"origin" "-1136 -256 72"
+"targetname" "BL5"
+"sounds" "1"
+"classname" "target_splash"
+}
+{
+"spawnflags" "2048"
+"origin" "-1136 -224 72"
+"targetname" "BL4"
+"sounds" "1"
+"classname" "target_splash"
+}
+{
+"spawnflags" "2048"
+"origin" "-1136 -224 56"
+"targetname" "BL2"
+"angle" "0"
+"sounds" "1"
+"classname" "target_splash"
+}
+{
+"spawnflags" "2048"
+"origin" "-1136 -288 72"
+"targetname" "BL1"
+"classname" "target_splash"
+"angle" "0"
+"sounds" "1"
+}
+{
+"spawnflags" "2048"
+"origin" "-1136 -288 56"
+"targetname" "BL3"
+"sounds" "1"
+"angle" "0"
+"classname" "target_splash"
+}
+{
+"spawnflags" "2048"
+"origin" "-852 -376 -126"
+"targetname" "t269"
+"killtarget" "trig1"
+"classname" "trigger_relay"
+}
+{
+"target" "t277"
+"origin" "-1137 -405 170"
+"targetname" "s3"
+"angle" "315"
+"classname" "monster_infantry"
+"item" "ammo_bullets"
+"spawnflags" "1"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "45"
+"origin" "-980 748 -12"
+"spawnflags" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "t267"
+"target" "t268"
+"origin" "-1608 272 132"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"target" "t267"
+"origin" "-1356 276 152"
+"targetname" "t266"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"target" "t255"
+"origin" "-1368 108 152"
+"targetname" "t346"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"target" "t266"
+"targetname" "t268"
+"origin" "-1064 252 152"
+}
+{
+"classname" "path_corner"
+"targetname" "t258"
+"target" "t259"
+"origin" "-1256 656 176"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"target" "t261"
+"targetname" "t264"
+"origin" "-1272 864 176"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"target" "t257"
+"targetname" "t260"
+"origin" "-1432 848 176"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"targetname" "t262"
+"target" "t263"
+"origin" "-1384 624 176"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"targetname" "t263"
+"target" "t264"
+"origin" "-1456 792 176"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"targetname" "t259"
+"target" "t260"
+"origin" "-1232 840 176"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"targetname" "t261"
+"target" "t262"
+"origin" "-1216 680 176"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"targetname" "t257"
+"target" "t258"
+"origin" "-1424 664 176"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_infantry"
+"spawnflags" "3"
+"targetname" "Response_troops"
+"origin" "-1344 96 184"
+"item" "ammo_bullets"
+"angle" "90"
+}
+{
+"classname" "monster_infantry"
+"target" "t255"
+"origin" "-1344 40 184"
+"item" "ammo_bullets"
+"angle" "270"
+"spawnflags" "1"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"delay" "1"
+"origin" "-1008 -200 152"
+"targetname" "BLRguns"
+"target" "BL5"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"delay" "1.25"
+"origin" "-976 -200 152"
+"targetname" "BLRguns"
+"target" "BL6"
+}
+{
+"spawnflags" "2048"
+"origin" "-1136 -256 72"
+"classname" "target_blaster"
+"angle" "0"
+"dmg" "5"
+"targetname" "BL5"
+}
+{
+"spawnflags" "2048"
+"origin" "-1136 -256 56"
+"classname" "target_blaster"
+"angle" "0"
+"dmg" "5"
+"targetname" "BL6"
+}
+{
+"model" "*53"
+"wait" "-1"
+"targetname" "BLR"
+"classname" "func_door"
+"angle" "-1"
+"lip" "1"
+}
+{
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.858268 0.279528"
+"origin" "-1960 960 172"
+}
+{
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.858268 0.279528"
+"origin" "-1904 960 172"
+}
+{
+"_color" "1.000000 0.858268 0.279528"
+"light" "100"
+"classname" "light"
+"origin" "-1848 960 172"
+}
+{
+"_color" "1.000000 0.858268 0.279528"
+"light" "150"
+"classname" "light"
+"origin" "-1904 872 228"
+}
+{
+"_color" "1.000000 0.858268 0.279528"
+"light" "100"
+"classname" "light"
+"origin" "-1960 656 172"
+}
+{
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.858268 0.279528"
+"origin" "-1904 744 228"
+}
+{
+"origin" "-1356 -344 168"
+"targetname" "t255"
+"target" "t254"
+"classname" "path_corner"
+}
+{
+"origin" "-1016 -200 224"
+"killtarget" "fl1"
+"targetname" "BLR"
+"classname" "trigger_relay"
+"target" "t423"
+}
+{
+"model" "*54"
+"target" "t379"
+"targetname" "trig1"
+"wait" "1.25"
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"origin" "-1056 -200 152"
+"delay" ".5"
+"target" "BL3"
+"targetname" "BLRguns"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-1080 -200 152"
+"delay" ".25"
+"target" "BL2"
+"targetname" "BLRguns"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-1112 -200 152"
+"delay" "0"
+"target" "BL1"
+"targetname" "BLRguns"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-1032 -200 152"
+"delay" ".75"
+"target" "BL4"
+"targetname" "BLRguns"
+"classname" "trigger_relay"
+}
+{
+"model" "*55"
+"targetname" "fl1"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"light" "80"
+"classname" "light"
+"origin" "-1096 -224 232"
+}
+{
+"spawnflags" "2048"
+"dmg" "5"
+"angle" "0"
+"targetname" "BL4"
+"classname" "target_blaster"
+"origin" "-1136 -224 72"
+}
+{
+"spawnflags" "2048"
+"dmg" "5"
+"angle" "0"
+"targetname" "BL2"
+"classname" "target_blaster"
+"origin" "-1136 -224 56"
+}
+{
+"spawnflags" "2048"
+"dmg" "5"
+"angle" "0"
+"targetname" "BL3"
+"classname" "target_blaster"
+"origin" "-1136 -288 56"
+}
+{
+"spawnflags" "2048"
+"dmg" "5"
+"targetname" "BL1"
+"angle" "0"
+"classname" "target_blaster"
+"origin" "-1136 -288 72"
+}
+{
+"model" "*56"
+"targetname" "trigbut"
+"spawnflags" "2048"
+"classname" "func_button"
+"angle" "180"
+"lip" "8"
+"health" "1"
+"_minlight" "0.3"
+"target" "t444"
+}
+{
+"angle" "180"
+"classname" "monster_soldier_light"
+"targetname" "Response_troops"
+"origin" "-912 -672 104"
+"spawnflags" "259"
+}
+{
+"angle" "180"
+"classname" "monster_soldier_light"
+"targetname" "Response_troops"
+"origin" "-992 -608 104"
+"spawnflags" "3"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "180"
+"targetname" "Response_troops"
+"origin" "-976 -688 104"
+"spawnflags" "3"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "180"
+"targetname" "Response_troops"
+"origin" "-928 -624 104"
+"spawnflags" "3"
+}
+{
+"spawnflags" "1"
+"origin" "-1016 -662 88"
+"targetname" "s3"
+"classname" "monster_infantry"
+"angle" "315"
+}
+{
+"model" "*57"
+"spawnflags" "2048"
+"classname" "trigger_multiple"
+"target" "s3"
+}
+{
+"model" "*58"
+"classname" "trigger_multiple"
+"delay" ".2"
+"target" "s2"
+}
+{
+"spawnflags" "2048"
+"classname" "trigger_relay"
+"targetname" "scum1"
+"target" "s2"
+"delay" "2"
+"origin" "-376 -1096 -248"
+}
+{
+"_color" "1.000000 0.432000 0.268000"
+"light" "64"
+"classname" "light"
+"origin" "-768 -800 -400"
+}
+{
+"_color" "1.000000 0.432000 0.268000"
+"light" "64"
+"classname" "light"
+"origin" "-768 -864 -400"
+}
+{
+"_color" "1.000000 0.432000 0.268000"
+"light" "64"
+"classname" "light"
+"origin" "-768 -928 -400"
+}
+{
+"_color" "1.000000 0.432000 0.268000"
+"light" "64"
+"classname" "light"
+"origin" "-768 -992 -400"
+}
+{
+"_color" "1.000000 0.432000 0.268000"
+"light" "64"
+"classname" "light"
+"origin" "-768 -1056 -400"
+}
+{
+"_color" "1.000000 0.432000 0.268000"
+"light" "64"
+"classname" "light"
+"origin" "-768 -1120 -400"
+}
+{
+"_color" "1.000000 0.432000 0.268000"
+"light" "64"
+"classname" "light"
+"origin" "-768 -1184 -400"
+}
+{
+"_color" "1.000000 0.432000 0.268000"
+"light" "64"
+"classname" "light"
+"origin" "-768 -1248 -400"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-1660 -641 -456"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1720 -638 -459"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1584 -641 -456"
+}
+{
+"classname" "monster_flipper"
+"targetname" "mf"
+"origin" "-1760 -624 -512"
+}
+{
+"model" "*59"
+"spawnflags" "2048"
+"classname" "trigger_multiple"
+"target" "mf"
+}
+{
+"classname" "monster_flipper"
+"target" "t253"
+"origin" "-728 -648 -440"
+}
+{
+"classname" "path_corner"
+"targetname" "t252"
+"target" "t253"
+"origin" "-760 -904 -456"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"targetname" "t252"
+"target" "t253"
+"origin" "-800 -896 -456"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"target" "t252"
+"targetname" "t253"
+"origin" "-784 -672 -456"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"targetname" "t253"
+"target" "t252"
+"origin" "-768 -1200 -456"
+"spawnflags" "2048"
+}
+{
+"_style" "10"
+"origin" "-1456 -528 264"
+"classname" "light"
+"light" "175"
+"_color" "1.000000 0.929412 0.435294"
+}
+{
+"origin" "-1456 -688 264"
+"classname" "light"
+"light" "125"
+"_color" "1.000000 0.929412 0.435294"
+}
+{
+"classname" "path_corner"
+"targetname" "t249"
+"target" "t225"
+"origin" "-1352 -1132 -52"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"targetname" "t224"
+"target" "t249"
+"origin" "-1440 -1128 -52"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"origin" "-1088 -1000 -272"
+"targetname" "t240"
+"target" "t239"
+}
+{
+"spawnflags" "256"
+"angle" "45"
+"classname" "monster_infantry"
+"origin" "-984 -864 -256"
+"target" "t240"
+}
+{
+"model" "*60"
+"spawnflags" "2048"
+"classname" "trigger_push"
+"angle" "180"
+"speed" "50"
+}
+{
+"model" "*61"
+"spawnflags" "2048"
+"classname" "trigger_multiple"
+"target" "paraspawn"
+}
+{
+"classname" "monster_parasite"
+"targetname" "paraspawn"
+"spawnflags" "2"
+"origin" "-640 -1400 1156"
+"angle" "225"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1361 720 -50"
+"light" "120"
+"classname" "light"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1297 784 -50"
+"classname" "light"
+"light" "120"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1297 720 -50"
+"classname" "light"
+"light" "120"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1432 720 -152"
+"light" "80"
+"classname" "light"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1240 784 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1240 720 -152"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1304 656 -152"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1368 848 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1304 848 -152"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1160 552 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1096 552 -152"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1160 488 -152"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1096 488 -152"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"light" "80"
+"classname" "light"
+"origin" "-1544 552 -152"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1496 1000 -152"
+}
+{
+"light" "80"
+"classname" "light"
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1496 936 -152"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1560 936 -152"
+}
+{
+"light" "80"
+"classname" "light"
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1560 872 -152"
+}
+{
+"origin" "-1560 808 -152"
+"classname" "light"
+"light" "80"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"origin" "-1560 744 -152"
+"light" "80"
+"classname" "light"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"origin" "-1560 680 -152"
+"classname" "light"
+"light" "80"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"origin" "-1560 616 -152"
+"light" "80"
+"classname" "light"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"origin" "-1504 600 -152"
+"classname" "light"
+"light" "80"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"origin" "-1544 488 -152"
+"light" "80"
+"classname" "light"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"origin" "-1480 552 -152"
+"classname" "light"
+"light" "80"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"origin" "-1480 488 -152"
+"light" "80"
+"classname" "light"
+"_color" "0.465649 1.000000 0.671756"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1416 552 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1392 520 -160"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1328 520 -160"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1264 520 -160"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1200 520 -160"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1152 600 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1432 1000 -152"
+"_color" "0.465649 1.000000 0.671756"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1032 424 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1032 488 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1032 744 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1032 680 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1096 616 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1096 680 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1096 744 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1096 808 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1032 872 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1096 872 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1160 936 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1096 936 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1096 1000 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1160 1000 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1224 1000 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1288 1000 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "0.465649 1.000000 0.671756"
+"origin" "-1352 1000 -152"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1432 1064 -152"
+"_color" "0.465649 1.000000 0.671756"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1392 904 192"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1488 808 192"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1392 600 192"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1280 600 192"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1184 680 192"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1184 824 192"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1280 904 192"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.299180 0.000000"
+"origin" "-1008 840 -16"
+}
+{
+"_color" "1.000000 0.299180 0.000000"
+"classname" "light"
+"light" "90"
+"origin" "-992 824 -16"
+}
+{
+"light" "90"
+"classname" "light"
+"_color" "1.000000 0.299180 0.000000"
+"origin" "-992 856 -16"
+}
+{
+"light" "90"
+"classname" "light"
+"_color" "1.000000 0.299180 0.000000"
+"origin" "-976 840 -16"
+}
+{
+"origin" "-976 664 -16"
+"_color" "1.000000 0.299180 0.000000"
+"classname" "light"
+"light" "90"
+}
+{
+"origin" "-992 648 -16"
+"light" "90"
+"classname" "light"
+"_color" "1.000000 0.299180 0.000000"
+}
+{
+"origin" "-1008 664 -16"
+"classname" "light"
+"light" "90"
+"_color" "1.000000 0.299180 0.000000"
+}
+{
+"origin" "-992 680 -16"
+"light" "90"
+"classname" "light"
+"_color" "1.000000 0.299180 0.000000"
+}
+{
+"origin" "-1008 224 176"
+"light" "125"
+"classname" "light"
+"_color" "1.000000 0.299180 0.000000"
+}
+{
+"origin" "-992 208 176"
+"classname" "light"
+"light" "125"
+"_color" "1.000000 0.299180 0.000000"
+}
+{
+"origin" "-1024 208 176"
+"light" "125"
+"classname" "light"
+"_color" "1.000000 0.299180 0.000000"
+}
+{
+"origin" "-1488 400 144"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.299180 0.000000"
+}
+{
+"origin" "-1504 416 144"
+"light" "100"
+"classname" "light"
+"_color" "1.000000 0.299180 0.000000"
+}
+{
+"origin" "-1520 400 144"
+"light" "100"
+"classname" "light"
+"_color" "1.000000 0.299180 0.000000"
+}
+{
+"model" "*62"
+"wait" "1"
+"delay" ".25"
+"classname" "func_plat"
+"sounds" "1"
+"speed" "150"
+"lip" "0"
+"accel" "250"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-104 -1760 1088"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-104 -1632 1088"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "24 -1760 1088"
+}
+{
+"classname" "info_player_start"
+"angle" "0"
+"origin" "-248 -1792 880"
+"targetname" "base3c"
+}
+{
+"model" "*63"
+"classname" "func_button"
+"angle" "90"
+"lip" "4"
+"sounds" "4"
+"_minlight" "0.8"
+"target" "access_panel"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1"
+"origin" "-328 -428 -294"
+"targetname" "s2"
+"classname" "monster_soldier"
+"angle" "270"
+}
+{
+"_color" "1.000000 0.929412 0.435294"
+"light" "125"
+"classname" "light"
+"origin" "-1456 -608 264"
+}
+{
+"origin" "-888 -184 -196"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.529881 0.306773"
+}
+{
+"item" "key_red_key"
+"classname" "trigger_key"
+"spawnflags" "2049"
+"target" "rusty_gate"
+"targetname" "keyhole1"
+"origin" "-1584 952 184"
+}
+{
+"angle" "90"
+"spawnflags" "2"
+"classname" "monster_soldier"
+"targetname" "goons1"
+"origin" "-808 -1368 912"
+}
+{
+"classname" "monster_soldier"
+"spawnflags" "2"
+"angle" "270"
+"targetname" "goons1"
+"origin" "-760 -1368 912"
+"item" "ammo_shells"
+}
+{
+"model" "*64"
+"spawnflags" "2048"
+"_minlight" "0.2"
+"wait" "-1"
+"classname" "func_door"
+"lip" "8"
+"targetname" "water_secret"
+"angle" "90"
+}
+{
+"model" "*65"
+"targetname" "lsecret"
+"target" "t417"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1"
+"item" "ammo_bullets"
+"classname" "monster_infantry"
+"angle" "225"
+"targetname" "scum1"
+"origin" "-448 -1080 -280"
+}
+{
+"model" "*66"
+"classname" "trigger_counter"
+"targetname" "goons1"
+"target" "goons2"
+"spawnflags" "2049"
+"count" "2"
+}
+{
+"classname" "path_corner"
+"targetname" "t245"
+"origin" "-219 -1385 856"
+"target" "t350"
+}
+{
+"classname" "path_corner"
+"targetname" "t244"
+"target" "t245"
+"origin" "-560 -1368 856"
+}
+{
+"classname" "path_corner"
+"targetname" "t245"
+"origin" "-590 -1456 864"
+"target" "t349"
+}
+{
+"classname" "monster_soldier_light"
+"origin" "-536 -1456 882"
+"target" "t349"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-376 -1460 864"
+"_color" "1.000000 0.360000 0.268000"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-376 -1356 864"
+"_color" "1.000000 0.360000 0.268000"
+}
+{
+"origin" "-1032 -224 232"
+"light" "80"
+"classname" "light"
+"_color" "1.000000 0.929412 0.443137"
+}
+{
+"_style" "11"
+"origin" "-1168 -256 192"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.833992 0.276680"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1096 -192 176"
+"_color" "1.000000 0.929412 0.443137"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1032 -192 176"
+"_color" "1.000000 0.929412 0.443137"
+}
+{
+"origin" "-56 -1872 984"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "-684 -788 872"
+"classname" "misc_explobox"
+"health" "50"
+"dmg" "200"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"dmg" "150"
+"health" "80"
+"classname" "misc_explobox"
+"origin" "-580 -764 876"
+}
+{
+"spawnflags" "2048"
+"origin" "-816 -840 872"
+"classname" "misc_explobox"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-512 -1308 864"
+"_color" "1.000000 0.360000 0.268000"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-512 -1516 864"
+"_color" "1.000000 0.360000 0.268000"
+}
+{
+"spawnflags" "2048"
+"classname" "weapon_supershotgun"
+"origin" "-1920 856 184"
+"target" "Response_troops"
+}
+{
+"model" "*67"
+"_minlight" "0.2"
+"target" "t342"
+"lip" "12"
+"classname" "func_door"
+"angle" "0"
+"speed" "100"
+"wait" "4"
+"team" "doorN"
+"sounds" "0"
+"spawnflags" "12"
+}
+{
+"model" "*68"
+"_minlight" "0.2"
+"lip" "12"
+"sounds" "2"
+"team" "doorN"
+"wait" "4"
+"speed" "100"
+"angle" "180"
+"classname" "func_door"
+"spawnflags" "12"
+"target" "t342"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1169 -642 268"
+"_color" "1.000000 0.992157 0.701961"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"origin" "148 -640 -960"
+"classname" "light"
+"light" "120"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"classname" "light"
+"light" "105"
+"origin" "98 -574 -64"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "148 -640 -64"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"light" "105"
+"classname" "light"
+"origin" "96 -708 -64"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"classname" "light"
+"light" "90"
+"origin" "98 -574 192"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "148 -640 192"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"light" "90"
+"classname" "light"
+"origin" "96 -708 192"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"origin" "96 -708 320"
+"classname" "light"
+"light" "105"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"origin" "148 -640 320"
+"classname" "light"
+"light" "105"
+}
+{
+"origin" "98 -574 320"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"model" "*69"
+"_minlight" "0.2"
+"lip" "12"
+"sounds" "2"
+"team" "door3"
+"wait" "4"
+"speed" "100"
+"angle" "270"
+"classname" "func_door"
+"target" "t432"
+}
+{
+"model" "*70"
+"_minlight" "0.2"
+"lip" "12"
+"classname" "func_door"
+"angle" "90"
+"speed" "100"
+"wait" "4"
+"team" "door3"
+"sounds" "0"
+"target" "t432"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1232 -896 -136"
+}
+{
+"model" "*71"
+"origin" "-932 -1120 -128"
+"speed" "70"
+"dmg" "5"
+"wait" "6"
+"targetname" "wallramp"
+"distance" "33"
+"sounds" "1"
+"angle" "-1"
+"classname" "func_door_rotating"
+"spawnflags" "128"
+}
+{
+"model" "*72"
+"_minlight" "0.2"
+"lip" "12"
+"classname" "func_door"
+"angle" "90"
+"speed" "100"
+"wait" "4"
+"team" "door2"
+"sounds" "0"
+}
+{
+"model" "*73"
+"_minlight" "0.2"
+"lip" "12"
+"sounds" "2"
+"team" "door2"
+"wait" "4"
+"speed" "100"
+"angle" "270"
+"classname" "func_door"
+}
+{
+"origin" "-1396 -376 160"
+"light" "75"
+"classname" "light"
+"_color" "1.000000 0.582677 0.204724"
+}
+{
+"origin" "-1396 -248 160"
+"light" "75"
+"classname" "light"
+"_color" "1.000000 0.582677 0.204724"
+}
+{
+"light" "75"
+"classname" "light"
+"origin" "-1396 -104 160"
+"_color" "1.000000 0.582677 0.204724"
+}
+{
+"light" "75"
+"classname" "light"
+"origin" "-1396 8 160"
+"_color" "1.000000 0.582677 0.204724"
+}
+{
+"light" "75"
+"classname" "light"
+"origin" "-1292 8 160"
+"_color" "1.000000 0.582677 0.204724"
+}
+{
+"light" "75"
+"classname" "light"
+"origin" "-1292 -104 160"
+"_color" "1.000000 0.582677 0.204724"
+}
+{
+"origin" "-1292 -248 160"
+"light" "75"
+"classname" "light"
+"_color" "1.000000 0.582677 0.204724"
+}
+{
+"origin" "-1292 -376 160"
+"classname" "light"
+"light" "75"
+"_color" "1.000000 0.582677 0.204724"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"origin" "-1762 -574 -320"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1762 -574 -192"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1432 -640 -464"
+"light" "120"
+"classname" "light"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-1304 -640 -464"
+"classname" "light"
+"light" "120"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-1176 -640 -464"
+"light" "120"
+"classname" "light"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"model" "*74"
+"origin" "-1552 808 160"
+"wait" "-1"
+"spawnflags" "137"
+"angle" "-1"
+"sounds" "1"
+"distance" "90"
+"speed" "75"
+"classname" "func_door_rotating"
+"targetname" "rusty_gate"
+"_minlight" "0.3"
+}
+{
+"classname" "light"
+"light" "70"
+"origin" "-1088 -1008 -240"
+"_color" "1.000000 0.517647 0.223529"
+}
+{
+"_color" "1.000000 0.992157 0.701961"
+"origin" "-1169 -642 228"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "-496 -392 -240"
+}
+{
+"origin" "-610 -574 -832"
+"light" "80"
+"classname" "light"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"_color" "1.000000 0.529881 0.306773"
+"origin" "-888 -312 -196"
+"classname" "light"
+"light" "64"
+}
+{
+"_color" "1.000000 0.529881 0.306773"
+"light" "32"
+"classname" "light"
+"origin" "-890 -152 -192"
+}
+{
+"_color" "1.000000 0.529881 0.306773"
+"origin" "-888 -248 -200"
+"classname" "light"
+"light" "64"
+}
+{
+"model" "*75"
+"spawnflags" "2048"
+"light" "90"
+"target" "water_secret"
+"lip" "4"
+"health" "1"
+"angle" "180"
+"classname" "func_button"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-320 -976 -280"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-320 -848 -280"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-320 -720 -280"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-320 -592 -280"
+"classname" "light"
+"light" "80"
+}
+{
+"item" "item_armor_shard"
+"origin" "-320 -464 -280"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-320 -336 -280"
+"classname" "light"
+"light" "150"
+}
+{
+"model" "*76"
+"spawnflags" "2048"
+"angle" "0"
+"target" "scum1"
+"classname" "trigger_multiple"
+}
+{
+"origin" "-984 -796 -256"
+"classname" "path_corner"
+"targetname" "t294"
+"target" "t239"
+}
+{
+"origin" "-852 -980 -272"
+"target" "t240"
+"targetname" "t293"
+"classname" "path_corner"
+}
+{
+"origin" "-640 -896 -272"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1416 792 152"
+"classname" "light"
+"light" "200"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-992 -1136 920"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-992 -1200 936"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-992 -1328 936"
+}
+{
+"light" "115"
+"classname" "light"
+"origin" "-992 -1392 936"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"origin" "-1032 -960 232"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"origin" "-1096 -960 232"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"classname" "light"
+"light" "150"
+"origin" "-856 -960 232"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"light" "150"
+"classname" "light"
+"origin" "-920 -960 232"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"origin" "-856 -224 232"
+"light" "80"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"origin" "-920 -224 232"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"origin" "-856 -992 200"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"origin" "-920 -992 200"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1060 -392 -88"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-1060 -392 -152"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1060 -392 -24"
+}
+{
+"origin" "-984 -392 -152"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-904 -392 -152"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"classname" "light"
+"light" "90"
+"origin" "-1048 -896 960"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-1048 -1024 832"
+"light" "90"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-1048 -1152 832"
+"light" "90"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-1048 -1024 960"
+"light" "90"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-1048 -1408 960"
+"light" "90"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-1048 -1536 960"
+"light" "90"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-816 -1664 960"
+"light" "90"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-960 -1880 960"
+"light" "90"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-832 -1880 960"
+"light" "90"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-704 -1880 960"
+"light" "90"
+"classname" "light"
+}
+{
+"origin" "-760 -1808 936"
+"light" "115"
+"classname" "light"
+}
+{
+"origin" "-776 -1584 1012"
+"light" "125"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-712 -1584 1012"
+}
+{
+"origin" "-728 -1564 896"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "-744 -1564 936"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-742 -1568 988"
+"light" "75"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "32"
+"origin" "-760 -1564 896"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"classname" "light"
+"light" "64"
+"origin" "-1048 -896 704"
+}
+{
+"origin" "-864 -1808 936"
+"classname" "light"
+"light" "115"
+}
+{
+"origin" "-992 -1792 936"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-992 -1264 936"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-992 -1296 888"
+"classname" "light"
+"light" "50"
+}
+{
+"origin" "-992 -1200 840"
+"classname" "light"
+"light" "50"
+}
+{
+"origin" "-992 -1168 824"
+"light" "50"
+"classname" "light"
+}
+{
+"origin" "-992 -1136 808"
+"light" "50"
+"classname" "light"
+}
+{
+"origin" "-992 -1104 792"
+"classname" "light"
+"light" "50"
+}
+{
+"origin" "-992 -1072 776"
+"light" "50"
+"classname" "light"
+}
+{
+"origin" "-992 -1040 760"
+"light" "50"
+"classname" "light"
+}
+{
+"origin" "-992 -1008 744"
+"classname" "light"
+"light" "50"
+}
+{
+"origin" "-992 -976 728"
+"light" "50"
+"classname" "light"
+}
+{
+"origin" "-992 -944 712"
+"light" "50"
+"classname" "light"
+}
+{
+"origin" "-992 -1264 872"
+"classname" "light"
+"light" "50"
+}
+{
+"origin" "-992 -1232 856"
+"classname" "light"
+"light" "50"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-992 -904 680"
+"classname" "light"
+"light" "90"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-992 -776 680"
+"classname" "light"
+"light" "130"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-1016 -640 680"
+"classname" "light"
+"light" "130"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-696 -640 744"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-728 -1392 1208"
+"classname" "light"
+"light" "350"
+"target" "t421"
+"_cone" "15"
+}
+{
+"model" "*77"
+"spawnflags" "2048"
+"classname" "trigger_multiple"
+"delay" ".25"
+"target" "goons1"
+"wait" "5"
+}
+{
+"origin" "-720 -780 936"
+"classname" "light"
+"light" "90"
+}
+{
+"origin" "-496 -1148 928"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "90"
+"classname" "light"
+"origin" "-624 -780 936"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-320 -972 920"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"light" "100"
+"classname" "light"
+"origin" "-344 -908 888"
+}
+{
+"classname" "light"
+"light" "350"
+"origin" "-728 -1416 1208"
+"target" "t419"
+"_cone" "15"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-592 -1400 944"
+}
+{
+"light" "350"
+"classname" "light"
+"origin" "-752 -1392 1208"
+"target" "t420"
+"_cone" "15"
+}
+{
+"light" "350"
+"classname" "light"
+"origin" "-752 -1416 1208"
+"target" "t418"
+"_cone" "15"
+}
+{
+"_color" "1.000000 0.360000 0.268000"
+"origin" "-328 -1460 864"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-649 -1347 1134"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-719 -1481 1134"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-827 -1369 1134"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-799 -1471 1134"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-649 -1471 1134"
+}
+{
+"origin" "-768 -1076 984"
+"classname" "light"
+"light" "110"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"origin" "-680 -1084 888"
+"classname" "light"
+"light" "96"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"origin" "-856 -1084 888"
+"classname" "light"
+"light" "96"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"light" "100"
+"classname" "light"
+"origin" "-856 -956 888"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"light" "96"
+"classname" "light"
+"origin" "-856 -1340 888"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"light" "96"
+"classname" "light"
+"origin" "-824 -1460 888"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-770 -1240 1024"
+}
+{
+"classname" "func_group"
+"light" "64"
+}
+{
+"_style" "6"
+"light" "150"
+"classname" "light"
+"origin" "-1344 -176 388"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1344 -256 388"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1344 -336 388"
+}
+{
+"light" "75"
+"classname" "light"
+"origin" "-376 -1136 -304"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"light" "90"
+"classname" "light"
+"origin" "-448 -1040 -280"
+}
+{
+"origin" "-336 -1192 -296"
+"classname" "light"
+"light" "80"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"light" "150"
+"classname" "light"
+"origin" "-368 -512 -280"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-320 -1104 -280"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-536 -1088 -280"
+"classname" "light"
+"light" "90"
+}
+{
+"light" "75"
+"classname" "light"
+"origin" "-464 -1088 -264"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-512 -1208 -352"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"origin" "-1096 -360 216"
+"light" "175"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"origin" "-1032 -360 216"
+"classname" "light"
+"light" "175"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"classname" "light"
+"light" "80"
+"origin" "-864 -192 176"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"light" "80"
+"classname" "light"
+"origin" "-920 -192 176"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"origin" "-1032 -992 200"
+"classname" "light"
+"light" "150"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"origin" "-1088 -992 200"
+"light" "150"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-1136 -824 -240"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-960 -1008 -240"
+"classname" "light"
+"light" "70"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-816 -960 -240"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-816 -832 -240"
+"classname" "light"
+"light" "70"
+}
+{
+"origin" "-832 -1008 -240"
+"light" "70"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"light" "175"
+"classname" "light"
+"origin" "-1096 -392 272"
+}
+{
+"_color" "1.000000 0.929412 0.443137"
+"classname" "light"
+"light" "175"
+"origin" "-1032 -392 272"
+}
+{
+"origin" "-768 -736 -400"
+"classname" "light"
+"light" "64"
+"_color" "1.000000 0.432000 0.268000"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-600 -896 -464"
+"classname" "light"
+"light" "64"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-404 -640 -360"
+"_color" "1.000000 0.256917 0.007905"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-404 -640 -488"
+"_color" "1.000000 0.256917 0.007905"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-420 -392 -688"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-368 -768 -280"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-480 -392 -968"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-496 -392 -175"
+"classname" "light"
+"light" "200"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"origin" "-288 -1248 -280"
+"classname" "light"
+"light" "130"
+}
+{
+"model" "*78"
+"angle" "45"
+"sounds" "2"
+"wait" "3"
+"spawnflags" "1"
+"height" "386"
+"speed" "100"
+"classname" "func_plat"
+}
+{
+"origin" "-1424 -924 -56"
+"target" "t224"
+"targetname" "t225"
+"classname" "path_corner"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"targetname" "t221"
+"target" "t223"
+"origin" "-1408 -640 128"
+}
+{
+"classname" "path_corner"
+"targetname" "t223"
+"target" "t221"
+"origin" "-1392 -448 152"
+}
+{
+"classname" "path_corner"
+"targetname" "t221"
+"target" "t222"
+"origin" "-1224 -448 152"
+}
+{
+"classname" "path_corner"
+"targetname" "t222"
+"target" "t223"
+"origin" "-1336 -480 152"
+}
+{
+"classname" "monster_soldier"
+"target" "t221"
+"origin" "-1328 -432 172"
+"spawnflags" "1"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"classname" "light"
+"light" "64"
+"origin" "-792 -640 -400"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"classname" "light"
+"light" "64"
+"origin" "-728 -640 -464"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-856 -640 -464"
+}
+{
+"_color" "1.000000 0.517647 0.223529"
+"light" "64"
+"classname" "light"
+"origin" "-664 -896 -464"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"classname" "light"
+"light" "80"
+"origin" "-1792 -640 -528"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-640 -896 -336"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-640 -896 -144"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-640 -896 -14"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-648 -888 -400"
+}
+{
+"model" "*79"
+"classname" "func_plat"
+"speed" "150"
+"height" "684"
+"spawnflags" "1793"
+"wait" "5"
+"sounds" "1"
+}
+{
+"model" "*80"
+"spawnflags" "8"
+"sounds" "1"
+"wait" "6"
+"speed" "125"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"origin" "-1060 -416 76"
+"light" "140"
+"classname" "light"
+}
+{
+"origin" "-536 -640 -208"
+"light" "175"
+"classname" "light"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-1024 -632 -384"
+"classname" "light"
+"light" "150"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-792 -640 -328"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"classname" "monster_soldier"
+"angle" "0"
+"origin" "-976 -240 76"
+"spawnflags" "0"
+}
+{
+"origin" "-794 -640 242"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-606 -641 179"
+}
+{
+"_color" "1.000000 0.880000 0.192000"
+"classname" "light"
+"light" "110"
+"origin" "-1036 -1172 -64"
+}
+{
+"origin" "-768 -1320 1128"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "148 -640 576"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "148 -640 960"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "96 -708 192"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "148 -640 -192"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "98 -574 192"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "96 -708 64"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "196 -736 128"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "98 -574 64"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "96 -708 448"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "98 -574 448"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "96 -708 576"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "148 -640 448"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "98 -574 576"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "96 -708 704"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "148 -640 704"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "98 -574 704"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "96 -708 -320"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "148 -640 -320"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "98 -574 -320"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "96 -708 -192"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "148 -640 192"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "98 -574 -192"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "96 -708 -960"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "148 -640 -704"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "98 -574 -960"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "96 -708 -704"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "98 -574 -704"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "96 -708 -576"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "148 -640 -576"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "98 -574 -576"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "96 -708 -448"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "148 -640 -448"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "98 -574 -448"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-608 -708 -960"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-420 -392 -944"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-610 -574 -960"
+"light" "80"
+"classname" "light"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-420 -392 -816"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-608 -708 -832"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-608 -708 -704"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-610 -574 -704"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-608 -708 -576"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-420 -392 -560"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-610 -574 -576"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-608 -708 -448"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-420 -392 -432"
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-610 -574 -448"
+"light" "100"
+"classname" "light"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-1203 -901 58"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-794 -640 210"
+}
+{
+"pathtarget" "hiss2"
+"wait" "5"
+"target" "t3"
+"classname" "path_corner"
+"origin" "-768 -764 832"
+"targetname" "t352"
+}
+{
+"pathtarget" "hiss"
+"target" "t150"
+"targetname" "t20"
+"wait" "3"
+"classname" "path_corner"
+"origin" "-1092 -760 -320"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"origin" "-1272 -640 944"
+"classname" "light"
+"light" "175\"
+"target" "t38"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"origin" "4 -640 -664"
+"classname" "light"
+"light" "105"
+"target" "t46"
+}
+{
+"_color" "1.000000 0.274510 0.035294"
+"light" "175\"
+"classname" "light"
+"origin" "-1404 -640 944"
+"target" "t27"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"light" "105"
+"classname" "light"
+"origin" "-1760 -708 960"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"light" "105"
+"classname" "light"
+"origin" "-1812 -640 960"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"classname" "light"
+"light" "105"
+"origin" "-1762 -574 960"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1760 -708 704"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1812 -640 704"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "-1762 -574 704"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1760 -708 576"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1812 -640 576"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1762 -574 576"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1760 -708 448"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1812 -640 448"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "-1762 -574 448"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1760 -708 320"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1812 -640 320"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1762 -574 320"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1760 -708 192"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1812 -640 192"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "-1762 -574 192"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1760 -708 64"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1812 -640 64"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1762 -574 64"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1760 -708 -64"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1812 -640 -64"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "-1762 -574 -64"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1760 -708 -192"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1812 -640 -192"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1760 -708 -320"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1812 -640 -320"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1760 -708 -448"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-1804 -640 -448"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.274510 0.035294"
+}
+{
+"origin" "-1762 -574 -448"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"light" "105"
+"classname" "light"
+"origin" "-1760 -708 832"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "-1812 -640 832"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "-1762 -574 832"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "96 -708 960"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "148 -640 1088"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "98 -574 960"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "96 -708 1088"
+"classname" "light"
+"light" "105"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"origin" "-404 -640 -104"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "98 -574 1088"
+"light" "105"
+"classname" "light"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"origin" "-1760 -708 1088"
+"classname" "light"
+"light" "105"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"origin" "-1812 -640 1088"
+"classname" "light"
+"light" "105"
+}
+{
+"_color" "1.000000 0.262745 0.243137"
+"origin" "-1762 -574 1088"
+"light" "105"
+"classname" "light"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "96 -708 832"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"light" "105"
+"classname" "light"
+"origin" "148 -640 832"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "light"
+"light" "105"
+"origin" "98 -574 832"
+"_color" "1.000000 0.262745 0.243137"
+}
+{
+"classname" "func_group"
+}
+{
+"wait" ".09"
+"pathtarget" "corner2"
+"origin" "-1820 -760 -288"
+"classname" "path_corner"
+"targetname" "t18"
+"target" "t13"
+"light" "64"
+}
+{
+"wait" ".09"
+"pathtarget" "corner1"
+"origin" "-1788 -760 -320"
+"classname" "path_corner"
+"targetname" "t150"
+"target" "t18"
+}
+{
+"wait" ".09"
+"pathtarget" "corner3"
+"classname" "path_corner"
+"origin" "-1820 -760 832"
+"target" "t12"
+"targetname" "t13"
+"light" "64"
+}
+{
+"wait" ".09"
+"classname" "path_corner"
+"origin" "-1788 -760 848"
+"targetname" "t12"
+"target" "t151"
+"light" "64"
+"pathtarget" "open_in"
+}
+{
+"wait" ".09"
+"pathtarget" "corner9"
+"classname" "path_corner"
+"origin" "-652 -760 -832"
+"targetname" "t24"
+"target" "t23"
+"light" "64"
+}
+{
+"wait" ".09"
+"pathtarget" "corner0B"
+"target" "t20"
+"classname" "path_corner"
+"origin" "-680 -760 -320"
+"targetname" "t21"
+"light" "64"
+}
+{
+"wait" ".09"
+"pathtarget" "corner0"
+"classname" "path_corner"
+"origin" "-652 -760 -336"
+"target" "t21"
+"targetname" "t22"
+"light" "64"
+}
+{
+"classname" "path_corner"
+"origin" "-656 -760 -784"
+"target" "t22"
+"targetname" "t23"
+"light" "64"
+}
+{
+"_color" "1.000000 0.360000 0.268000"
+"origin" "-328 -1356 864"
+"light" "80"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.388235 0.239216"
+"origin" "-856 -828 888"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1232 -896 -168"
+"light" "100"
+"classname" "light"
+}
+{
+"wait" ".09"
+"pathtarget" "corner7"
+"target" "t7"
+"origin" "-80 -760 -800"
+"targetname" "t8"
+"classname" "path_corner"
+"light" "64"
+}
+{
+"wait" ".09"
+"pathtarget" "corner8"
+"target" "t24"
+"targetname" "t7"
+"classname" "path_corner"
+"origin" "-100 -760 -832"
+"light" "64"
+}
+{
+"wait" ".09"
+"pathtarget" "corner6"
+"target" "t8"
+"origin" "-80 -760 816"
+"targetname" "t4"
+"classname" "path_corner"
+}
+{
+"wait" ".09"
+"origin" "-104 -760 832"
+"target" "t4"
+"targetname" "t3"
+"classname" "path_corner"
+"light" "64"
+"pathtarget" "close_out"
+}
+{
+"model" "*81"
+"_minlight" "0.2"
+"sounds" "0"
+"health" "1"
+"lip" "8"
+"angle" "180"
+"target" "ws_trgr"
+"classname" "func_button"
+}
+{
+"origin" "-1344 80 388"
+"classname" "light"
+"light" "100"
+}
+{
+"_style" "6"
+"origin" "-1344 0 388"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1344 -80 388"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-336 -1408 1092"
+"classname" "light"
+"light" "64"
+}
+{
+"targetname" "ws_trgr"
+"classname" "trigger_relay"
+"target" "wallramp"
+"origin" "-1268 -1040 -224"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1344 176 388"
+}
+{
+"origin" "-244 -1792 952"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*82"
+"classname" "func_door"
+"angle" "-1"
+"_minlight" ".2"
+"targetname" "t247"
+}
+{
+"model" "*83"
+"classname" "func_button"
+"angle" "180"
+"target" "t247"
+"_minlight" "0.3"
+}
+{
+"model" "*84"
+"spawnflags" "2048"
+"classname" "trigger_multiple"
+"target" "t246"
+}
+{
+"spawnflags" "2048"
+"classname" "target_changelevel"
+"map" "base3$train"
+"origin" "-248 -1748 932"
+"targetname" "t246"
+}

--- a/stuff/mapfixes/juggernaut/jug19.ent
+++ b/stuff/mapfixes/juggernaut/jug19.ent
@@ -1,0 +1,4169 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Moved monster_soldier_ss (2689) out of solid
+//
+// Changed his vertical origin from -320 to -208 like the guy next to him.
+//
+// 2. Added misc_teleporter (4161) to get out of sled area
+//
+// Teleports back to the start of the level (4156).
+//
+// 3. Removed func_door (1409, 1423) and trigger_key (2080)
+//
+// There is no power cube in the level and the doors serve no purpose.
+// Removed by setting spawnflags from 2048 to 3840 (never spawn).
+// This ensures entity alignment is unchanged.
+//
+// 4. Added Power Shield (4166) to sled area to give it a purpose
+{
+"sky" "env2_"
+"skyrotate" "0"
+"skyaxis" "0"
+"gravity" "800"
+"message" "THE HEART OF DARKNESS"
+"light" "0"
+"sounds" "5"
+"classname" "worldspawn"
+}
+{
+"origin" "-79 949 30"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-80 688 32"
+"_color" ".4 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-176 484 96"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "16 472 48"
+"_color" ".4 1 0"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "111 159 96"
+"_color" "0 .7 .6"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-81 160 96"
+"_color" "1 .4 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "112 368 216"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-80 367 216"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "16 216 216"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-248 288 216"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "16 816 160"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-176 815 160"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-24 1088 -160"
+"_color" "1 .5 0"
+"style" "0"
+"light" "175"
+"classname" "light"
+}
+{
+"origin" "-216 1088 -160"
+"_color" "1 .5 0"
+"style" "0"
+"light" "175"
+"classname" "light"
+}
+{
+"origin" "320 976 -158"
+"_color" "1 .5 0"
+"style" "0"
+"light" "175"
+"classname" "light"
+}
+{
+"origin" "192 1088 -158"
+"_color" "1 .5 0"
+"style" "0"
+"light" "175"
+"classname" "light"
+}
+{
+"origin" "193 656 -168"
+"_color" "1 .5 0"
+"style" "0"
+"light" "175"
+"classname" "light"
+}
+{
+"origin" "-16 656 -168"
+"_color" "1 .5 0"
+"style" "0"
+"light" "175"
+"classname" "light"
+}
+{
+"origin" "-225 656 -168"
+"_color" "1 .5 0"
+"style" "0"
+"light" "175"
+"classname" "light"
+}
+{
+"origin" "-225 912 -168"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "192 288 216"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "232 1064 152"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "400"
+"classname" "light"
+}
+{
+"origin" "-316 288 24"
+"_color" ".4 1 0"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-80 732 159"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-80 900 175"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "80 816 -16"
+"_color" ".4 1 0"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "208 473 48"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "1052 -592 12"
+"_color" ".2 .4 .6"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "1051 -435 12"
+"_color" ".2 .4 .6"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "838 -592 11"
+"_color" ".2 .4 .6"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "841 -435 12"
+"_color" ".2 .4 .6"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "806 -504 -180"
+"_color" ".2 .4 .6"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "1010 -504 -180"
+"_color" ".2 .6 .4"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "1088 -1296 -141"
+"_color" ".8 .5 .8"
+"targetname" "part"
+"style" "32"
+"light" "500"
+"classname" "light"
+}
+{
+"origin" "683 -1280 -1"
+"_color" "1 0 0"
+"targetname" "full"
+"style" "33"
+"light" "300"
+"spawnflags" "1"
+"classname" "light"
+}
+{
+"origin" "1004 -1364 4"
+"_color" ".1 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "1172 -1196 4"
+"_color" ".1 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "969 -1276 4"
+"_color" ".1 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "1196 -1275 4"
+"_color" ".1 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "1085 -1165 4"
+"_color" ".1 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "1087 -1392 4"
+"_color" ".1 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "1004 -1196 4"
+"_color" ".1 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "1172 -1360 4"
+"_color" ".1 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-632 312 104"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-864 432 104"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-712 312 104"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-564 686 32"
+"_color" "0 .8 .5"
+"style" "0"
+"light" "350"
+"classname" "light"
+}
+{
+"origin" "-864 312 104"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-576 528 64"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-896 -8 0"
+"_color" ".3 .6 .5"
+"style" "0"
+"light" "350"
+"classname" "light"
+}
+{
+"origin" "66 816 -212"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-938 418 -24"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-940 546 -24"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1240 8 40"
+"_color" ".5 1 3"
+"style" "10"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-880 808 104"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-880 720 192"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1296 80 72"
+"_color" ".5 1 3"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1168 80 72"
+"_color" ".5 1 3"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1168 -64 72"
+"_color" ".5 1 3"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1296 -64 72"
+"_color" ".5 1 3"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1295 144 200"
+"_color" ".5 1 3"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1167 144 200"
+"_color" ".5 1 3"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1169 -128 200"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1297 -128 200"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1392 65 200"
+"_color" ".5 1 3"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1392 -63 200"
+"_color" ".5 1 3"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "1088 -1256 -139"
+"_color" ".8 .5 .8"
+"targetname" "full"
+"style" "33"
+"light" "500"
+"spawnflags" "1"
+"classname" "light"
+}
+{
+"origin" "-971 -995 -148"
+"_color" ".6 .8 .1"
+"style" "5"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-968 -995 -52"
+"_color" ".6 .8 .1"
+"style" "5"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-750 -987 -53"
+"_color" ".6 .8 .1"
+"style" "5"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-753 -987 -149"
+"_color" ".6 .8 .1"
+"style" "5"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1104 -631 -144"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1104 -553 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1104 -503 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1104 -425 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1104 -375 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1104 -297 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1104 -247 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1104 -169 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1104 -119 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1104 -41 -144"
+"_color" ".2 .5 .6"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-944 -502 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-944 -424 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-944 -374 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-944 -296 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-944 -246 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-944 -168 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-944 -118 -144"
+"_color" ".6 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-944 -40 -144"
+"_color" ".2 .5 .6"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-920 -640 56"
+"_color" ".6 .8 .1"
+"style" "0"
+"light" "350"
+"classname" "light"
+}
+{
+"origin" "-1024 -688 56"
+"_color" ".6 .8 .1"
+"style" "0"
+"light" "400"
+"classname" "light"
+}
+{
+"origin" "320 -948 -200"
+"_color" ".3 .5 .4"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "188 -948 -200"
+"_color" ".3 .5 .4"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "60 -948 -200"
+"_color" ".3 .5 .4"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-56 -944 -200"
+"_color" ".3 .5 .4"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1024 176 -288"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-1024 112 -287"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-1168 656 -287"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-752 464 -168"
+"_color" ".2 .5 .6"
+"style" "0"
+"light" "400"
+"classname" "light"
+}
+{
+"origin" "-576 240 -181"
+"_color" ".2 .5 .6"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-392 -72 -160"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-168 -64 -240"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "24 -470 -368"
+"_color" "1 .7 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "176 -470 -368"
+"_color" "1 .7 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "327 -470 -368"
+"_cone" "10"
+"_color" "1 .7 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-127 -470 -368"
+"_color" "1 .7 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "24 -307 -368"
+"_color" "0 .7 .6"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "176 -307 -368"
+"_color" "0 .7 .6"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "327 -307 -368"
+"_color" "1 .7 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-127 -307 -368"
+"_color" "1 .7 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "24 -145 -368"
+"_color" "0 .7 .6"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "176 -145 -368"
+"_color" "0 .7 .6"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "327 -145 -368"
+"_color" "1 .7 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-127 -145 -368"
+"_color" "1 .7 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "24 16 -368"
+"_color" ".5 .5 1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "176 16 -368"
+"_color" ".5 .5 1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "327 16 -368"
+"_color" "1 .7 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-127 16 -368"
+"_color" "1 .7 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "24 -470 -304"
+"_color" ".5 .5 1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "176 -470 -304"
+"_color" ".5 .5 1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "327 -470 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-127 -470 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "24 -307 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "176 -307 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "327 -307 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-127 -307 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "24 -145 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "176 -145 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "327 -145 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-127 -145 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "24 16 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "176 16 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "327 16 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-127 16 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"model" "*1"
+"delay" "2"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "4"
+"sounds" "1"
+"speed" "56"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"model" "*2"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "4"
+"sounds" "1"
+"speed" "112"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"origin" "-696 -424 -128"
+"_color" "0 .8 .7"
+"style" "0"
+"light" "350"
+"classname" "light"
+}
+{
+"origin" "-456 -696 -168"
+"_color" "0 .8 .7"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-464 -320 -168"
+"_color" "0 .8 .7"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-1055 143 -287"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-991 143 -286"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-352 -632 -166"
+"_color" "0 .8 .7"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-744 288 -288"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-743 232 -288"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-743 176 -288"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-920 672 -264"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"model" "*3"
+"targetname" "p1"
+"health" "0"
+"dmg" "0"
+"lip" "96"
+"wait" "4"
+"sounds" "2"
+"speed" "100"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*4"
+"target" "p1"
+"health" "0"
+"wait" "0.2"
+"delay" "2"
+"sounds" "0"
+"classname" "trigger_multiple"
+}
+{
+"origin" "-1019 -675 -184"
+"_color" ".6 .8 .1"
+"classname" "light"
+}
+{
+"origin" "-987 -810 -155"
+"_color" ".6 .8 .1"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*5"
+"delay" "2"
+"health" "0"
+"dmg" "220"
+"lip" "-960"
+"wait" "3"
+"sounds" "1"
+"speed" "600"
+"targetname" "sled"
+"spawnflags" "32"
+"angle" "90"
+"classname" "func_door"
+}
+{
+"origin" "-200 -800 -166"
+"_color" "1 .7 .5"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "196 -768 -184"
+"_cone" "10"
+"_color" ".6 .6 1"
+"style" "0"
+"light" "600"
+"classname" "light"
+}
+{
+"origin" "-64 -656 -165"
+"_color" "1 .7 .5"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "692 -1280 0"
+"_color" "1 0 0"
+"targetname" "part"
+"style" "32"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "544 -1104 -80"
+"_color" ".7 .5 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "576 -848 -80"
+"_color" ".7 .5 0"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "576 -592 -80"
+"_color" ".7 .5 0"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "560 -1296 -80"
+"_color" ".7 .5 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "552 -336 -64"
+"_color" ".7 .5 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "560 -64 -16"
+"_color" ".7 .5 0"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "576 192 -16"
+"_color" ".7 .5 0"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "640 48 -16"
+"_color" ".7 .5 0"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-446 -62 171"
+"_color" "0 .2 .7"
+"classname" "light"
+}
+{
+"origin" "-446 -62 27"
+"classname" "light"
+}
+{
+"origin" "-734 816 190"
+"_color" "0 .3 .6"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-766 528 254"
+"_color" "0 .3 .6"
+"classname" "light"
+}
+{
+"origin" "-686 272 254"
+"_color" "0 .3 .6"
+"classname" "light"
+}
+{
+"origin" "-702 64 254"
+"classname" "light"
+}
+{
+"origin" "-702 -62 27"
+"_color" ".2 .6 .4"
+"classname" "light"
+}
+{
+"origin" "-702 194 75"
+"_color" ".2 .6 .4"
+"classname" "light"
+}
+{
+"origin" "-512 1104 -168"
+"_color" ".7 1 .3"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-344 1088 -160"
+"_color" "1 .5 0"
+"style" "0"
+"light" "175"
+"classname" "light"
+}
+{
+"origin" "-664 528 64"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-664 448 64"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-576 448 64"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"model" "*6"
+"health" "0"
+"wait" "5"
+"delay" ".5"
+"sounds" "0"
+"target" "m"
+"classname" "trigger_multiple"
+}
+{
+"origin" "-592 688 144"
+"_cone" "10"
+"_color" "1 .5 0"
+"style" "1"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-784 734 44"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-816 496 32"
+"_color" ".1 .5 .4"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"model" "*7"
+"delay" "2"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "4"
+"sounds" "1"
+"speed" "112"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*8"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "4"
+"sounds" "1"
+"speed" "56"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"model" "*9"
+"delay" "2"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "4"
+"sounds" "1"
+"speed" "112"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*10"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "4"
+"sounds" "1"
+"speed" "56"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"model" "*11"
+"message" "Contamination - Sect4AQ Sealed"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "4"
+"sounds" "1"
+"speed" "112"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*12"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "4"
+"sounds" "1"
+"speed" "56"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"model" "*13"
+"delay" "4"
+"target" "sled"
+"health" "0"
+"wait" "4"
+"sounds" "1"
+"speed" "100"
+"angle" "-2"
+"classname" "func_button"
+}
+{
+"origin" "-446 -382 91"
+"_color" "0 .8 .7"
+"classname" "light"
+}
+{
+"origin" "-264 -912 -224"
+"_color" ".2 .6 .5"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-496 -912 -292"
+"_color" ".2 .6 .5"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-576 -930 -304"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-576 -802 -304"
+"_color" ".2 .6 .5"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-576 -672 -304"
+"_color" ".2 .6 .5"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-576 -516 -304"
+"_color" ".2 .6 .5"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-576 -360 -304"
+"_color" ".2 .6 .5"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"model" "*14"
+"target" "sled"
+"health" "0"
+"wait" "5"
+"delay" "2"
+"sounds" "0"
+"classname" "trigger_multiple"
+}
+{
+"model" "*15"
+"targetname" "enddoor"
+"delay" "0"
+"health" "0"
+"dmg" "0"
+"lip" "24"
+"wait" "-1"
+"sounds" "1"
+"speed" "112"
+"spawnflags" "3840"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*16"
+"delay" "0"
+"targetname" "enddoor"
+"health" "0"
+"dmg" "0"
+"lip" "24"
+"wait" "-1"
+"sounds" "1"
+"speed" "56"
+"spawnflags" "3840"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"origin" "-904 340 256"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "448 -624 -112"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "320 -768 -160"
+"style" "0"
+"light" "170"
+"classname" "light"
+}
+{
+"origin" "-372 -912 -256"
+"_color" ".2 .6 .5"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-1388 -528 222"
+"_color" "1 .6 0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1324 -456 222"
+"_color" "1 .6 0"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1236 -408 222"
+"_color" "1 .6 0"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1100 -400 222"
+"light" "150"
+"_color" "1 .6 0"
+"classname" "light"
+}
+{
+"origin" "-988 -432 222"
+"_color" "1 .6 0"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-992 -536 136"
+"_color" "1 .6 0"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1054 -536 135"
+"_color" "1 .6 0"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1236 -304 222"
+"_color" "1 .6 0"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-848 1040 0"
+"_color" ".7 1 .3"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-720 1032 0"
+"_color" ".7 1 .3"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-520 1104 80"
+"_color" "1 .7 .2"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*17"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "10"
+"sounds" "1"
+"speed" "112"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"model" "*18"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "10"
+"sounds" "1"
+"speed" "224"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"origin" "416 192 12"
+"_color" ".4 1 0"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-216 1104 144"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "350"
+"classname" "light"
+}
+{
+"origin" "320 520 153"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "450"
+"classname" "light"
+}
+{
+"origin" "329 264 160"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-304 624 52"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-304 964 52"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-408 -72 -296"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-560 -40 -235"
+"_color" "0 .2 .7"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-568 112 -195"
+"_color" "0 .2 .7"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "160 -302 0"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "159 -146 0"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "176 -162 0"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "176 -285 0"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "17 -286 0"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "34 -146 0"
+"_color" "0 .5 1"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "18 -163 0"
+"_color" "0 .5 1"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "34 -302 0"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "160 -302 128"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "184 -112 128"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "176 -162 128"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "208 -312 128"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "17 -286 128"
+"_color" "0 .5 1"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "34 -146 128"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-15 -136 128"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "8 -336 128"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "160 -302 -128"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "184 -112 -128"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "176 -162 -128"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "208 -312 -128"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "17 -286 -128"
+"_color" "0 .5 1"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "34 -146 -128"
+"_color" "0 .5 1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-15 -136 -128"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "8 -336 -128"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-752 -800 -32"
+"_color" "0 .5 .6"
+"style" "0"
+"light" "350"
+"classname" "light"
+}
+{
+"origin" "-910 0 206"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "56 1152 -8"
+"_color" "1 .7 .2"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "344 808 -48"
+"_color" ".4 1 0"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-288 1168 -64"
+"_color" "1 .7 .2"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"model" "*19"
+"dmg" "0"
+"wait" "4"
+"spawnflags" "2"
+"classname" "func_door_secret"
+}
+{
+"origin" "-1350 -302 52"
+"_color" "1 .6 0"
+"targetname" "secret5"
+"style" "34"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*20"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "10"
+"sounds" "1"
+"speed" "112"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"model" "*21"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "10"
+"sounds" "1"
+"speed" "224"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"origin" "1088 -1584 -241"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-864 -976 32"
+"_color" ".6 1 0"
+"style" "5"
+"light" "200"
+"classname" "light"
+}
+{
+"model" "*22"
+"targetname" "o"
+"delay" "0"
+"health" "0"
+"dmg" "0"
+"lip" "-1"
+"wait" "0"
+"sounds" "1"
+"speed" "100"
+"spawnflags" "32"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"model" "*23"
+"targetname" "m"
+"delay" "0"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "0"
+"sounds" "1"
+"speed" "100"
+"spawnflags" "32"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"origin" "-702 -62 203"
+"classname" "light"
+}
+{
+"model" "*24"
+"health" "0"
+"wait" "0.2"
+"delay" "0"
+"sounds" "0"
+"target" "endkey"
+"classname" "trigger_multiple"
+}
+{
+"origin" "672 -1132 -224"
+"classname" "trigger_relay"
+}
+{
+"origin" "-204 12 -147"
+"classname" "trigger_relay"
+}
+{
+"origin" "-204 -478 68"
+"classname" "trigger_relay"
+}
+{
+"origin" "-184 40 -146"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1320 16 40"
+"classname" "info_player_start"
+}
+{
+"origin" "1520 -1280 -48"
+"light" "400"
+"classname" "light"
+}
+{
+"origin" "106 -770 -168"
+"angle" "180"
+"classname" "key_commander_head"
+}
+{
+"origin" "584 -1104 -112"
+"item" "key_commander_head"
+"health" "0"
+"wait" "0.2"
+"delay" "0"
+"sounds" "0"
+"target" "headdoor"
+"targetname" "headkey"
+"classname" "trigger_key"
+}
+{
+"model" "*25"
+"health" "0"
+"wait" "5"
+"delay" "2"
+"sounds" "0"
+"target" "o"
+"classname" "trigger_multiple"
+}
+{
+"origin" "-512 1216 16"
+"_color" "1 .7 .2"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1024 320 -176"
+"_color" ".2 .5 .6"
+"style" "0"
+"light" "400"
+"classname" "light"
+}
+{
+"model" "*26"
+"message" "The Head of Gorok!!"
+"classname" "trigger_once"
+}
+{
+"model" "*27"
+"message" "A foul stench of rotting flesh . . ."
+"classname" "trigger_once"
+}
+{
+"model" "*28"
+"delay" "2"
+"target" "rumb"
+"message" "oh oh.  It's a trap--get out!"
+"classname" "trigger_once"
+}
+{
+"origin" "-132 -764 -184"
+"speed" "400"
+"count" "5"
+"targetname" "rumb"
+"classname" "target_earthquake"
+}
+{
+"origin" "-84 -768 -184"
+"dmg" "150"
+"delay" "5"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "-112 -812 -184"
+"speed" "5"
+"message" "az"
+"target" "rumblite"
+"targetname" "rumb"
+"classname" "target_lightramp"
+}
+{
+"origin" "-76 -812 -184"
+"_color" "1 0 0"
+"_cone" "10"
+"style" "35"
+"light" "600"
+"targetname" "rumblite"
+"spawnflags" "1"
+"classname" "light"
+}
+{
+"origin" "-240 -768 -184"
+"dmg" "150"
+"delay" "4"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "-64 -684 -184"
+"dmg" "150"
+"delay" "5"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "16 -748 -184"
+"dmg" "150"
+"delay" "5.5"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "-68 -512 -184"
+"dmg" "150"
+"delay" "6"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "92 -768 -236"
+"_color" "1 .7 .5"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "132 -500 -80"
+"dmg" "150"
+"delay" "6.1"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "100 -372 -80"
+"dmg" "150"
+"delay" "6.3"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "-76 -208 -80"
+"dmg" "150"
+"delay" "6.5"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "56 -388 8"
+"dmg" "150"
+"delay" "7"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "344 -804 -188"
+"item" "key_power_cube"
+"health" "0"
+"wait" "0.2"
+"delay" "0"
+"sounds" "0"
+"target" "enddoor"
+"targetname" "endkey"
+"classname" "trigger_key"
+"spawnflags" "3840"
+}
+{
+"model" "*29"
+"dmg" "200"
+"health" "0"
+"wait" "0"
+"delay" "0"
+"targetname" "rumboom"
+"mass" "800"
+"classname" "func_explosive"
+}
+{
+"origin" "-500 996 80"
+"_color" ".7 1 .3"
+"style" "0"
+"light" "300"
+"classname" "light"
+}
+{
+"origin" "-1344 -384 64"
+"_color" "1 .6 0"
+"targetname" "secret5"
+"style" "34"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-48 -448 -48"
+"dmg" "150"
+"delay" "6"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "-96 -432 -40"
+"dmg" "150"
+"delay" "6"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "-112 -512 -112"
+"dmg" "150"
+"delay" "6"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "-32 -520 -96"
+"dmg" "150"
+"delay" "6"
+"targetname" "rumb"
+"classname" "target_explosion"
+}
+{
+"origin" "944 -784 -160"
+"_color" "1 .5 0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "1200 -784 -160"
+"_color" "1 .5 0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "944 -256 -160"
+"_color" "1 .5 0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "1200 -256 -160"
+"_color" "1 .5 0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "728 -792 -152"
+"_color" "1 .5 0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "728 -264 -152"
+"_color" "1 .5 0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "-200 1160 456"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "350"
+"classname" "light"
+}
+{
+"origin" "-64 956 487"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "32 872 472"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-64 788 471"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "128 424 528"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "345 320 472"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "208 344 528"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "32 272 528"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-64 423 528"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "-232 344 528"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "336 576 465"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "450"
+"classname" "light"
+}
+{
+"origin" "248 1120 464"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "400"
+"classname" "light"
+}
+{
+"origin" "-160 871 472"
+"_color" "1 .6 .1"
+"style" "0"
+"light" "200"
+"classname" "light"
+}
+{
+"origin" "112 -416 -112"
+"wait" "0"
+"delay" "7"
+"target" "rumboom"
+"targetname" "rumb"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1220 0 40"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "-1264 44 40"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-980 -4 32"
+"angle" "183"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-1036 -4 32"
+"angle" "158"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-1308 152 152"
+"classname" "item_health_large"
+}
+{
+"origin" "-1232 148 152"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-1308 -136 148"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-1224 -132 152"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-900 492 0"
+"spawnflags" "1"
+"angle" "274"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-896 324 0"
+"spawnflags" "1"
+"angle" "274"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-576 512 4"
+"spawnflags" "1"
+"angle" "232"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-712 468 12"
+"angle" "238"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-800 864 -12"
+"spawnflags" "1"
+"angle" "274"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-760 780 -36"
+"spawnflags" "1"
+"angle" "274"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-788 724 -36"
+"spawnflags" "1"
+"angle" "274"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-632 492 -16"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-632 440 -16"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-580 468 -16"
+"classname" "item_health_large"
+}
+{
+"origin" "-632 996 12"
+"spawnflags" "1"
+"angle" "185"
+"classname" "monster_infantry"
+}
+{
+"origin" "-572 1008 0"
+"spawnflags" "1"
+"angle" "185"
+"classname" "monster_infantry"
+}
+{
+"origin" "-700 1004 8"
+"angle" "176"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-892 1016 4"
+"classname" "weapon_supershotgun"
+}
+{
+"origin" "-504 1056 -200"
+"spawnflags" "1"
+"angle" "99"
+"classname" "monster_infantry"
+}
+{
+"origin" "-384 1056 -204"
+"angle" "182"
+"classname" "monster_infantry"
+}
+{
+"origin" "232 996 -192"
+"spawnflags" "1"
+"angle" "177"
+"classname" "monster_hover"
+}
+{
+"origin" "172 960 -180"
+"spawnflags" "1"
+"angle" "177"
+"classname" "monster_hover"
+}
+{
+"origin" "140 1020 -180"
+"spawnflags" "1"
+"angle" "183"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "116 948 -168"
+"spawnflags" "1"
+"angle" "183"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "280 520 -36"
+"spawnflags" "1"
+"angle" "90"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "288 580 -32"
+"spawnflags" "1"
+"angle" "90"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "88 572 -60"
+"spawnflags" "1"
+"angle" "42"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "96 512 -64"
+"spawnflags" "1"
+"angle" "42"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-92 572 -72"
+"spawnflags" "1"
+"angle" "42"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-84 512 -76"
+"spawnflags" "1"
+"angle" "42"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "412 1020 544"
+"angle" "183"
+"classname" "monster_gunner"
+}
+{
+"origin" "412 636 544"
+"angle" "183"
+"classname" "monster_gunner"
+}
+{
+"origin" "-336 472 548"
+"angle" "354"
+"classname" "monster_gunner"
+}
+{
+"origin" "-352 852 548"
+"angle" "183"
+"classname" "monster_gunner"
+}
+{
+"origin" "-68 1248 552"
+"angle" "183"
+"classname" "monster_gunner"
+}
+{
+"origin" "128 1248 552"
+"angle" "183"
+"classname" "monster_gunner"
+}
+{
+"origin" "-72 812 488"
+"targetname" "fball1"
+"dmg" "100"
+"delay" "0"
+"classname" "target_explosion"
+}
+{
+"origin" "-100 812 492"
+"delay" "0"
+"random" "2"
+"target" "fball1"
+"pausetime" "0"
+"wait" "5"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"origin" "-60 296 520"
+"targetname" "fball3"
+"dmg" "100"
+"delay" "0"
+"classname" "target_explosion"
+}
+{
+"origin" "-88 296 524"
+"delay" "0"
+"random" "1"
+"target" "fball3"
+"pausetime" "0"
+"wait" "4"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"origin" "132 292 468"
+"targetname" "fball2"
+"dmg" "100"
+"delay" "0"
+"classname" "target_explosion"
+}
+{
+"origin" "104 292 472"
+"delay" "0"
+"random" "1"
+"target" "fball2"
+"pausetime" "1"
+"wait" "3"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"origin" "1088 -1280 -196"
+"target" "theend"
+"spawnflags" "1"
+"angle" "182"
+"classname" "monster_supertank"
+}
+{
+"origin" "336 296 -80"
+"classname" "item_health_large"
+}
+{
+"origin" "392 296 -80"
+"classname" "ammo_bullets"
+}
+{
+"origin" "336 224 -88"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-328 336 -80"
+"classname" "weapon_hyperblaster"
+}
+{
+"origin" "-320 232 -80"
+"classname" "ammo_cells"
+}
+{
+"origin" "-328 384 -80"
+"classname" "ammo_cells"
+}
+{
+"origin" "-320 568 -24"
+"spawnflags" "1"
+"angle" "317"
+"classname" "monster_hover"
+}
+{
+"origin" "-320 192 -16"
+"spawnflags" "1"
+"angle" "39"
+"classname" "monster_hover"
+}
+{
+"origin" "632 104 -88"
+"spawnflags" "1"
+"angle" "90"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "632 48 -80"
+"spawnflags" "1"
+"angle" "90"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "632 -8 -80"
+"spawnflags" "1"
+"angle" "90"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "552 -144 -96"
+"spawnflags" "1"
+"angle" "88"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "552 -216 -112"
+"spawnflags" "1"
+"angle" "88"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "552 -288 -88"
+"spawnflags" "1"
+"angle" "88"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "832 -552 -176"
+"spawnflags" "1"
+"angle" "183"
+"classname" "monster_gunner"
+}
+{
+"origin" "968 -584 -176"
+"spawnflags" "1"
+"angle" "183"
+"classname" "monster_gunner"
+}
+{
+"origin" "960 -440 -160"
+"spawnflags" "1"
+"angle" "183"
+"classname" "monster_gunner"
+}
+{
+"origin" "600 -744 -152"
+"spawnflags" "1"
+"classname" "monster_infantry"
+}
+{
+"origin" "592 -888 -136"
+"angle" "95"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "728 -1288 -136"
+"classname" "weapon_rocketlauncher"
+}
+{
+"origin" "960 -1496 -152"
+"classname" "weapon_grenadelauncher"
+}
+{
+"origin" "1488 -1408 -136"
+"classname" "item_health_mega"
+}
+{
+"origin" "1296 -1256 -160"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"origin" "1304 -1344 -168"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"origin" "1272 -1176 -144"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"origin" "1376 -1200 -136"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"origin" "208 -952 -208"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "112 -960 -208"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-568 -736 -336"
+"spawnflags" "1"
+"angle" "267"
+"classname" "monster_flipper"
+}
+{
+"origin" "-720 -456 -208"
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-720 -504 -208"
+"spawnflags" "1"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-608 -480 -224"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-560 -440 -216"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-240 1056 -200"
+"classname" "weapon_rocketlauncher"
+}
+{
+"origin" "-120 1056 -216"
+"classname" "weapon_rocketlauncher"
+}
+{
+"origin" "-48 1048 -184"
+"classname" "weapon_rocketlauncher"
+}
+{
+"origin" "128 776 -216"
+"classname" "item_health_large"
+}
+{
+"origin" "128 824 -224"
+"classname" "item_health_large"
+}
+{
+"origin" "256 -384 -152"
+"spawnflags" "1"
+"angle" "96"
+"classname" "monster_medic"
+}
+{
+"origin" "288 -56 -80"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_medic"
+}
+{
+"origin" "-32 -64 -8"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "80 -64 -56"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-888 -744 -176"
+"angle" "142"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-888 -824 -160"
+"angle" "116"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-824 -800 -176"
+"angle" "129"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-704 -920 -160"
+"angle" "138"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-704 -840 -176"
+"angle" "147"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-768 -784 -176"
+"angle" "145"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-768 -864 -160"
+"angle" "152"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-992 -576 -152"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-992 -496 -168"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-1056 -440 -168"
+"angle" "86"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-1056 -520 -152"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-1000 -328 -160"
+"angle" "89"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-1000 -248 -176"
+"angle" "88"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-1064 -192 -176"
+"angle" "86"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-1064 -272 -160"
+"angle" "82"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-776 72 -296"
+"spawnflags" "1"
+"angle" "270"
+"classname" "monster_flipper"
+}
+{
+"origin" "-896 256 -304"
+"angle" "270"
+"classname" "monster_flipper"
+}
+{
+"origin" "-1024 320 -200"
+"classname" "weapon_hyperblaster"
+}
+{
+"origin" "-976 312 -200"
+"classname" "ammo_cells"
+}
+{
+"origin" "-88 -56 -32"
+"classname" "item_health_large"
+}
+{
+"origin" "-144 -392 24"
+"classname" "weapon_hyperblaster"
+}
+{
+"origin" "-56 -392 40"
+"classname" "ammo_cells"
+}
+{
+"origin" "-144 -64 -16"
+"classname" "weapon_grenadelauncher"
+}
+{
+"origin" "40 -56 -8"
+"classname" "item_health_large"
+}
+{
+"origin" "732 -1332 -156"
+"classname" "ammo_rockets"
+}
+{
+"origin" "724 -1188 -132"
+"classname" "item_health_large"
+}
+{
+"origin" "152 520 -64"
+"classname" "item_health_large"
+}
+{
+"origin" "-40 508 -68"
+"classname" "item_health_large"
+}
+{
+"origin" "1196 -468 -128"
+"classname" "item_armor_body"
+}
+{
+"origin" "1200 -552 -132"
+"classname" "item_health_large"
+}
+{
+"origin" "-595 689 -31"
+"angle" "176"
+"classname" "item_health_large"
+}
+{
+"origin" "293 720 -231"
+"angle" "178"
+"classname" "ammo_rockets"
+}
+{
+"origin" "-213 654 -231"
+"angle" "114"
+"classname" "ammo_rockets"
+}
+{
+"origin" "-224 972 -231"
+"classname" "item_health_small"
+}
+{
+"origin" "-120 972 -231"
+"angle" "1"
+"classname" "item_health_small"
+}
+{
+"origin" "-21 974 -231"
+"angle" "2"
+"classname" "item_health_small"
+}
+{
+"origin" "-311 1170 -103"
+"angle" "-51"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-82 1180 -103"
+"angle" "35"
+"classname" "ammo_bullets"
+}
+{
+"origin" "337 1236 -103"
+"spawnflags" "1"
+"angle" "-104"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "67 1223 -103"
+"spawnflags" "1"
+"angle" "-77"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-293 1140 -103"
+"spawnflags" "1"
+"angle" "-90"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-330 755 -103"
+"spawnflags" "1"
+"angle" "-53"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-986 99 -7"
+"angle" "137"
+"classname" "item_health_small"
+}
+{
+"origin" "-833 -69 -7"
+"angle" "-57"
+"classname" "item_health_small"
+}
+{
+"origin" "-841 122 -7"
+"angle" "90"
+"classname" "item_health_small"
+}
+{
+"origin" "-905 137 -7"
+"angle" "137"
+"classname" "item_health_small"
+}
+{
+"origin" "-736 820 112"
+"spawnflags" "1"
+"angle" "-7"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-344 832 112"
+"spawnflags" "1"
+"angle" "178"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-92 705 112"
+"spawnflags" "1"
+"angle" "-95"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-718 247 176"
+"spawnflags" "1"
+"angle" "111"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-318 297 176"
+"spawnflags" "1"
+"angle" "85"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-486 -74 120"
+"spawnflags" "1"
+"angle" "-176"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-635 -16 120"
+"angle" "-171"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-360 -378 24"
+"spawnflags" "1"
+"angle" "178"
+"classname" "monster_infantry"
+}
+{
+"origin" "-71 -212 -6"
+"spawnflags" "1"
+"angle" "-98"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "357 24 -391"
+"angle" "-178"
+"classname" "item_health_large"
+}
+{
+"origin" "338 -455 -391"
+"angle" "-88"
+"classname" "item_health_large"
+}
+{
+"origin" "-152 -462 -391"
+"angle" "-87"
+"classname" "weapon_chaingun"
+}
+{
+"origin" "-414 60 -327"
+"angle" "-169"
+"classname" "item_health_large"
+}
+{
+"origin" "259 -443 17"
+"spawnflags" "1"
+"angle" "147"
+"classname" "monster_flyer"
+}
+{
+"origin" "315 -22 16"
+"spawnflags" "1"
+"angle" "-162"
+"classname" "monster_flyer"
+}
+{
+"origin" "-903 49 -7"
+"angle" "86"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-443 837 112"
+"spawnflags" "1"
+"angle" "-157"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-68 933 112"
+"spawnflags" "1"
+"angle" "85"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "157 388 176"
+"spawnflags" "1"
+"angle" "108"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-66 384 176"
+"spawnflags" "1"
+"angle" "94"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-466 293 176"
+"spawnflags" "1"
+"angle" "-179"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-900 211 176"
+"spawnflags" "1"
+"angle" "92"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-1017 -80 176"
+"spawnflags" "1"
+"angle" "8"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-59 -391 24"
+"spawnflags" "1"
+"angle" "-177"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-209 -783 -231"
+"spawnflags" "1"
+"angle" "1"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-551 158 -31"
+"spawnflags" "1"
+"angle" "-173"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-413 79 -39"
+"angle" "-97"
+"classname" "item_health_large"
+}
+{
+"origin" "-495 79 -39"
+"angle" "-64"
+"classname" "item_health_large"
+}
+{
+"origin" "-21 -938 -231"
+"spawnflags" "1"
+"angle" "-5"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-1030 -871 -167"
+"spawnflags" "1"
+"angle" "90"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-756 -509 -199"
+"spawnflags" "1"
+"angle" "1"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-577 290 176"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-415 286 176"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-287 286 176"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-919 -88 176"
+"angle" "178"
+"classname" "item_health_small"
+}
+{
+"origin" "-903 103 176"
+"angle" "-176"
+"classname" "item_health_small"
+}
+{
+"origin" "-911 135 176"
+"spawnflags" "1"
+"angle" "-73"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-650 -30 120"
+"angle" "38"
+"classname" "weapon_rocketlauncher"
+}
+{
+"origin" "-693 98 -31"
+"angle" "-85"
+"classname" "item_health_large"
+}
+{
+"origin" "-583 161 -31"
+"angle" "-24"
+"classname" "weapon_chaingun"
+}
+{
+"origin" "857 -1494 -167"
+"angle" "-1"
+"classname" "item_health_large"
+}
+{
+"origin" "1345 -1474 -167"
+"angle" "-150"
+"classname" "ammo_rockets"
+}
+{
+"origin" "1461 -1102 -167"
+"angle" "164"
+"classname" "ammo_rockets"
+}
+{
+"origin" "580 -1285 -167"
+"angle" "3"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-789 -717 -183"
+"spawnflags" "1"
+"angle" "160"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-897 -685 -199"
+"spawnflags" "1"
+"angle" "126"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "-695 -765 -183"
+"spawnflags" "1"
+"angle" "149"
+"classname" "monster_soldier_light"
+}
+{
+"origin" "896 -1368 -64"
+"map" "jug20"
+"targetname" "te"
+"classname" "target_changelevel"
+}
+{
+"origin" "-468 1086 -206"
+"_color" ".7 1 .3"
+"style" "0"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*30"
+"targetname" "headdoor"
+"delay" "0"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "-1"
+"sounds" "1"
+"speed" "56"
+"angle" "-2"
+"classname" "func_door"
+}
+{
+"model" "*31"
+"delay" "0"
+"targetname" "headdoor"
+"health" "0"
+"dmg" "0"
+"lip" "16"
+"wait" "-1"
+"sounds" "1"
+"speed" "112"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*32"
+"delay" "0"
+"target" "headkey"
+"classname" "trigger_multiple"
+}
+{
+"origin" "928 -1320 -64"
+"health" "0"
+"wait" "0.2"
+"delay" "6"
+"sounds" "0"
+"target" "te"
+"targetname" "theend"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1319 16 -7"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-907 25 -7"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-741 342 -23"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-848 736 -55"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-798 1027 -39"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-523 1066 -39"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-486 1088 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-277 1058 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "224 869 -65"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-224 667 -42"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-310 279 -38"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-260 1047 -22"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-50 1076 110"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "78 594 154"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-141 470 240"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-260 249 219"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-256 1115 -10"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "206 939 -109"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-245 655 -89"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "584 -141 -103"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "585 -300 -135"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "583 -517 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "542 -751 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "552 -969 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1126 -532 -167"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "941 -228 -167"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "945 -732 -167"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "822 -1482 -167"
+"noise" "world/klaxon1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1101 -1522 -167"
+"noise" "world/klaxon1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1410 -1441 -167"
+"noise" "world/klaxon1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1429 -1087 -167"
+"noise" "world/klaxon1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "949 -1109 -247"
+"noise" "world/klaxon1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1106 -1415 -247"
+"noise" "world/klaxon1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1229 -1224 -247"
+"noise" "world/klaxon1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1371 -1360 -247"
+"noise" "world/klaxon1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "868 -1266 -247"
+"noise" "world/klaxon1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1283 11 -7"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1283 11 -7"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1283 11 -7"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-900 159 -7"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-868 276 -23"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-832 341 -23"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-688 368 -7"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-606 372 -7"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-618 481 -7"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-685 525 -7"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-702 607 -10"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-803 978 -39"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-752 1063 -39"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-619 1034 -39"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-577 1066 -39"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-515 1141 -39"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-491 1155 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-447 1063 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-416 1046 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-203 1057 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-67 1058 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "84 1011 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "131 980 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "280 903 -218"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "257 756 -140"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "205 603 -103"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "91 619 -103"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "540 181 -103"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "649 152 -103"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "684 31 -103"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "650 -80 -103"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "584 -168 -105"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "590 -299 -132"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "590 -455 -166"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "570 -600 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "553 -746 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "553 -899 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "568 -1020 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "743 -497 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "856 -476 -193"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "983 -501 -199"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1098 -553 -174"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "30 629 -103"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "244 635 -103"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "375 752 -103"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "343 965 -103"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "222 1129 -103"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-7 1141 -103"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-203 1123 -103"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-280 926 -103"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-247 706 -103"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-106 614 -103"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "70 773 -231"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "227 713 -231"
+"noise" "world/amb12.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-102 653 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-181 656 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-255 728 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-242 847 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-231 935 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-555 857 112"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-617 848 112"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-703 784 112"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-726 663 150"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-760 539 184"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-763 411 184"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-711 294 176"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-569 282 176"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-498 276 176"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-685 169 170"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-724 22 168"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-769 -68 168"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-896 -69 176"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1006 -35 176"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1001 82 176"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-636 -110 154"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-515 -16 120"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-426 -104 120"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-422 -235 89"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-321 -426 24"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-135 -393 24"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-83 -241 3"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-121 -70 -39"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-121 -70 -39"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-121 -70 -39"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "196 -45 -100"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "197 -44 -100"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "197 -44 -100"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "269 -343 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "269 -343 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "269 -343 -167"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-57 -396 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-57 -396 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-57 -396 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-16 -778 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-16 -778 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-16 -778 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-16 -778 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-16 -778 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-16 -778 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-134 -782 -231"
+"noise" "world/amb18.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1334 4 36"
+"targetname" "msgtrig"
+"target" "helpmsg"
+"classname" "trigger_always"
+}
+{
+"origin" "-1326 -12 24"
+"message" "Ship...leave..\nstop... st... sh..."
+"targetname" "helpmsg"
+"spawnflags" "1"
+"classname" "target_help"
+}
+{
+"origin" "-1350 26 24"
+"message" "..."
+"targetname" "helpmsg"
+"classname" "target_help"
+}
+{
+"origin" "-1323 -68 -7"
+"angle" "22"
+"classname" "info_player_coop"
+}
+{
+"origin" "-1334 80 -7"
+"angle" "-6"
+"classname" "info_player_coop"
+}
+{
+"origin" "-1232 96 -7"
+"angle" "-28"
+"classname" "info_player_coop"
+}
+{
+"origin" "-1204 -73 -7"
+"angle" "37"
+"classname" "info_player_coop"
+}
+{
+"origin" "-1129 -63 -7"
+"angle" "47"
+"classname" "info_player_coop"
+}
+{
+"origin" "-1123 59 -7"
+"angle" "-29"
+"classname" "info_player_coop"
+}
+{
+"classname" "path_corner"
+"targetname" "teledest"
+"origin" "-1320 16 0"
+}
+{
+"classname" "misc_teleporter"
+"origin" "315 -635 -223"
+"target" "teledest"
+}
+{
+"classname" "item_power_shield"
+"origin" "-845 -965 8"
+}


### PR DESCRIPTION
This PR fixes the following bugs: https://github.com/yquake2/yquake2/issues/689 https://github.com/yquake2/yquake2/issues/687

In addition I implemented the code hacks as map fixes (city2, city3, cool1, lab), as well as fixing some additional bugs reported within the bug reports (city1). There are other more minor fixes, like fixing "duration is not a field" console warning in biggun and using an orphaned target_explosion entity in base2.

I removed the code hacks for the following reasons:
1. They make correct configuration more complicated and easy to mess up.
2. They are incomplete. A lot of the bugs found were not addressed by them and the hack for map "lab" was not even fully working.
3. Only the absolutely most die-hard Q2 fans will notice any difference, and even then I doubt they will mind having to kill an extra enemy or two in a couple of levels.

I have a question for @Yamagi, how would you like me to document the map fixes in the YQ2 docs?