### PR TITLE
Add r_lerp_list and r_videos_unfiltered CVars, fix #800

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -289,10 +289,19 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   anti aliasing is expensive and can lead to a huge performance hit, so
   try setting it to a lower value if the framerate is too low.
 
-* **r_nolerp_list**: list separate by spaces of textures omitted from
-  bilinear filtering. Used by default to exclude the console and HUD
-  fonts.  Make sure to include the default values when extending the
-  list.
+* **r_videos_unfiltered**: If set to `1`, don't use bilinear texture
+  filtering on videos (defaults to `0`).
+
+* **r_2D_unfiltered**: If set to `1`, don't filter textures of 2D
+  elements like menus and the HUD (defaults to `0`).
+
+* **r_lerp_list**: List separated by spaces of 2D textures that *should*
+  be filtered bilinearly, even if `r_2D_unfiltered` is set to `1`.
+
+* **r_nolerp_list**: List separated by spaces of textures omitted from
+  bilinear filtering (mostly relevant if `r_2D_unfiltered` is `0`).
+  Used by default to exclude the console and HUD font and crosshairs.
+  Make sure to include the default values when extending the list.
 
 * **r_retexturing**: If set to `1` (the default) and a retexturing pack
   is installed, the high resolution textures are used.

--- a/src/client/refresh/gl1/gl1_draw.c
+++ b/src/client/refresh/gl1/gl1_draw.c
@@ -503,8 +503,9 @@ RDraw_StretchRaw(int x, int y, int w, int h, int cols, int rows, byte *data)
 
 	// Note: gl_filter_min could be GL_*_MIPMAP_* so we can't use it for min filter here (=> no mipmaps)
 	//       but gl_filter_max (either GL_LINEAR or GL_NEAREST) should do the trick.
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, gl_filter_max);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, gl_filter_max);
+	GLint filter = (r_videos_unfiltered->value == 0) ? gl_filter_max : GL_NEAREST;
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
 
 	glEnableClientState( GL_VERTEX_ARRAY );
 	glEnableClientState( GL_TEXTURE_COORD_ARRAY );

--- a/src/client/refresh/gl1/gl1_image.c
+++ b/src/client/refresh/gl1/gl1_image.c
@@ -214,6 +214,7 @@ R_TextureMode(char *string)
 	}
 
 	const char* nolerplist = gl_nolerp_list->string;
+	const char* lerplist = r_lerp_list->string;
 	qboolean unfiltered2D = r_2D_unfiltered->value != 0;
 
 	/* change all the existing mipmap texture objects */
