### PR TITLE
backends: Only enable ARM "RunFast" mode when targeting hardware FPU

### DIFF
--- a/src/backends/generic/misc.c
+++ b/src/backends/generic/misc.c
@@ -192,7 +192,7 @@ void Sys_SetupFPU(void) {
 }
 #else
 void Sys_SetupFPU(void) {
-#if defined(__arm__)
+#if defined(__arm__) && defined(__ARM_PCS_VFP)
 	// Enable RunFast mode if not enabled already
 	static const unsigned int bit = 0x04086060;
 	static const unsigned int fpscr = 0x03000000;


### PR DESCRIPTION
Older ARM ABIs like Debian armel (ARMv5 EABI softfloat) don't use
or require a hardware FPU, so they can't execute the fmrx and fmxr
instructions. Only do this in hardfloat configurations that guarantee
VFP instructions are available.

The client might not be practically usable on ARM softfloat (although
nobody has reported that it isn't...) but the dedicated server is probably
fine, and ceasing to be able to build either would be a regression.