### PR TITLE
Feature request : add cvar to disable machine gun recoil in single player #741 (baseq2)

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -48,6 +48,12 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
 * **aimfix**: Fix aiming. When set to to `0` (the default) aiming is
   slightly inaccurate, bullets and the like have a little drift. When
   set to `1` they hit exactly were the crosshair is.
+  
+* **machinegun_norecoil**: Disable machine gun recoil in single player. 
+  By default this is set to `0`, this keeps the original machine gun 
+  recoil in single player. When set to `1` the recoil is disabled in
+  single player, the same way as in multiplayer.
+  This cvar only works if the game.dll implements this behaviour.
 
 * **busywait**: By default this is set to `1`, causing Quake II to spin
   in a very tight loop until it's time to process the next frame. This

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -49,7 +49,7 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   slightly inaccurate, bullets and the like have a little drift. When
   set to `1` they hit exactly were the crosshair is.
   
-* **machinegun_norecoil**: Disable machine gun recoil in single player. 
+* **g_machinegun_norecoil**: Disable machine gun recoil in single player. 
   By default this is set to `0`, this keeps the original machine gun 
   recoil in single player. When set to `1` the recoil is disabled in
   single player, the same way as in multiplayer.

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -86,6 +86,7 @@ cvar_t *sv_maplist;
 cvar_t *gib_on;
 
 cvar_t *aimfix;
+cvar_t *machinegun_norecoil;
 
 void SpawnEntities(char *mapname, char *entities, char *spawnpoint);
 void ClientThink(edict_t *ent, usercmd_t *cmd);

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -86,7 +86,7 @@ cvar_t *sv_maplist;
 cvar_t *gib_on;
 
 cvar_t *aimfix;
-cvar_t *machinegun_norecoil;
+cvar_t *g_machinegun_norecoil;
 
 void SpawnEntities(char *mapname, char *entities, char *spawnpoint);
 void ClientThink(edict_t *ent, usercmd_t *cmd);

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -549,6 +549,7 @@ extern cvar_t *flood_waitdelay;
 extern cvar_t *sv_maplist;
 
 extern cvar_t *aimfix;
+extern cvar_t *machinegun_norecoil;
 
 #define world (&g_edicts[0])
 

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -549,7 +549,7 @@ extern cvar_t *flood_waitdelay;
 extern cvar_t *sv_maplist;
 
 extern cvar_t *aimfix;
-extern cvar_t *machinegun_norecoil;
+extern cvar_t *g_machinegun_norecoil;
 
 #define world (&g_edicts[0])
 

--- a/src/game/player/weapon.c
+++ b/src/game/player/weapon.c
@@ -1249,7 +1249,7 @@ Machinegun_Fire(edict_t *ent)
 	ent->client->kick_angles[0] = ent->client->machinegun_shots * -1.5;
 
 	/* raise the gun as it is firing */
-	if (!deathmatch->value)
+	if (!(deathmatch->value || machinegun_norecoil->value))
 	{
 		ent->client->machinegun_shots++;
 
@@ -1258,7 +1258,8 @@ Machinegun_Fire(edict_t *ent)
 			ent->client->machinegun_shots = 9;
 		}
 	}
-
+	
+	
 	/* get start / end positions */
 	VectorAdd(ent->client->v_angle, ent->client->kick_angles, angles);
 	AngleVectors(angles, forward, right, NULL);

--- a/src/game/player/weapon.c
+++ b/src/game/player/weapon.c
@@ -1249,7 +1249,7 @@ Machinegun_Fire(edict_t *ent)
 	ent->client->kick_angles[0] = ent->client->machinegun_shots * -1.5;
 
 	/* raise the gun as it is firing */
-	if (!(deathmatch->value || machinegun_norecoil->value))
+	if (!(deathmatch->value || g_machinegun_norecoil->value))
 	{
 		ent->client->machinegun_shots++;
 
@@ -1258,7 +1258,6 @@ Machinegun_Fire(edict_t *ent)
 			ent->client->machinegun_shots = 9;
 		}
 	}
-	
 	
 	/* get start / end positions */
 	VectorAdd(ent->client->v_angle, ent->client->kick_angles, angles);

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -273,6 +273,7 @@ InitGame(void)
 
 	/* others */
 	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
+	machinegun_norecoil = gi.cvar("machinegun_norecoil", "0", CVAR_ARCHIVE);
 
 	/* items */
 	InitItems();

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -273,7 +273,7 @@ InitGame(void)
 
 	/* others */
 	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
-	machinegun_norecoil = gi.cvar("machinegun_norecoil", "0", CVAR_ARCHIVE);
+	g_machinegun_norecoil = gi.cvar("g_machinegun_norecoil", "0", CVAR_ARCHIVE);
 
 	/* items */
 	InitItems();


### PR DESCRIPTION
This adds the cvar machinegun_norecoil
It should only impact non-deathmatch games.
I used the aimfix cvar as a template to make this change.

The cvar will only work if the game.dll supports it.