### PR TITLE
Re-enable thread-local stuff in stb_image, link winpthread statically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1077,7 +1077,7 @@ endif
 ifeq ($(YQ2_OSTYPE), Windows)
 release/ref_gl1.dll : $(REFGL1_OBJS)
 	@echo "===> LD $@"
-	${Q}$(CC) $(LDFLAGS) $(REFGL1_OBJS) $(LDLIBS) $(DLL_SDLLDFLAGS) -o $@
+	${Q}$(CC) $(LDFLAGS) $(REFGL1_OBJS) $(LDLIBS) $(DLL_SDLLDFLAGS) -Wl,-Bstatic -lpthread -o $@
 	$(Q)strip $@
 else ifeq ($(YQ2_OSTYPE), Darwin)
 release/ref_gl1.dylib : $(REFGL1_OBJS)
@@ -1093,7 +1093,7 @@ endif
 ifeq ($(YQ2_OSTYPE), Windows)
 release/ref_gl3.dll : $(REFGL3_OBJS)
 	@echo "===> LD $@"
-	${Q}$(CC) $(LDFLAGS) $(REFGL3_OBJS) $(LDLIBS) $(DLL_SDLLDFLAGS) -o $@
+	${Q}$(CC) $(LDFLAGS) $(REFGL3_OBJS) $(LDLIBS) $(DLL_SDLLDFLAGS) -Wl,-Bstatic -lpthread -o $@
 	$(Q)strip $@
 else ifeq ($(YQ2_OSTYPE), Darwin)
 release/ref_gl3.dylib : $(REFGL3_OBJS)
@@ -1109,7 +1109,7 @@ endif
 ifeq ($(YQ2_OSTYPE), Windows)
 release/ref_soft.dll : $(REFSOFT_OBJS)
 	@echo "===> LD $@"
-	${Q}$(CC) $(LDFLAGS) $(REFSOFT_OBJS) $(LDLIBS) $(DLL_SDLLDFLAGS) -o $@
+	${Q}$(CC) $(LDFLAGS) $(REFSOFT_OBJS) $(LDLIBS) $(DLL_SDLLDFLAGS) -Wl,-Bstatic -lpthread -o $@
 	$(Q)strip $@
 else ifeq ($(YQ2_OSTYPE), Darwin)
 release/ref_soft.dylib : $(REFSOFT_OBJS)

--- a/src/client/refresh/files/stb.c
+++ b/src/client/refresh/files/stb.c
@@ -37,8 +37,6 @@
 #define STBI_MALLOC(sz)    malloc(sz)
 #define STBI_REALLOC(p,sz) realloc(p,sz)
 #define STBI_FREE(p)       free(p)
-// Switch of the thread local stuff. Breaks mingw under Windows.
-#define STBI_NO_THREAD_LOCALS
 // include implementation part of stb_image into this file
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"


### PR DESCRIPTION
The real problem wasn't that thread-local variables are unsupported by
MinGW-w64, but that using them makes it link against libwinpthread-1.dll

Alternatively that lib can be linked statically, like we do now, at least
for the rendering backends that use stb_image.h/stb.c

For some reason it didn't work to add
`-Wl,-Bstatic -lpthread -Wl,-Bdynamic` in LDLIBS - it only worked without
the `-Wl,-Bdynamic` part, so it must be last on the linking commandline
(otherwise it'll try to link SDL2 statically as well).

refs #762