### PR TITLE
build fix proposal on mac where archs are well defined.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,12 @@ YQ2_ARCH ?= $(PROCESSOR_ARCHITECTURE)
 endif
 endif # windows but MINGW_CHOST not defined
 else
+ifneq ($(YQ2_OSTYPE), Darwin)
 # Normalize some abiguous YQ2_ARCH strings
 YQ2_ARCH ?= $(shell uname -m | sed -e 's/i.86/i386/' -e 's/amd64/x86_64/' -e 's/^arm.*/arm/')
+else
+YQ2_ARCH ?= $(shell uname -m)
+endif
 endif
 
 # On Windows / MinGW $(CC) is undefined by default.


### PR DESCRIPTION
the arch normalization leads to arm32 bit build under mac m1.