### PR TITLE
client download, adding two new cvar to have the ability to set

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -110,6 +110,13 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
 
 * **cl_http_show_dw_progress**: Show a HTTP download progress bar.
 
+* **cl_http_bw_limit_rate**: Average speed transfer threshold for
+`cl_http_bw_limit_tmout` variable. Set `0` by default.
+
+* **cl_http_bw_limit_tmout**: Seconds before the download is aborted
+when the speed transfer is below the var set by `cl_http_bw_limit_rate`.
+Set `0` by default.
+
 * **cl_kickangles**: If set to `0` angle kicks (weapon recoil, damage
   hits and the like) are ignored. Cheat-protected. Defaults to `1`.
 

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -554,6 +554,8 @@ CL_InitLocal(void)
 	cl_http_downloads = Cvar_Get("cl_http_downloads", "1", CVAR_ARCHIVE);
 	cl_http_max_connections = Cvar_Get("cl_http_max_connections", "4", 0);
 	cl_http_show_dw_progress = Cvar_Get("cl_http_show_dw_progress", "0", 0);
+	cl_http_bw_limit_rate = Cvar_Get("cl_http_bw_limit_rate", "0", 0);
+	cl_http_bw_limit_tmout = Cvar_Get("cl_http_bw_limit_tmout", "0", 0);
 #endif
 
 	/* register our commands */

--- a/src/client/curl/download.c
+++ b/src/client/curl/download.c
@@ -36,6 +36,8 @@ cvar_t *cl_http_filelists;
 cvar_t *cl_http_proxy;
 cvar_t *cl_http_max_connections;
 cvar_t *cl_http_show_dw_progress;
+cvar_t *cl_http_bw_limit_rate;
+cvar_t *cl_http_bw_limit_tmout;
 
 dlquirks_t dlquirks = { .error = false, .filelist = true, .gamedir = {'\0'} };
 
@@ -290,6 +292,8 @@ static void CL_StartHTTPDownload (dlqueue_t *entry, dlhandle_t *dl)
 	}
 
 	qcurl_easy_setopt(dl->curl, CURLOPT_PROXY, cl_http_proxy->string);
+	qcurl_easy_setopt(dl->curl, CURLOPT_LOW_SPEED_TIME, (long)cl_http_bw_limit_tmout->value);
+	qcurl_easy_setopt(dl->curl, CURLOPT_LOW_SPEED_LIMIT, (long)cl_http_bw_limit_rate->value);
 	qcurl_easy_setopt(dl->curl, CURLOPT_FOLLOWLOCATION, 1);
 	qcurl_easy_setopt(dl->curl, CURLOPT_MAXREDIRS, 5);
 	qcurl_easy_setopt(dl->curl, CURLOPT_NOPROGRESS, (cl_http_show_dw_progress->value != 1.0));

--- a/src/client/curl/header/download.h
+++ b/src/client/curl/header/download.h
@@ -75,6 +75,8 @@ extern cvar_t *cl_http_filelists;
 extern cvar_t *cl_http_proxy;
 extern cvar_t *cl_http_max_connections;
 extern cvar_t *cl_http_show_dw_progress;
+extern cvar_t *cl_http_bw_limit_rate;
+extern cvar_t *cl_http_bw_limit_tmout;
 
 void CL_CancelHTTPDownloads(qboolean permKill);
 void CL_InitHTTPDownloads(void);


### PR DESCRIPTION
a threshold to abort the download if a certain transfer rate is too low.
Disbabled by default.