@@ -221,7 +222,12 @@ R_TextureMode(char *string)
 	{
 		qboolean nolerp = false;
 		/* r_2D_unfiltered and r_nolerp_list allow rendering stuff unfiltered even if gl_filter_* is filtered */
-		if ( (unfiltered2D && glt->type == it_pic) || (nolerplist != NULL && strstr(nolerplist, glt->name) != NULL) )
+		if (unfiltered2D && glt->type == it_pic)
+		{
+			// exception to that exception: stuff on the r_lerp_list
+			nolerp = (lerplist== NULL) || (strstr(lerplist, glt->name) == NULL);
+		}
+		else if(nolerplist != NULL && strstr(nolerplist, glt->name) != NULL)
 		{
 			nolerp = true;
 		}
@@ -863,7 +869,9 @@ R_LoadPic(char *name, byte *pic, int width, int realwidth,
 	}
 	else if(gl_nolerp_list != NULL && gl_nolerp_list->string != NULL)
 	{
-		nolerp = strstr(gl_nolerp_list->string, name) != NULL;
+		// if r_2D_unfiltered is true(ish), nolerp should usually be true,
+		// *unless* the texture is on the r_lerp_list
+		nolerp = (r_lerp_list->string == NULL) || (strstr(r_lerp_list->string, name) == NULL);
 	}
 
 	/* find a free image_t */

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -104,7 +104,9 @@ cvar_t *r_retexturing;
 cvar_t *r_scale8bittextures;
 
 cvar_t *gl_nolerp_list;
+cvar_t *r_lerp_list;
 cvar_t *r_2D_unfiltered;
+cvar_t *r_videos_unfiltered;
 
 cvar_t *gl1_dynamic;
 cvar_t *r_modulate;
@@ -1275,9 +1277,13 @@ R_Register(void)
 	r_scale8bittextures = ri.Cvar_Get("r_scale8bittextures", "0", CVAR_ARCHIVE);
 
 	/* don't bilerp characters and crosshairs */
-	gl_nolerp_list = ri.Cvar_Get("r_nolerp_list", "pics/conchars.pcx pics/ch1.pcx pics/ch2.pcx pics/ch3.pcx", 0);
+	gl_nolerp_list = ri.Cvar_Get("r_nolerp_list", "pics/conchars.pcx pics/ch1.pcx pics/ch2.pcx pics/ch3.pcx", CVAR_ARCHIVE);
+	/* textures that should always be filtered, even if r_2D_unfiltered or an unfiltered gl mode is used */
+	r_lerp_list = ri.Cvar_Get("r_lerp_list", "", CVAR_ARCHIVE);
 	/* don't bilerp any 2D elements */
 	r_2D_unfiltered = ri.Cvar_Get("r_2D_unfiltered", "0", CVAR_ARCHIVE);
+	/* don't bilerp videos */
+	r_videos_unfiltered = ri.Cvar_Get("r_videos_unfiltered", "0", CVAR_ARCHIVE);
 
 	gl1_stereo = ri.Cvar_Get( "gl1_stereo", "0", CVAR_ARCHIVE );
 	gl1_stereo_separation = ri.Cvar_Get( "gl1_stereo_separation", "-0.4", CVAR_ARCHIVE );
@@ -1702,13 +1708,16 @@ RI_BeginFrame(float camera_separation)
 
 	/* texturemode stuff */
 	if (gl_texturemode->modified || (gl_config.anisotropic && gl_anisotropic->modified)
-	    || gl_nolerp_list->modified || r_2D_unfiltered->modified)
+	    || gl_nolerp_list->modified || r_lerp_list->modified
+		|| r_2D_unfiltered->modified || r_videos_unfiltered->modified)
 	{
 		R_TextureMode(gl_texturemode->string);
 		gl_texturemode->modified = false;
 		gl_anisotropic->modified = false;
 		gl_nolerp_list->modified = false;
+		r_lerp_list->modified = false;
 		r_2D_unfiltered->modified = false;
+		r_videos_unfiltered->modified = false;
 	}
 
 	if (gl1_texturealphamode->modified)

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -195,7 +195,9 @@ extern cvar_t *r_retexturing;
 extern cvar_t *r_scale8bittextures;
 
 extern cvar_t *gl_nolerp_list;
+extern cvar_t *r_lerp_list;
 extern cvar_t *r_2D_unfiltered;
+extern cvar_t *r_videos_unfiltered;
 
 extern cvar_t *gl_lightmap;
 extern cvar_t *gl_shadows;

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -380,8 +380,9 @@ GL3_Draw_StretchRaw(int x, int y, int w, int h, int cols, int rows, byte *data)
 
 	// Note: gl_filter_min could be GL_*_MIPMAP_* so we can't use it for min filter here (=> no mipmaps)
 	//       but gl_filter_max (either GL_LINEAR or GL_NEAREST) should do the trick.
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, gl_filter_max);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, gl_filter_max);
+	GLint filter = (r_videos_unfiltered->value == 0) ? gl_filter_max : GL_NEAREST;
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
 
 	drawTexturedRectangle(x, y, w, h, 0.0f, 0.0f, 1.0f, 1.0f);
 

--- a/src/client/refresh/gl3/gl3_image.c
+++ b/src/client/refresh/gl3/gl3_image.c
@@ -88,6 +88,7 @@ GL3_TextureMode(char *string)
 	gl3image_t *glt;
 
 	const char* nolerplist = gl_nolerp_list->string;
+	const char* lerplist = r_lerp_list->string;
 	qboolean unfiltered2D = r_2D_unfiltered->value != 0;
 
 	/* change all the existing texture objects */
