### PR TITLE
Improved controller thumbsticks precision + Flick Stick

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -476,6 +476,9 @@ Set `0` by default.
   - `2`: *Legacy*, left moves forward/backward and turns, right strafes
     and looks up/down
   - `3`: *Legacy Southpaw*, inverted sticks version of previous one
+  - `4`: *Flick Stick*, left stick moves, right checks your surroundings
+    in 360º, gyro required for looking up/down
+  - `5`: *Flick Stick Southpaw*, swapped sticks version of last one
 
 * **joy_left_deadzone** / **joy_right_deadzone**: Inner, circular
   deadzone for each stick, where inputs below this radius will be
@@ -486,12 +489,17 @@ Set `0` by default.
   deadzone with the shape of a "bowtie", which will help you to do
   perfectly horizontal or vertical movements the more you mark a
   direction with the stick. Increasing this too much will reduce speed
-  for the diagonals. Default `0.15`.
+  for the diagonals, but will help you to mark 90º/180º turns with Flick
+  Stick. Default `0.15`.
 
 * **joy_left_expo** / **joy_right_expo**: Exponents on the response
   curve on each stick. Increasing this will make small movements to
   represent much smaller inputs, which helps precision with the sticks.
   `1.0` is linear. Default `2.0` (quadratic curve).
+
+* **joy_flick_threshold**: Used only with Flick Stick, specifies the
+  distance from the center of the stick that will make the player flick
+  or rotate. Default `0.65` (65%).
 
 * **gyro_mode**: Operation mode for the gyroscope sensor of the game
   controller. Options are `0` = always off, `1` = off with the

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -501,6 +501,11 @@ Set `0` by default.
   distance from the center of the stick that will make the player flick
   or rotate. Default `0.65` (65%).
 
+* **joy_flick_smoothed**: Flick Stick only, rotations below this angle
+  (in degrees) will be smoothed. Reducing this will increase
+  responsiveness at the cost of jittery movement. Most gamepads will work
+  nicely with a value between 4.0 and 8.0. Default `8.0`.
+
 * **gyro_mode**: Operation mode for the gyroscope sensor of the game
   controller. Options are `0` = always off, `1` = off with the
   `+gyroaction` bind to enable, `2` = on with `+gyroaction` to

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -481,6 +481,13 @@ Set `0` by default.
   deadzone for each stick, where inputs below this radius will be
   ignored. Default is `0.16` (16% of possible stick travel).
 
+* **joy_left_snapaxis** / **joy_right_snapaxis**: Ratio on the value of
+  one axis (X or Y) to snap you to the other. It creates an axial
+  deadzone with the shape of a "bowtie", which will help you to do
+  perfectly horizontal or vertical movements the more you mark a
+  direction with the stick. Increasing this too much will reduce speed
+  for the diagonals. Default `0.15`.
+
 * **joy_left_expo** / **joy_right_expo**: Exponents on the response
   curve on each stick. Increasing this will make small movements to
   represent much smaller inputs, which helps precision with the sticks.

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -470,6 +470,22 @@ Set `0` by default.
   `2` to use the Guide/Home/PS button. Requires a game restart
   (or controller replug) when changed.
 
+* **joy_layout**: Allows to select the stick layout of the gamepad.
+  - `0`: *Default*, left stick moves, right aims
+  - `1`: *Southpaw*, same as previous one with inverted sticks
+  - `2`: *Legacy*, left moves forward/backward and turns, right strafes
+    and looks up/down
+  - `3`: *Legacy Southpaw*, inverted sticks version of previous one
+
+* **joy_left_deadzone** / **joy_right_deadzone**: Inner, circular
+  deadzone for each stick, where inputs below this radius will be
+  ignored. Default is `0.16` (16% of possible stick travel).
+
+* **joy_left_expo** / **joy_right_expo**: Exponents on the response
+  curve on each stick. Increasing this will make small movements to
+  represent much smaller inputs, which helps precision with the sticks.
+  `1.0` is linear. Default `2.0` (quadratic curve).
+
 * **gyro_mode**: Operation mode for the gyroscope sensor of the game
   controller. Options are `0` = always off, `1` = off with the
   `+gyroaction` bind to enable, `2` = on with `+gyroaction` to

--- a/src/client/header/client.h
+++ b/src/client/header/client.h
@@ -294,6 +294,7 @@ extern	cvar_t	*cl_shownet;
 extern	cvar_t	*cl_showmiss;
 extern	cvar_t	*cl_showclamp;
 extern	cvar_t	*lookstrafe;
