### PR TITLE
Faster weapon switching with 'cycleweap'

### DIFF
--- a/doc/050_commands.md
+++ b/doc/050_commands.md
@@ -9,6 +9,7 @@ original clients (Vanilla Quake II) commands are still in place.
   weapon classnames separated by whitespaces. A weapon in the list is
   skipped if it is not a valid weapon classname, you do not own it in
   your inventory or you do not have enough ammo to use it.
+  By quickly tapping the bound key, you can navigate the list faster.
 
 * **prefweap <weapons>**: Similar to the previous command, this will
   select the first weapon available in the priority list given. Useful

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -1430,6 +1430,7 @@ cycle_weapon(edict_t *ent)
 	int i;
 	int start;
 	int num_weaps;
+	const char *weapname = NULL;
 
 	if (!ent)
 	{
@@ -1446,11 +1447,20 @@ cycle_weapon(edict_t *ent)
 	num_weaps = gi.argc();
 
 	/* find where we want to start the search for the next eligible weapon */
-	if (cl->pers.weapon)
+	if (cl->newweapon)
+	{
+		weapname = cl->newweapon->classname;
+	}
+	else if (cl->pers.weapon)
+	{
+		weapname = cl->pers.weapon->classname;
+	}
+
+	if (weapname)
 	{
 		for (i = 1; i < num_weaps; i++)
 		{
-			if (Q_stricmp(cl->pers.weapon->classname, gi.argv(i)) == 0)
+			if (Q_stricmp(weapname, gi.argv(i)) == 0)
 			{
 				break;
 			}


### PR DESCRIPTION
This PR makes _cycleweap_ "count the amount of key presses" so it can navigate through its defined list quicker and pull out the desired weapon faster, instead of waiting for the appearance and animation of every weapon on its list.

e.g. you have the following bind:
`bind e "cycleweap weapon_machinegun weapon_chaingun"`
..and you are using any other weapon. By double-tapping "e", you can immediately swap to the chaingun, instead of having to wait for the machinegun to come out first.
It's the equivalent of pressing "4" and quickly after, "5". The press of "5" overrides the previous "4", so the chaingun is the weapon selected at the end.