### PR TITLE
Inventory screen keys/buttons display fix

### DIFF
--- a/src/client/cl_inventory.c
+++ b/src/client/cl_inventory.c
@@ -139,7 +139,7 @@ CL_DrawInventory(void)
 			}
 		}
 
-		Com_sprintf(string, sizeof(string), "%6s %3i %s", bind,
+		Com_sprintf(string, sizeof(string), "%6.6s %3i %s", bind,
 				cl.inventory[item], cl.configstrings[CS_ITEMS + item]);
 
 		if (item != selected)


### PR DESCRIPTION
When a key/button name is too long, and its bound to an inventory element, its display in the inventory screen misaligns the item it is bound to, even pushing it out of the inventory frame.

![old](https://user-images.githubusercontent.com/32081604/169676709-cfffee2d-8b85-4411-8605-92cdbb090f3d.jpg)

This single-line fix limits its display to the maximum of 6 characters the inventory screen allows.

![new](https://user-images.githubusercontent.com/32081604/169676711-2934c04d-d5da-4181-8ed9-6342ebc73de6.jpg)