+extern	cvar_t	*joy_layout;
 extern	cvar_t	*gyro_mode;
 extern	cvar_t	*gyro_turning_axis;
 extern	cvar_t	*m_pitch;

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -166,7 +166,7 @@ static cvar_t *gyro_calibration_z;
 static qboolean first_init = true;
 
 // Countdown of calls to IN_Update(), needed for controller init and gyro calibration
-static unsigned int updates_countdown = 30;
+static unsigned short int updates_countdown = 30;
 
 // Reason for the countdown
 static updates_countdown_reasons countdown_reason = REASON_CONTROLLERINIT;
@@ -833,11 +833,9 @@ IN_Update(void)
 					num_samples++;
 					break;
 				}
-				if (!gyro_active || !gyro_mode->value)
-				{
-					gyro_yaw = gyro_pitch = 0;
-				}
-				else
+
+				if (gyro_active && gyro_mode->value &&
+					!cl_paused->value && cls.key_dest == key_game)
 				{
 					if (!gyro_turning_axis->value)
 					{
@@ -850,6 +848,10 @@ IN_Update(void)
 					gyro_yaw *= gyro_yawsensitivity->value * cl_yawspeed->value;
 					gyro_pitch = (event.csensor.data[0] - gyro_calibration_x->value)
 							* gyro_pitchsensitivity->value * cl_pitchspeed->value;
+				}
+				else
+				{
+					gyro_yaw = gyro_pitch = 0;
 				}
 				break;
 #endif	// SDL_VERSION_ATLEAST(2, 0, 16)
@@ -1474,7 +1476,7 @@ IN_Controller_Init(qboolean notify_user)
 
 		Com_Printf ("The name of the joystick is '%s'\n", joystick_name);
 
-		// Ugly hack to detect IMU-only devices - works for Switch Pro Controller at least
+		// Ugly hack to detect IMU-only devices - works for Switch controllers at least
 		if (name_len > 4 && !strncmp(joystick_name + name_len - 4, " IMU", 4))
 		{
 			Com_Printf ("Skipping IMU device.\n");

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -894,12 +894,12 @@ IN_StickMagnitude(thumbstick_t stick)
 }
 
 /*
- * Scaling to represent a value in a certain input range, on a different output range
+ * Scales "v" from [deadzone, 1] range to [0, 1] range, then inherits sign
  */
 static float
-IN_MapRange(float v, float old_min, float old_max, float new_min, float new_max)
+IN_MapRange(float v, float deadzone, float sign)
 {
-	return new_min + ((new_max - new_min) * (v - old_min) / (old_max - old_min));
+	return ((v - deadzone) / (1 - deadzone)) * sign;
 }
 
 /*
@@ -940,11 +940,11 @@ IN_SlopedAxialDeadzone(thumbstick_t stick, float deadzone)
 
 	if (abs_x > deadzone_x)
 	{
-		result.x = sign_x * IN_MapRange(abs_x, deadzone_x, 1, 0, 1);
+		result.x = IN_MapRange(abs_x, deadzone_x, sign_x);
 	}
 	if (abs_y > deadzone_y)
 	{
-		result.y = sign_y * IN_MapRange(abs_y, deadzone_y, 1, 0, 1);
+		result.y = IN_MapRange(abs_y, deadzone_y, sign_y);
 	}
 
 	return result;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -1814,6 +1814,17 @@ Joy_MenuInit(void)
         0
     };
 
+    static const char *stick_layouts_fs[] =
+    {
+        "default",
+        "southpaw",
+        "legacy",
+        "legacy southpaw",
+        "flick stick",
+        "flick stick spaw",
+        0
+    };
+
     int y = 0;
 
     s_joy_menu.x = (int)(viddef.width * 0.50f);
@@ -1905,8 +1916,16 @@ Joy_MenuInit(void)
     y += 10;
     s_joy_layout_box.generic.name = "stick layout";
     s_joy_layout_box.generic.callback = StickLayoutFunc;
-    s_joy_layout_box.itemnames = stick_layouts;
-    s_joy_layout_box.curvalue = ClampCvar(0, 3, joy_layout->value);
+    if (gyro_hardware || joy_layout->value > 3)
+    {
+        s_joy_layout_box.itemnames = stick_layouts_fs;
+        s_joy_layout_box.curvalue = ClampCvar(0, 5, joy_layout->value);
+    }
+    else
+    {
+        s_joy_layout_box.itemnames = stick_layouts;
+        s_joy_layout_box.curvalue = ClampCvar(0, 3, joy_layout->value);
+    }
     Menu_AddItem(&s_joy_menu, (void *)&s_joy_layout_box);
 
     if (gyro_hardware)

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -1764,12 +1764,13 @@ M_Menu_Gyro_f(void)
 /*
  * JOY MENU
  */
-static menuslider_s s_joy_expo_slider;
+static menulist_s s_joy_layout_box;
 static menuslider_s s_joy_yawsensitivity_slider;
 static menuslider_s s_joy_pitchsensitivity_slider;
 static menuslider_s s_joy_forwardsensitivity_slider;
 static menuslider_s s_joy_sidesensitivity_slider;
-static menuslider_s s_joy_upsensitivity_slider;
+static menuslider_s s_joy_left_expo_slider;
+static menuslider_s s_joy_right_expo_slider;
 static menuslider_s s_joy_haptic_slider;
 static menuaction_s s_joy_gyro_action;
 static menuaction_s s_joy_customize_buttons_action;
@@ -1794,9 +1795,25 @@ ConfigGyroFunc(void *unused)
 }
 
 static void
