### PR TITLE
Load gamecontrollerdb.txt for SDL2 joy mappings

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -117,7 +117,7 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   during gameplay and released otherwise (in menu, videos, console or if
   game is paused).
 
-  **in_sdlbackbutton**: Defines which button is used in the gamepad or
+* **in_sdlbackbutton**: Defines which button is used in the gamepad or
   joystick as the `Esc` key, that is, to be able to access the menu
   and 'cancel'/'go back' on its options. When set to `0` (the default)
   the Back/Select/Minus button is used. Set this to `1` to use the

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -1285,7 +1285,7 @@ IN_Init(void)
 			{
 				for (const char* rawPath = FS_GetNextRawPath(NULL); rawPath != NULL; rawPath = FS_GetNextRawPath(rawPath))
 				{
-					snprintf(controllerdb, MAX_OSPATH, "%s/%s", rawPath, "gamecontrollerdb.txt");
+					snprintf(controllerdb, MAX_OSPATH, "%s/gamecontrollerdb.txt", rawPath);
 					nummappings = SDL_GameControllerAddMappingsFromFile(controllerdb);
 					if (nummappings > 0)
 						Com_Printf ("%d mappings loaded from gamecontrollerdb.txt\n", nummappings);

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -1201,7 +1201,9 @@ Haptic_Feedback(char *name, int effect_volume, int effect_duration,
 void
 IN_Init(void)
 {
-	static cvar_t *in_sdlbackbutton;
+	cvar_t *in_sdlbackbutton;
+	int nummappings;
+	char controllerdb[MAX_OSPATH] = {0};
 	Com_Printf("------- input initialization -------\n");
 
 	mouse_x = mouse_y = 0;
@@ -1279,7 +1281,16 @@ IN_Init(void)
 		{
 			Com_Printf ("%i joysticks were found.\n", SDL_NumJoysticks());
 
-			if (SDL_NumJoysticks() > 0) {
+			if (SDL_NumJoysticks() > 0)
+			{
+				for (const char* rawPath = FS_GetNextRawPath(NULL); rawPath != NULL; rawPath = FS_GetNextRawPath(rawPath))
+				{
+					snprintf(controllerdb, MAX_OSPATH, "%s/%s", rawPath, "gamecontrollerdb.txt");
+					nummappings = SDL_GameControllerAddMappingsFromFile(controllerdb);
+					if (nummappings > 0)
+						Com_Printf ("%d mappings loaded from gamecontrollerdb.txt\n", nummappings);
+				}
+
 				for (int i = 0; i < SDL_NumJoysticks(); i++) {
 					joystick = SDL_JoystickOpen(i);
 


### PR DESCRIPTION
This allows for the loading of _gamecontrollerdb.txt_, database of game controller mappings to be used with SDL2 controllers.
This is _optional_ and its an alternative to the use of setting the SDL_GAMECONTROLLERCONFIG variable to use a gamepad.
It's practical for gamepads that change their GUID when used wired or bluetooth, e.g. Nintendo Switch Pro Controller on Linux.
The text file is usually obtained from https://github.com/gabomdq/SDL_GameControllerDB, and can be put in both the game or "config" directories.