### PR TITLE
Infinite loop in bind menu fix

### DIFF
--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -44,6 +44,7 @@
 #define QMF_GRAYED              0x00000002
 #define QMF_NUMBERSONLY         0x00000004
 #define QMF_HIGHLIGHT_IF_FOCUS  0x00000008
+#define QMF_INACTIVE            0x00000010
 
 enum {
 	KEYS_ALL	= 0,

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -621,7 +621,7 @@ InitMainMenu(void)
     Draw_GetPicSize(&w, &h, "m_main_plaque");
 
     s_plaque.generic.type = MTYPE_BITMAP;
-    s_plaque.generic.flags = QMF_LEFT_JUSTIFY | QMF_GRAYED;
+    s_plaque.generic.flags = QMF_LEFT_JUSTIFY | QMF_INACTIVE;
     s_plaque.generic.x = (x - (m_cursor_width + 5) - w);
     s_plaque.generic.y = y;
     s_plaque.generic.name = "m_main_plaque";
@@ -629,7 +629,7 @@ InitMainMenu(void)
     s_plaque.focuspic = 0;
 
     s_logo.generic.type = MTYPE_BITMAP;
-    s_logo.generic.flags = QMF_LEFT_JUSTIFY | QMF_GRAYED;
+    s_logo.generic.flags = QMF_LEFT_JUSTIFY | QMF_INACTIVE;
     s_logo.generic.x = (x - (m_cursor_width + 5) - w);
     s_logo.generic.y = y + h + 5;
     s_logo.generic.name = "m_main_logo";
@@ -736,13 +736,16 @@ M_Menu_Main_f(void)
     InitMainMenu();
 
     // force first available item to have focus 
-    while (s_main.cursor >= 0 && s_main.cursor < s_main.nitems) {
-
+    while (s_main.cursor >= 0 && s_main.cursor < s_main.nitems)
+    {
         item = ( menucommon_s * )s_main.items[s_main.cursor];
         
-        if ((item->flags & (QMF_GRAYED))) {
+        if ((item->flags & (QMF_INACTIVE)))
+        {
             s_main.cursor++;
-        } else {
+        }
+        else
+        {
             break;
         }
     }

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -338,7 +338,7 @@ Menu_AdjustCursor(menuframework_s *m, int dir)
 		if ((citem = Menu_ItemAtCursor(m)) != 0)
 		{
 			if (citem->type != MTYPE_SEPARATOR &&
-				(citem->flags & QMF_GRAYED) != QMF_GRAYED)
+				(citem->flags & QMF_INACTIVE) != QMF_INACTIVE)
 			{
 				return;
 			}
@@ -356,7 +356,7 @@ Menu_AdjustCursor(menuframework_s *m, int dir)
 			if (citem)
 			{
 				if (citem->type != MTYPE_SEPARATOR &&
-				(citem->flags & QMF_GRAYED) != QMF_GRAYED)
+				(citem->flags & QMF_INACTIVE) != QMF_INACTIVE)
 				{
 					break;
 				}
@@ -379,7 +379,7 @@ Menu_AdjustCursor(menuframework_s *m, int dir)
 			if (citem)
 			{
 				if (citem->type != MTYPE_SEPARATOR &&
-				(citem->flags & QMF_GRAYED) != QMF_GRAYED)
+				(citem->flags & QMF_INACTIVE) != QMF_INACTIVE)
 				{
 					break;
 				}


### PR DESCRIPTION
Bug introduced in #841.
Added QMF_INACTIVE.
QMF_INACTIVE menu items are skipped.