### PR TITLE
Fix for some player sound bugs

### DIFF
--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -1048,7 +1048,7 @@ struct edict_s
 	int dmg;
 	int radius_dmg;
 	float dmg_radius;
-	int sounds; /* make this a spawntemp var? */
+	int sounds; /* now also used for player death sound aggregation */
 	int count;
 
 	edict_t *chain;

--- a/src/game/player/client.c
+++ b/src/game/player/client.c
@@ -908,9 +908,8 @@ player_die(edict_t *self, edict_t *inflictor, edict_t *attacker,
 
 	if (self->health < -40)
 	{
-		/* gib */
-		gi.sound(self, CHAN_BODY, gi.soundindex(
-						"misc/udeath.wav"), 1, ATTN_NORM, 0);
+		/* gib (sound is played at end of server frame) */
+		self->sounds = gi.soundindex("misc/udeath.wav");
 
 		for (n = 0; n < 4; n++)
 		{
@@ -958,8 +957,12 @@ player_die(edict_t *self, edict_t *inflictor, edict_t *attacker,
 				}
 			}
 
-			gi.sound(self, CHAN_VOICE, gi.soundindex(va("*death%i.wav",
-							(randk() % 4) + 1)), 1, ATTN_NORM, 0);
+			/* sound is played at end of server frame */
+			if (!self->sounds)
+			{
+				self->sounds = gi.soundindex(va("*death%i.wav",
+								(randk() % 4) + 1));
+			}
 		}
 	}
 

--- a/src/game/player/view.c
+++ b/src/game/player/view.c
@@ -82,6 +82,13 @@ P_DamageFeedback(edict_t *player)
 		return;
 	}
 
+	/* death/gib sound is now aggregated and played here */
+	if (player->sounds)
+	{
+		gi.sound (player, CHAN_VOICE, player->sounds, 1, ATTN_NORM, 0);
+		player->sounds = 0;
+	}
+
 	client = player->client;
 
 	/* flash the backgrounds behind the status numbers */
@@ -151,7 +158,8 @@ P_DamageFeedback(edict_t *player)
 	/* play an apropriate pain sound */
 	if ((level.time > player->pain_debounce_time) &&
 		!(player->flags & FL_GODMODE) &&
-		(client->invincible_framenum <= level.framenum))
+		(client->invincible_framenum <= level.framenum) &&
+		player->health > 0)
 	{
 		r = 1 + (randk() & 1);
 		player->pain_debounce_time = level.time + 0.7;
@@ -908,7 +916,8 @@ P_WorldEffects(void)
 		{
 			if ((current_player->health > 0) &&
 				(current_player->pain_debounce_time <= level.time) &&
-				(current_client->invincible_framenum < level.framenum))
+				(current_client->invincible_framenum < level.framenum) &&
+				!(current_player->flags & FL_GODMODE))
 			{
 				if (randk() & 1)
 				{
@@ -1026,6 +1035,11 @@ G_SetClientEvent(edict_t *ent)
 		return;
 	}
 
+	if (ent->health <= 0)
+	{
+		return;
+	}
+
 	if (g_footsteps->value == 1)
 	{
 		if (ent->groundentity && (xyspeed > 225))
@@ -1036,7 +1050,7 @@ G_SetClientEvent(edict_t *ent)
 			}
 		}
 	}
-	if (g_footsteps->value == 2)
+	else if (g_footsteps->value == 2)
 	{
 		if ((int)(current_client->bobtime + bobmove) != bobcycle)
 		{


### PR DESCRIPTION
This PR fixes some bugs with player sounds.

* Player does pain sound in lava with godmode on

A small oversight by id. They check for the invul powerup but not the godmode flag. I just added the godmode flag check.

* Player gib sound is rarely replaced by a footstep

This is a side-effect of change to sound priority ordering. Footstep events schedule the sound after the server frame has ends so it would override the gib sound. This was fixed by adding a check for player's health, and also by changing the channel the gib sound is played on (see later).

* Player gib sound is played on the wrong channel

This is a bug in the original game and causes player death scream and gib sound to play over each other if the player is killed by a powerful shotgun blast or is gibbed very quickly after dying. It was playing on the CHAN_BODY channel but should have been CHAN_VOICE. This change is also consistent with monsters, which play their gibs on CHAN_VOICE.

* Incorrect death sound plays some times

Another side-effect of the change to sound priority is that pain sound could override the death sound. This would happen if for example a shotgun blast first hurts the player and then kills him, all in a single server frame. Was easily fixed by adding a check for player health for the pain sound code.

I also prevented the death scream from overriding the gib sound which could happen after  I made both play on the same channel. Fixed by using the *sounds* variable to aggregate the sound effect, and then play it at the end of the server frame in P_DamageFeedback.