### PR TITLE
Remove broken pusher delta yaw manipulation

### DIFF
--- a/src/game/g_phys.c
+++ b/src/game/g_phys.c
@@ -579,7 +579,6 @@ typedef struct
 	edict_t *ent;
 	vec3_t origin;
 	vec3_t angles;
-	float deltayaw;
 } pushed_t;
 
 pushed_t pushed[MAX_EDICTS], *pushed_p;
@@ -630,12 +629,6 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 	pushed_p->ent = pusher;
 	VectorCopy(pusher->s.origin, pushed_p->origin);
 	VectorCopy(pusher->s.angles, pushed_p->angles);
-
-	if (pusher->client)
-	{
-		pushed_p->deltayaw = pusher->client->ps.pmove.delta_angles[YAW];
-	}
-
 	pushed_p++;
 
 	/* move the pusher to it's final position */
@@ -706,11 +699,6 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 			/* try moving the contacted entity */
 			VectorAdd(check->s.origin, move, check->s.origin);
 
-			if (check->client)
-			{
-				check->client->ps.pmove.delta_angles[YAW] += amove[YAW];
-			}
-
 			/* figure movement due to the pusher's amove */
 			VectorSubtract(check->s.origin, pusher->s.origin, org);
 			org2[0] = DotProduct(org, forward);
@@ -758,11 +746,6 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 		{
 			VectorCopy(p->origin, p->ent->s.origin);
 			VectorCopy(p->angles, p->ent->s.angles);
-
-			if (p->ent->client)
-			{
-				p->ent->client->ps.pmove.delta_angles[YAW] = p->deltayaw;
-			}
 
 			gi.linkentity(p->ent);
 		}


### PR DESCRIPTION
This didn't work correctly for multiple reasons:

1. `deltayaw` was wrongly initialized for the pusher itself, rather than for pushed client.
2. `delta_angles[YAW]` is a short, adding plain `amove[YAW]` to it is wrong.

To support yaw angle rotation properly, delta_angles must be interpolated on the client. But this is hardly practical as it would introduce other bugs. Thus, simply remove delta yaw manipulation code altogether.

Fixes infamous Q2 bug when player standing on a blocked lift gets turned into wrong direction.

I'll also send PRs for mission packs if this is accepted.