+StickLayoutFunc(void *unused)
+{
+	Cvar_SetValue("joy_layout", (int)s_joy_layout_box.curvalue);
+}
+
+static void
 Joy_MenuInit(void)
 {
     extern qboolean show_haptic;
+
+    static const char *stick_layouts[] =
+    {
+        "default",
+        "southpaw",
+        "legacy",
+        "legacy southpaw",
+        0
+    };
+
     int y = 0;
 
     s_joy_menu.x = (int)(viddef.width * 0.50f);
@@ -1846,27 +1863,25 @@ Joy_MenuInit(void)
 
     y += 10;
 
-    s_joy_upsensitivity_slider.generic.type = MTYPE_SLIDER;
-    s_joy_upsensitivity_slider.generic.x = 0;
-    s_joy_upsensitivity_slider.generic.y = y;
+    s_joy_left_expo_slider.generic.type = MTYPE_SLIDER;
+    s_joy_left_expo_slider.generic.x = 0;
+    s_joy_left_expo_slider.generic.y = y;
     y += 10;
-    s_joy_upsensitivity_slider.generic.name = "up sensitivity";
-    s_joy_upsensitivity_slider.cvar = "joy_upsensitivity";
-    s_joy_upsensitivity_slider.minvalue = 0.0f;
-    s_joy_upsensitivity_slider.maxvalue = 2.0f;
-    Menu_AddItem(&s_joy_menu, (void *)&s_joy_upsensitivity_slider);
+    s_joy_left_expo_slider.generic.name = "left expo";
+    s_joy_left_expo_slider.cvar = "joy_left_expo";
+    s_joy_left_expo_slider.minvalue = 1;
+    s_joy_left_expo_slider.maxvalue = 5;
+    Menu_AddItem(&s_joy_menu, (void *)&s_joy_left_expo_slider);
 
+    s_joy_right_expo_slider.generic.type = MTYPE_SLIDER;
+    s_joy_right_expo_slider.generic.x = 0;
+    s_joy_right_expo_slider.generic.y = y;
     y += 10;
-
-    s_joy_expo_slider.generic.type = MTYPE_SLIDER;
-    s_joy_expo_slider.generic.x = 0;
-    s_joy_expo_slider.generic.y = y;
-    y += 10;
-    s_joy_expo_slider.generic.name = "expo";
-    s_joy_expo_slider.cvar = "joy_expo";
-    s_joy_expo_slider.minvalue = 1;
-    s_joy_expo_slider.maxvalue = 5;
-    Menu_AddItem(&s_joy_menu, (void *)&s_joy_expo_slider);
+    s_joy_right_expo_slider.generic.name = "right expo";
+    s_joy_right_expo_slider.cvar = "joy_right_expo";
+    s_joy_right_expo_slider.minvalue = 1;
+    s_joy_right_expo_slider.maxvalue = 5;
+    Menu_AddItem(&s_joy_menu, (void *)&s_joy_right_expo_slider);
 
     if (show_haptic) {
         y += 10;
@@ -1881,6 +1896,18 @@ Joy_MenuInit(void)
         s_joy_haptic_slider.maxvalue = 2.2f;
         Menu_AddItem(&s_joy_menu, (void *)&s_joy_haptic_slider);
     }
+
+    y += 10;
+
+    s_joy_layout_box.generic.type = MTYPE_SPINCONTROL;
+    s_joy_layout_box.generic.x = 0;
+    s_joy_layout_box.generic.y = y;
+    y += 10;
+    s_joy_layout_box.generic.name = "stick layout";
+    s_joy_layout_box.generic.callback = StickLayoutFunc;
+    s_joy_layout_box.itemnames = stick_layouts;
+    s_joy_layout_box.curvalue = ClampCvar(0, 3, joy_layout->value);
+    Menu_AddItem(&s_joy_menu, (void *)&s_joy_layout_box);
 
     if (gyro_hardware)
     {

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -1709,12 +1709,12 @@ Gyro_MenuInit(void)
 	s_gyro_pitchsensitivity_slider.maxvalue = 8.0f;
 
 	s_calibrating_text[0].generic.type = MTYPE_SEPARATOR;
-	s_calibrating_text[0].generic.x = 48 * scale + 30;
+	s_calibrating_text[0].generic.x = 48 * scale + 32;
 	s_calibrating_text[0].generic.y = (y += 20);
 	s_calibrating_text[0].generic.name = "place the controller on a flat,";
 
 	s_calibrating_text[1].generic.type = MTYPE_SEPARATOR;
-	s_calibrating_text[1].generic.x = 48 * scale + 30;
+	s_calibrating_text[1].generic.x = 48 * scale + 32;
 	s_calibrating_text[1].generic.y = (y += 10);
 	s_calibrating_text[1].generic.name = "stable surface to...";
 
@@ -1909,7 +1909,7 @@ Joy_MenuInit(void)
     s_joy_customize_alt_buttons_action.generic.x = 0;
     s_joy_customize_alt_buttons_action.generic.y = y;
     y += 10;
-    s_joy_customize_alt_buttons_action.generic.name = "customize alt buttons";
+    s_joy_customize_alt_buttons_action.generic.name = "custom. alt buttons";
     s_joy_customize_alt_buttons_action.generic.callback = CustomizeControllerAltButtonsFunc;
     Menu_AddItem(&s_joy_menu, (void *)&s_joy_customize_alt_buttons_action);
 


### PR DESCRIPTION
I know all of you are very busy right now, but doesn't matter how much time you take to review this, I wanted to do this before the 25th anniversary of Quake II :)

The present PR rewrites joystick reading and handling to introduce some new features that improve thumbsticks' precision and customization.

First, what's been removed:

1. Assigning a function to each stick axis individually.
2. Classic "threshold" deadzones by axis, so no more axial deadzone either.
3. Having "joystick_up" as input for IN_Move(), along with its sensitivity. No gamepad standard uses it, it would be useful only on a ladder or underwater, and only people who have looked at the source code would've known about it, since the name of the function was needed to be assigned to an axis (not present in documentation).

**Deleted cvars: 14.**

What's introduced:

1. A cvar to quickly assign stick layout from a list of classic predetermined ones (plus a new surprise); also available in menu.
2. Circular, inner deadzone, for each stick.
3. Sloped axial deadzone (also called "angular deadzone") replacing the previous axial one, configured separately from the inner deadzone. This maintains the "snap-to-axis" feeling of the previous one, the facility to mark perfectly horizontal or vertical movements, but without sacrificing space of diagonal movement.
Having separated deadzones allows for a more custom experience, since people that prefer a larger inner deadzone and get rid of the axial one can do that now, or on the contrary, eliminate the inner deadzone but require a bigger "snap-to-axis" feeling can do that too.
![Deadzones](https://user-images.githubusercontent.com/32081604/186547044-de9f8915-eb89-412e-9b59-1dc595fd86e3.png)

4. "Expo" is now different for each stick, and it's applied to the "magnitude" of the stick, meaning it's measured on the distance from the center of the stick. Currently, it's applied separately on each axis, which wouldn't make possible to reach the full curve on diagonals, since diagonals don't reach the whole range of either axis.
5. Among the stick layouts, a new one is introduced: [Flick Stick](https://en.wikipedia.org/wiki/Flick_Stick), a state-of-the-art control method designed by @JibbSmart, currently featured in games like _CS:GO_ and _Fortnite_. In this layout, the right stick functions as the camera of a racing game, capable of covering horizontally your surroundings in 360º. Another way to describe it is that makes the game operate as a 2D twin-stick shooter in 3D. Its creator explains it better: https://www.youtube.com/watch?v=C5L_Px3dFtE
To look up and down, gyro aiming is required, so at least to set it up with the menus, a gyro-capable controller is required.

**Added cvars: 9.**

Finally, I wanted to ask what is needed to be included in the Yamagi credits. I'll continue to contribute to the project, regardless.

#### Bibliography

- Introduction to deadzones and its handling
http://joshsutphin.com/2013/04/12/doing-thumbstick-dead-zones-right.html
- Advanced deadzone handling (from this, implemented what the author refers to as a "hybrid" solution)
https://github.com/Minimuino/thumbstick-deadzones
- Flick Stick and how to implement
http://gyrowiki.jibbsmart.com/blog:good-gyro-controls-part-2:the-flick-stick