### PR TITLE
Shark bbox fix and added check for inuse after entity thinking

### DIFF
--- a/src/game/g_phys.c
+++ b/src/game/g_phys.c
@@ -924,6 +924,12 @@ SV_Physics_Toss(edict_t *ent)
 	/* regular thinking */
 	SV_RunThink(ent);
 
+	/* entities are very often freed during thinking */
+	if (!ent->inuse)
+	{
+		return;
+	}
+
 	/* if not a team captain, so movement
 	   will be handled elsewhere */
 	if (ent->flags & FL_TEAMSLAVE)

--- a/src/game/monster/flipper/flipper.c
+++ b/src/game/monster/flipper/flipper.c
@@ -356,13 +356,24 @@ flipper_pain(edict_t *self, edict_t *other /* unused */,
 void
 flipper_dead(edict_t *self)
 {
+	vec3_t p;
+	trace_t tr;
+
 	if (!self)
 	{
 		return;
 	}
 
-	VectorSet(self->mins, -16, -16, -24);
-	VectorSet(self->maxs, 16, 16, -8);
+	/* original dead bbox was wrong - and make sure the bbox adjustment stays in solidity */
+
+	p[0] = self->s.origin[0];
+	p[1] = self->s.origin[1];
+	p[2] = self->s.origin[2] - 8;
+
+	tr = gi.trace(self->s.origin, self->mins, self->maxs, p, self, self->clipmask);
+
+	self->mins[2] = tr.endpos[2] - self->s.origin[2];
+
 	self->movetype = MOVETYPE_TOSS;
 	self->svflags |= SVF_DEADMONSTER;
 	self->nextthink = 0;


### PR DESCRIPTION
This PR fixes bug https://github.com/yquake2/yquake2/issues/704

flipper_dead() sets the dead bbox top and bottom planes incorrectly. This is likely a copy/paste error by id. Unlike most monsters, the flipper's point of origin is at the bottom of its model, so mins[2] is 0, however the death code sets mins to -24 and maxs to -8, not only moving the bbox but actually leaving the model completely.

This makes it hard for the player to know where to actually shoot to gib the dead body, and because the bbox moves, it means it might clip into the world and this causes the entity to freefall forever.

I fixed this by keeping maxs[2] unchanged and doing a trace downwards by 8 units, so mins[2] will be anywhere from 0 to -8 based on if/when the trace hits an obstacle.

I also snuck in a small inuse check after SV_RunThink() in SV_Physics_Toss(). Entities are very often freed while thinking so this both prevents wasteful physics calculations and reduces the risk of writing data to a freed entity.