### PR TITLE
Check >= maxsize in Info_SetValueForKey().  Found by ASAN.

### DIFF
--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -1398,7 +1398,7 @@ Info_SetValueForKey(char *s, char *key, char *value)
 
 	Com_sprintf(newi, sizeof(newi), "\\%s\\%s", key, value);
 
-	if (strlen(newi) + strlen(s) > maxsize)
+	if (strlen(newi) + strlen(s) >= maxsize)
 	{
 		Com_Printf("Info string length exceeded\n");
 		return;


### PR DESCRIPTION
This might be rare, but I found in Daikatana (which uses the same exact code here) that ASAN triggered a warning from the *s = 0; at the end of Info_SetValueForKey().  This can happen if you have a lot of SERVERINFO (especially custom ones like 'admin', 'email', and 'website') flagged CVARs and someone does a /serverinfo packet.  In Daikatana, it was more prevalent use of UB since the same command was sent every time a map transition happened on a public server to send the serverinfo stats to the gamespy master server.

This bug exists in R1Q2 and all varieties of Info_SetValueForKey() out there that I am aware of.  So the mods would need this fix as well.