### PR TITLE
Made the game able to handle entity overload better

### DIFF
--- a/src/game/g_ai.c
+++ b/src/game/g_ai.c
@@ -1196,8 +1196,15 @@ ai_run(edict_t *self, float dist)
 		return;
 	}
 
+	tempgoal = G_SpawnOptional();
+
+	if (!tempgoal)
+	{
+		M_MoveToGoal(self, dist);
+		return;
+	}
+
 	save = self->goalentity;
-	tempgoal = G_Spawn();
 	self->goalentity = tempgoal;
 
 	new = false;

--- a/src/game/g_misc.c
+++ b/src/game/g_misc.c
@@ -196,14 +196,19 @@ ThrowGib(edict_t *self, char *gibname, int damage, int type)
 		return;
 	}
 
-	gibsthisframe++;
-
-	if (gibsthisframe > MAX_GIBS)
+	if (gibsthisframe >= MAX_GIBS)
 	{
 		return;
 	}
 
-	gib = G_Spawn();
+	gib = G_SpawnOptional();
+
+	if (!gib)
+	{
+		return;
+	}
+
+	gibsthisframe++;
 
 	VectorScale(self->size, 0.5, size);
 	VectorAdd(self->absmin, size, origin);
@@ -373,14 +378,20 @@ ThrowDebris(edict_t *self, char *modelname, float speed, vec3_t origin)
 		return;
 	}
 
-	debristhisframe++;
-
-	if (debristhisframe > MAX_DEBRIS)
+	if (debristhisframe >= MAX_DEBRIS)
 	{
 		return;
 	}
 
-	chunk = G_Spawn();
+	chunk = G_SpawnOptional();
+
+	if (!chunk)
+	{
+		return;
+	}
+
+	debristhisframe++;
+
 	VectorCopy(origin, chunk->s.origin);
 	gi.setmodel(chunk, modelname);
 	v[0] = 100 * crandom();

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -629,6 +629,7 @@ void G_UseTargets(edict_t *ent, edict_t *activator);
 void G_SetMovedir(vec3_t angles, vec3_t movedir);
 
 void G_InitEdict(edict_t *e);
+edict_t *G_SpawnOptional(void);
 edict_t *G_Spawn(void);
 void G_FreeEdict(edict_t *e);
 


### PR DESCRIPTION
This PR amortizes the issues reported in https://github.com/yquake2/yquake2/issues/759 by easing entity allocation policies.

These are the main points:
* If no free entity is found according to the default policy, a second search is done, ignoring any freetime restrictions
* New function G_SpawnOptional, instead of calling gi.error() it will return NULL, allowing the caller to react more gracefully
* Made ThrowDebris, ThrowGib and AI tempgoals use G_SpawnOptional