@@ -95,7 +96,12 @@ GL3_TextureMode(char *string)
 	{
 		qboolean nolerp = false;
 		/* r_2D_unfiltered and gl_nolerp_list allow rendering stuff unfiltered even if gl_filter_* is filtered */
-		if ( (unfiltered2D && glt->type == it_pic) || (nolerplist != NULL && strstr(nolerplist, glt->name) != NULL) )
+		if (unfiltered2D && glt->type == it_pic)
+		{
+			// exception to that exception: stuff on the r_lerp_list
+			nolerp = (lerplist== NULL) || (strstr(lerplist, glt->name) == NULL);
+		}
+		else if(nolerplist != NULL && strstr(nolerplist, glt->name) != NULL)
 		{
 			nolerp = true;
 		}
@@ -383,7 +389,9 @@ GL3_LoadPic(char *name, byte *pic, int width, int realwidth,
 	qboolean nolerp = false;
 	if (r_2D_unfiltered->value && type == it_pic)
 	{
-		nolerp = true;
+		// if r_2D_unfiltered is true(ish), nolerp should usually be true,
+		// *unless* the texture is on the r_lerp_list
+		nolerp = (r_lerp_list->string == NULL) || (strstr(r_lerp_list->string, name) == NULL);
 	}
 	else if (gl_nolerp_list != NULL && gl_nolerp_list->string != NULL)
 	{

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -107,7 +107,9 @@ cvar_t *r_norefresh;
 cvar_t *r_drawentities;
 cvar_t *r_drawworld;
 cvar_t *gl_nolerp_list;
+cvar_t *r_lerp_list;
 cvar_t *r_2D_unfiltered;
+cvar_t *r_videos_unfiltered;
 cvar_t *gl_nobind;
 cvar_t *r_lockpvs;
 cvar_t *r_novis;
@@ -221,9 +223,13 @@ GL3_Register(void)
 	r_fixsurfsky = ri.Cvar_Get("r_fixsurfsky", "0", CVAR_ARCHIVE);
 
 	/* don't bilerp characters and crosshairs */
-	gl_nolerp_list = ri.Cvar_Get("r_nolerp_list", "pics/conchars.pcx pics/ch1.pcx pics/ch2.pcx pics/ch3.pcx", 0);
+	gl_nolerp_list = ri.Cvar_Get("r_nolerp_list", "pics/conchars.pcx pics/ch1.pcx pics/ch2.pcx pics/ch3.pcx", CVAR_ARCHIVE);
+	/* textures that should always be filtered, even if r_2D_unfiltered or an unfiltered gl mode is used */
+	r_lerp_list = ri.Cvar_Get("r_lerp_list", "", CVAR_ARCHIVE);
 	/* don't bilerp any 2D elements */
 	r_2D_unfiltered = ri.Cvar_Get("r_2D_unfiltered", "0", CVAR_ARCHIVE);
+	/* don't bilerp videos */
+	r_videos_unfiltered = ri.Cvar_Get("r_videos_unfiltered", "0", CVAR_ARCHIVE);
 	gl_nobind = ri.Cvar_Get("gl_nobind", "0", 0);
 
 	gl_texturemode = ri.Cvar_Get("gl_texturemode", "GL_LINEAR_MIPMAP_NEAREST", CVAR_ARCHIVE);
@@ -1772,13 +1778,16 @@ GL3_BeginFrame(float camera_separation)
 
 	/* texturemode stuff */
 	if (gl_texturemode->modified || (gl3config.anisotropic && gl_anisotropic->modified)
-	    || gl_nolerp_list->modified || r_2D_unfiltered->modified)
+	    || gl_nolerp_list->modified || r_lerp_list->modified
+		|| r_2D_unfiltered->modified || r_videos_unfiltered->modified)
 	{
 		GL3_TextureMode(gl_texturemode->string);
 		gl_texturemode->modified = false;
 		gl_anisotropic->modified = false;
 		gl_nolerp_list->modified = false;
+		r_lerp_list->modified = false;
 		r_2D_unfiltered->modified = false;
+		r_videos_unfiltered->modified = false;
 	}
 
 	if (r_vsync->modified)

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -488,7 +488,9 @@ extern cvar_t *r_customwidth;
 extern cvar_t *r_customheight;
 
 extern cvar_t *r_2D_unfiltered;
+extern cvar_t *r_videos_unfiltered;
 extern cvar_t *gl_nolerp_list;
+extern cvar_t *r_lerp_list;
 extern cvar_t *gl_nobind;
 extern cvar_t *r_lockpvs;
 extern cvar_t *r_novis;


### PR DESCRIPTION
r_lerp_list is to allow exceptions to r_2D_unfiltered (like for having
pixely UI in general, but filtered console background).

r_videos_unfiltered controls whether videos should be filtered or not

I also made r_nolerp_list CVAR_ARCHIVE, like users probably expect it.