### PR TITLE
Improve timings in Qcommon_Frame()

### DIFF
--- a/src/client/header/client.h
+++ b/src/client/header/client.h
@@ -211,7 +211,7 @@ typedef struct
 	keydest_t	key_dest;
 
 	int			framecount;
-	int			realtime; /* always increasing, no clamping, etc */
+	int			realtime; /* always increasing, no clamping, etc, in MS */
 	float		rframetime; /* seconds since last render frame */
 	float		nframetime; /* network frame time */
 

--- a/src/common/frame.c
+++ b/src/common/frame.c
@@ -428,10 +428,10 @@ Qcommon_Frame(int usec)
 	int time_after;
 
 	// Target packetframerate.
-	int pfps;
+	float pfps;
 
-	//Target renderframerate.
-	int rfps;
+	// Target renderframerate.
+	float rfps;
 
 	// Time since last packetframe in microsec.
 	static int packetdelta = 1000000;
@@ -553,7 +553,7 @@ Qcommon_Frame(int usec)
 		// use vid_maxfps if it looks like the user really means it to be different from refreshRate
 		if (vid_maxfps->value < refreshrate - 2 )
 		{
-			rfps = (int)vid_maxfps->value;
+			rfps = vid_maxfps->value;
 			// we can't have more packet frames than render frames, so limit pfps to rfps
 			pfps = (cl_maxfps->value > rfps) ? rfps : cl_maxfps->value;
 		}
@@ -574,7 +574,7 @@ Qcommon_Frame(int usec)
 	}
 	else
 	{
-		rfps = (int)vid_maxfps->value;
+		rfps = vid_maxfps->value;
 		// we can't have more packet frames than render frames, so limit pfps to rfps
 		pfps = (cl_maxfps->value > rfps) ? rfps : cl_maxfps->value;
 	}
@@ -586,7 +586,7 @@ Qcommon_Frame(int usec)
 		// packet framerates between about 45 and 90 should be ok,
 		// with other values the game (esp. movement/clipping) can become glitchy
 		// as pfps must be <= rfps, for rfps < 90 just use that as pfps
-		if (rfps < 90)
+		if (rfps < 90.0f)
 		{
 			pfps = rfps;
 		}

--- a/src/common/frame.c
+++ b/src/common/frame.c
@@ -550,21 +550,38 @@ Qcommon_Frame(int usec)
 	// Calculate target and renderframerate.
 	if (R_IsVSyncActive())
 	{
-		rfps = GLimp_GetRefreshRate();
+		int refreshrate = GLimp_GetRefreshRate();
 
-		if (rfps > vid_maxfps->value)
+		// using refreshRate - 2, because targeting a value slightly below the
+		// (possibly not 100% correctly reported) refreshRate would introduce jittering, so only
+		// use vid_maxfps if it looks like the user really means it to be different from refreshRate
+		if (vid_maxfps->value < refreshrate - 2 )
 		{
 			rfps = (int)vid_maxfps->value;
+			// we can't have more packet frames than render frames, so limit pfps to rfps
+			pfps = (cl_maxfps->value > rfps) ? rfps : cl_maxfps->value;
+		}
+		else // target refresh rate, not vid_maxfps
+		{
+			// if vsync is active, we increase the target framerate a bit for two reasons
+			// 1. On Windows, GLimp_GetFrefreshRate() (or the SDL counterpart, or even
+			//    the underlying WinAPI function) often returns a too small value,
+			//    like 58 or 59 when it's really 59.95 and thus (as integer) should be 60
+			// 2. vsync will throttle us to refreshrate anyway, so there is no harm
+			//    in starting the frame *a bit* earlier, instead of risking starting
+			//    it too late
+			rfps = refreshrate * 1.2f;
+			// we can't have more packet frames than render frames, so limit pfps to rfps
+			// but in this case use tolerance for comparison and assign rfps with tolerance
+			pfps = (cl_maxfps->value < refreshrate - 2) ? cl_maxfps->value : rfps;
 		}
 	}
 	else
 	{
 		rfps = (int)vid_maxfps->value;
+		// we can't have more packet frames than render frames, so limit pfps to rfps
+		pfps = (cl_maxfps->value > rfps) ? rfps : cl_maxfps->value;
 	}
-
-	// we can't have more packet frames than render frames, so limit pfps to rfps
-	pfps = (cl_maxfps->value > rfps) ? rfps : cl_maxfps->value;
-
 
 	// Calculate timings.
 	packetdelta += usec;
