### PR TITLE
Gyro aiming through Bluetooth for PS4 & PS5 controllers

### DIFF
--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -1425,6 +1425,14 @@ IN_Controller_Init(qboolean notify_user)
 
 	if (!SDL_WasInit(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC))
 	{
+
+#ifdef SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE	// extended input reports on PS controllers (enables gyro thru bluetooth)
+		SDL_SetHint( SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1" );
+#endif
+#ifdef SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE
+		SDL_SetHint( SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1" );
+#endif
+
 		if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC) == -1)
 		{
 			Com_Printf ("Couldn't init SDL joystick: %s.\n", SDL_GetError ());

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -1882,7 +1882,7 @@ Joy_MenuInit(void)
     s_joy_yawsensitivity_slider.generic.name = "yaw sensitivity";
     s_joy_yawsensitivity_slider.generic.callback = JoyYawSensitivityFunc;
     s_joy_yawsensitivity_slider.minvalue = 0;
-    s_joy_yawsensitivity_slider.maxvalue = 20;
+    s_joy_yawsensitivity_slider.maxvalue = 70;
     Menu_AddItem(&s_joy_menu, (void *)&s_joy_yawsensitivity_slider);
 
     s_joy_pitchsensitivity_slider.curvalue = joy_pitchsensitivity->value * 10;
@@ -1893,7 +1893,7 @@ Joy_MenuInit(void)
     s_joy_pitchsensitivity_slider.generic.name = "pitch sensitivity";
     s_joy_pitchsensitivity_slider.generic.callback = JoyPitchSensitivityFunc;
     s_joy_pitchsensitivity_slider.minvalue = 0;
-    s_joy_pitchsensitivity_slider.maxvalue = 20;
+    s_joy_pitchsensitivity_slider.maxvalue = 70;
     Menu_AddItem(&s_joy_menu, (void *)&s_joy_pitchsensitivity_slider);
 
     y += 10;


### PR DESCRIPTION
This is an extension of https://github.com/yquake2/yquake2/pull/849, where gyro aiming was available wireless on Nintendo Switch controllers, but not on PS4 ones (on Windows and Mac). This commit fixes this, even enabling it for the PS5 controller.
What this does is to enable "extended input reports", which handles sensors and rumble through bluetooth.
Wanted to add this on my next PR, but that will take more work and more time.

EDIT: Second commit is something that was requested on Discord. I don't think it hurts to make some people happy...