### PR TITLE
Change the amount of listed renderers to 3 in documentation

### DIFF
--- a/doc/030_configuration.md
+++ b/doc/030_configuration.md
@@ -8,7 +8,7 @@ with the defaults and the options that can be set through the menu.
 
 ## Choosing a Renderer
 
-Yamagi Quake II ships with 4 renderers:
+Yamagi Quake II ships with 3 renderers:
 
 * The **OpenGL 3.2** renderer: This renderer was developed for the needs
   of modern graphics hardware and is usually the best choice for OpenGL


### PR DESCRIPTION
This is a tiny change.
Since **Vulkan** was removed from the list as a renderer,  there are only 3 renderers listed.