@@ -576,34 +593,18 @@ Qcommon_Frame(int usec)
 	{
 		if (cl_async->value)
 		{
-			if (R_IsVSyncActive())
+			// Network frames.
+			if (packetdelta < (1000000.0f / pfps))
 			{
-				// Network frames.
-				if (packetdelta < (0.8 * (1000000.0f / pfps)))
-				{
-					packetframe = false;
-				}
-
-				// Render frames.
-				if (renderdelta < (0.8 * (1000000.0f / rfps)))
-				{
-					renderframe = false;
-				}
+				packetframe = false;
 			}
-			else
+
+			// Render frames.
+			if (renderdelta < (1000000.0f / rfps))
 			{
-				// Network frames.
-				if (packetdelta < (1000000.0f / pfps))
-				{
-					packetframe = false;
-				}
-
-				// Render frames.
-				if (renderdelta < (1000000.0f ) / rfps)
-				{
-					renderframe = false;
-				}
+				renderframe = false;
 			}
+
 			if (!renderframe)
 			{
 				// we must have at least one render frame between two packet frames

--- a/src/common/frame.c
+++ b/src/common/frame.c
@@ -342,7 +342,7 @@ Qcommon_Init(int argc, char **argv)
 
 	// cvars
 
-	cl_maxfps = Cvar_Get("cl_maxfps", "60", CVAR_ARCHIVE);
+	cl_maxfps = Cvar_Get("cl_maxfps", "-1", CVAR_ARCHIVE);
 
 	developer = Cvar_Get("developer", "0", 0);
 	fixedtime = Cvar_Get("fixedtime", "0", 0);
@@ -542,10 +542,6 @@ Qcommon_Frame(int usec)
 	{
 		Cvar_SetValue("cl_maxfps", 250);
 	}
-	else if (cl_maxfps->value < 1)
-	{
-		Cvar_SetValue("cl_maxfps", 60);
-	}
 
 	// Calculate target and renderframerate.
 	if (R_IsVSyncActive())
@@ -563,13 +559,13 @@ Qcommon_Frame(int usec)
 		}
 		else // target refresh rate, not vid_maxfps
 		{
-			// if vsync is active, we increase the target framerate a bit for two reasons
-			// 1. On Windows, GLimp_GetFrefreshRate() (or the SDL counterpart, or even
-			//    the underlying WinAPI function) often returns a too small value,
-			//    like 58 or 59 when it's really 59.95 and thus (as integer) should be 60
-			// 2. vsync will throttle us to refreshrate anyway, so there is no harm
-			//    in starting the frame *a bit* earlier, instead of risking starting
-			//    it too late
+			/* if vsync is active, we increase the target framerate a bit for two reasons
+			   1. On Windows, GLimp_GetFrefreshRate() (or the SDL counterpart, or even
+			      the underlying WinAPI function) often returns a too small value,
+			      like 58 or 59 when it's really 59.95 and thus (as integer) should be 60
+			   2. vsync will throttle us to refreshrate anyway, so there is no harm
+			      in starting the frame *a bit* earlier, instead of risking starting
+			      it too late */
 			rfps = refreshrate * 1.2f;
 			// we can't have more packet frames than render frames, so limit pfps to rfps
 			// but in this case use tolerance for comparison and assign rfps with tolerance
@@ -581,6 +577,35 @@ Qcommon_Frame(int usec)
 		rfps = (int)vid_maxfps->value;
 		// we can't have more packet frames than render frames, so limit pfps to rfps
 		pfps = (cl_maxfps->value > rfps) ? rfps : cl_maxfps->value;
+	}
+
+	// cl_maxfps <= 0 means: automatically choose a packet framerate that should work
+	// well with the render framerate, which is the case if rfps is a multiple of pfps
+	if (cl_maxfps->value <= 0.0f && cl_async->value != 0.0f)
+	{
+		// packet framerates between about 45 and 90 should be ok,
+		// with other values the game (esp. movement/clipping) can become glitchy
+		// as pfps must be <= rfps, for rfps < 90 just use that as pfps
+		if (rfps < 90)
+		{
+			pfps = rfps;
+		}
+		else
+		{
+			/* we want an integer divider, so every div-th renderframe is a packetframe.
+			   this formula gives nice dividers that keep pfps as close as possible
+			   to 60 (which seems to be ideal):
+			   - for < 150 rfps div will be 2, so pfps will be between 45 and ~75
+			     => exactly every second renderframe we also run a packetframe
+			   - for < 210 rfps div will be 3, so pfps will be between 50 and ~70
+			     => exactly every third renderframe we also run a packetframe
+			   - etc, the higher the rfps, the closer the pfps-range will be to 60
+			     (and you probably get the very best results by running at a
+			      render framerate that's a multiple of 60) */
+			// TODO: what happens if we can't reach rfps? probably a suboptimal pfps?
+			float div = round(rfps/60);
+			pfps = rfps/div;
+		}
 	}
 
 	// Calculate timings.


### PR DESCRIPTION
* packet framerate doesn't have to be lower than render framerate (unless render framerate is too high) => that 0.95 factor didn't really help
* Improve the max framerate-handling with vsync, around vid_maxfps and the display refreshrate, especially considering the reported display refresh might be a bit too low
* The packet framerate should be a fraction of the render framerate; and it should be between 45 and 90 to prevent movement glitches and such. Setting `cl_maxfps` to `-1` now automatically chooses an appropriate packet framerate that meets those criteria.
    - If you want it extra smooth, make sure your render framerate is a multiple of 60Hz (by setting vid_maxfps accordingly, or use vsync with a 60Hz display)

Might fix (or at least improve) #819