### PR TITLE
Added cvar to define SDL gamepad's 'Back' button

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -117,6 +117,13 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   during gameplay and released otherwise (in menu, videos, console or if
   game is paused).
 
+  **in_sdlbackbutton**: Defines which button is used in the gamepad or
+  joystick as the `Esc` key, that is, to be able to access the menu
+  and 'cancel'/'go back' on its options. When set to `0` (the default)
+  the Back/Select/Minus button is used. Set this to `1` to use the
+  Start/Menu/Plus button, and to `2` to use the Guide/Home/PS button.
+  Requires a game restart when changed.
+
 * **singleplayer**: Only available in the dedicated server. Vanilla
   Quake II enforced that either `coop` or `deathmatch` is set to `1`
   when running the dedicated server. That made it impossible to play

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -48,6 +48,7 @@
 // actual movement functions called at a later time.
 static float mouse_x, mouse_y;
 static int back_button_id = -1;
+static int sdl_back_button = SDL_CONTROLLER_BUTTON_BACK;
 static float joystick_yaw, joystick_pitch;
 static float joystick_forwardmove, joystick_sidemove;
 static float joystick_up;
@@ -586,7 +587,7 @@ IN_Update(void)
 			{
 				qboolean down = (event.type == SDL_CONTROLLERBUTTONDOWN);
 
-				if (event.cbutton.button == SDL_CONTROLLER_BUTTON_BACK)
+				if (event.cbutton.button == sdl_back_button)
 				{
 					Key_Event(K_JOY_BACK, down, true);
 				}
@@ -1200,6 +1201,7 @@ Haptic_Feedback(char *name, int effect_volume, int effect_duration,
 void
 IN_Init(void)
 {
+	static cvar_t *in_sdlbackbutton;
 	Com_Printf("------- input initialization -------\n");
 
 	mouse_x = mouse_y = 0;
@@ -1241,6 +1243,22 @@ IN_Init(void)
 	joy_axis_triggerright_threshold = Cvar_Get("joy_axis_triggerright_threshold", "0.15", CVAR_ARCHIVE);
 
 	windowed_mouse = Cvar_Get("windowed_mouse", "1", CVAR_USERINFO | CVAR_ARCHIVE);
+
+	in_sdlbackbutton = Cvar_Get("in_sdlbackbutton", "0", CVAR_ARCHIVE);
+	if (in_sdlbackbutton)
+	{
+		switch ((int)in_sdlbackbutton->value)
+		{
+			case 1:
+				sdl_back_button = SDL_CONTROLLER_BUTTON_START;
+				break;
+			case 2:
+				sdl_back_button = SDL_CONTROLLER_BUTTON_GUIDE;
+				break;
+			default:
+				sdl_back_button = SDL_CONTROLLER_BUTTON_BACK;
+		}
+	}
 
 	Cmd_AddCommand("+mlook", IN_MLookDown);
 	Cmd_AddCommand("-mlook", IN_MLookUp);
@@ -1304,7 +1322,7 @@ IN_Init(void)
 						Com_Printf (" * triggerleft = %f\n", joy_axis_triggerleft_threshold->value);
 						Com_Printf (" * triggerright = %f\n", joy_axis_triggerright_threshold->value);
 
-						backBind = SDL_GameControllerGetBindForButton(controller, SDL_CONTROLLER_BUTTON_BACK);
+						backBind = SDL_GameControllerGetBindForButton(controller, sdl_back_button);
 
 						if (backBind.bindType == SDL_CONTROLLER_BINDTYPE_BUTTON)
 						{


### PR DESCRIPTION
This allows to redefine the button used as the "**Esc key**" in the SDL controller, by default the _Back/Select/Minus_ (center left) button. Now it can be changed to the _Start/Menu/Plus_ (center right) button, or even to the _Guide/Home/PS_ button (middle of the gamepad, normally big). Requires a game restart to take effect.
Useful for people not happy with the current location of the button.