### PR TITLE
Fixed updated gunangles and gunoffset not always being sent to client

### DIFF
--- a/src/server/sv_entities.c
+++ b/src/server/sv_entities.c
@@ -251,7 +251,15 @@ SV_WritePlayerstateToClient(client_frame_t *from, client_frame_t *to,
 		pflags |= PS_RDFLAGS;
 	}
 
-	if (ps->gunframe != ops->gunframe)
+	if ((ps->gunframe != ops->gunframe) ||
+		/* added so weapon angle/offset update during pauseframes */
+		(ps->gunoffset[0] != ops->gunoffset[0]) ||
+		(ps->gunoffset[1] != ops->gunoffset[1]) ||
+		(ps->gunoffset[2] != ops->gunoffset[2]) ||
+
+		(ps->gunangles[0] != ops->gunangles[0]) ||
+		(ps->gunangles[1] != ops->gunangles[1]) ||
+		(ps->gunangles[2] != ops->gunangles[2]))
 	{
 		pflags |= PS_WEAPONFRAME;
 	}


### PR DESCRIPTION
This (at least partially) addresses https://github.com/yquake2/yquake2/issues/735.

The problem is that client weaponframe is only updated if the gunframe changed, which does not happen during pauseframes which play randomly during the idle animations. gunangles and gunoffset are tied to PS_WEAPONFRAME, so if gunframe stays the same, gunangles and gunoffset updates are discarded, leading to the weapon bobbing stopping randomly and for random amounts of time.

This PR addresses the issue by sending PS_WEAPONFRAME segment if either the gunframe, gunangles or gunoffset changed, ensuring clients stay up to date on the weaponframe state.