### PR TITLE
Update retexturing command in configuration document.

### DIFF
--- a/doc/030_configuration.md
+++ b/doc/030_configuration.md
@@ -244,7 +244,7 @@ The OpenGL 3.2 renderer:
 
 Yamagi Quake II has full support for retexturing packs. They just need
 to be installed and should be picked up automatically. To disable the
-retexturing pack at a later time set `gl_retexturing` to `0`.
+retexturing pack at a later time set `r_retexturing` to `0`.
 
 * The most comprehensive build retexturing pack can be found here:
   https://deponie.yamagi.org/quake2/texturepack/


### PR DESCRIPTION
Update to the configuration document.  Removed the deprecated command 'gl_retexturing' and replaced it with the current command 'r_retexturing'