### PR TITLE
Options to invert gyro axes

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -471,6 +471,10 @@ Set `0` by default.
 
 ## Game Controller
 
+* **in_initjoy**: Toggles initialization of game controller. Default is
+  `1`, which enables gamepad usage; `0` disables its detection at
+  startup. Can only be set from command line.
+
 * **in_sdlbackbutton**: Defines which button is used in the gamepad or
   joystick as the `Esc` key, to access the main menu and 'cancel' /
   'go back' on its options. Default is `0`, which corresponds to the

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -1618,16 +1618,16 @@ IsCalibrationZero(void)
 static void
 IN_Controller_Init(qboolean notify_user)
 {
-	cvar_t *in_sdlbackbutton;
+	cvar_t *cvar;
 	int nummappings;
 	char controllerdb[MAX_OSPATH] = {0};
 	SDL_Joystick *joystick = NULL;
 	SDL_bool is_controller = SDL_FALSE;
 
-	in_sdlbackbutton = Cvar_Get("in_sdlbackbutton", "0", CVAR_ARCHIVE);
-	if (in_sdlbackbutton)
+	cvar = Cvar_Get("in_sdlbackbutton", "0", CVAR_ARCHIVE);
+	if (cvar)
 	{
-		switch ((int)in_sdlbackbutton->value)
+		switch ((int)cvar->value)
 		{
 			case 1:
 				sdl_back_button = SDL_CONTROLLER_BUTTON_START;
@@ -1638,6 +1638,12 @@ IN_Controller_Init(qboolean notify_user)
 			default:
 				sdl_back_button = SDL_CONTROLLER_BUTTON_BACK;
 		}
+	}
+
+	cvar = Cvar_Get("in_initjoy", "1", CVAR_NOSET);
+	if (!cvar->value)
+	{
+		return;
 	}
 
 	if (notify_user)

--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -113,6 +113,7 @@ typedef struct
 	float	maxvalue;
 	float	slidestep;
 	char *	printformat;
+	qboolean	abs;
 } menuslider_s;
 
 typedef struct

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -1607,6 +1607,8 @@ static menulist_s s_gyro_mode_box;
 static menulist_s s_turning_axis_box;
 static menuslider_s s_gyro_yawsensitivity_slider;
 static menuslider_s s_gyro_pitchsensitivity_slider;
+static menulist_s s_gyro_invertyaw_box;
+static menulist_s s_gyro_invertpitch_box;
 static menuseparator_s s_calibrating_text[2];
 static menuaction_s s_calibrate_gyro;
 
@@ -1652,6 +1654,18 @@ TurningAxisFunc(void *unused)
 }
 
 static void
+InvertGyroYawFunc(void *unused)
+{
+	Cvar_SetValue("gyro_yawsensitivity", -Cvar_VariableValue("gyro_yawsensitivity"));
+}
+
+static void
+InvertGyroPitchFunc(void *unused)
+{
+	Cvar_SetValue("gyro_pitchsensitivity", -Cvar_VariableValue("gyro_pitchsensitivity"));
+}
+
+static void
 Gyro_MenuInit(void)
 {
 	static const char *gyro_modes[] =
@@ -1667,6 +1681,13 @@ Gyro_MenuInit(void)
 	{
 		"yaw (turn)",
 		"roll (lean)",
+		0
+	};
+
+	static const char *yesno_names[] =
+	{
+		"no",
+		"yes",
 		0
 	};
 
@@ -1710,6 +1731,22 @@ Gyro_MenuInit(void)
 	s_gyro_pitchsensitivity_slider.maxvalue = 8.0f;
 	s_gyro_pitchsensitivity_slider.abs = true;
 
+	s_gyro_invertyaw_box.generic.type = MTYPE_SPINCONTROL;
+	s_gyro_invertyaw_box.generic.x = 0;
+	s_gyro_invertyaw_box.generic.y = (y += 10);
+	s_gyro_invertyaw_box.generic.name = "invert yaw";
+	s_gyro_invertyaw_box.generic.callback = InvertGyroYawFunc;
+	s_gyro_invertyaw_box.itemnames = yesno_names;
+	s_gyro_invertyaw_box.curvalue = (Cvar_VariableValue("gyro_yawsensitivity") < 0);
+
+	s_gyro_invertpitch_box.generic.type = MTYPE_SPINCONTROL;
+	s_gyro_invertpitch_box.generic.x = 0;
+	s_gyro_invertpitch_box.generic.y = (y += 10);
+	s_gyro_invertpitch_box.generic.name = "invert pitch";
+	s_gyro_invertpitch_box.generic.callback = InvertGyroPitchFunc;
+	s_gyro_invertpitch_box.itemnames = yesno_names;
+	s_gyro_invertpitch_box.curvalue = (Cvar_VariableValue("gyro_pitchsensitivity") < 0);
+
 	s_calibrating_text[0].generic.type = MTYPE_SEPARATOR;
 	s_calibrating_text[0].generic.x = 48 * scale + 32;
 	s_calibrating_text[0].generic.y = (y += 20);
@@ -1730,6 +1767,8 @@ Gyro_MenuInit(void)
 	Menu_AddItem(&s_gyro_menu, (void *)&s_turning_axis_box);
 	Menu_AddItem(&s_gyro_menu, (void *)&s_gyro_yawsensitivity_slider);
 	Menu_AddItem(&s_gyro_menu, (void *)&s_gyro_pitchsensitivity_slider);
+	Menu_AddItem(&s_gyro_menu, (void *)&s_gyro_invertyaw_box);
+	Menu_AddItem(&s_gyro_menu, (void *)&s_gyro_invertpitch_box);
 	Menu_AddItem(&s_gyro_menu, (void *)&s_calibrating_text[0]);
 	Menu_AddItem(&s_gyro_menu, (void *)&s_calibrating_text[1]);
 	Menu_AddItem(&s_gyro_menu, (void *)&s_calibrate_gyro);

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2508,6 +2508,7 @@ static const char *idcredits[] = {
 	"Sander van Dijk",
 	"Denis Pauk",
 	"Bjorn Alfredsson",
+	"Jaime Moreira",
 	"",
 	"Quake II(tm) (C)1997 Id Software, Inc.",
 	"All Rights Reserved.  Distributed by",

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -1699,6 +1699,7 @@ Gyro_MenuInit(void)
 	s_gyro_yawsensitivity_slider.cvar = "gyro_yawsensitivity";
 	s_gyro_yawsensitivity_slider.minvalue = 0.1f;
 	s_gyro_yawsensitivity_slider.maxvalue = 8.0f;
+	s_gyro_yawsensitivity_slider.abs = true;
 
 	s_gyro_pitchsensitivity_slider.generic.type = MTYPE_SLIDER;
 	s_gyro_pitchsensitivity_slider.generic.x = 0;
@@ -1707,6 +1708,7 @@ Gyro_MenuInit(void)
 	s_gyro_pitchsensitivity_slider.cvar = "gyro_pitchsensitivity";
 	s_gyro_pitchsensitivity_slider.minvalue = 0.1f;
 	s_gyro_pitchsensitivity_slider.maxvalue = 8.0f;
+	s_gyro_pitchsensitivity_slider.abs = true;
 
 	s_calibrating_text[0].generic.type = MTYPE_SEPARATOR;
 	s_calibrating_text[0].generic.x = 48 * scale + 32;

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -661,13 +661,20 @@ Slider_DoSlide(menuslider_s *s, int dir)
 {
 	float value = Cvar_VariableValue(s->cvar);
 	float step = 0.1f;
+	float sign = 1.0f;
 
 	if (s->slidestep)
 	{
 		step = s->slidestep;
 	}
+	if (s->abs && value < 0)	// absolute value treatment
+	{
+		value = -value;
+		sign = -1.0f;
+	}
+
 	value += dir * step;
-	Cvar_SetValue(s->cvar, ClampCvar(s->minvalue, s->maxvalue, value));
+	Cvar_SetValue(s->cvar, ClampCvar(s->minvalue, s->maxvalue, value) * sign);
 
 	if (s->generic.callback)
 	{
@@ -688,6 +695,10 @@ Slider_Draw(menuslider_s *s)
 	int y = s->generic.parent->y + s->generic.y;
 
 	float value = Cvar_VariableValue(s->cvar);
+	if (s->abs && value < 0)	// absolute value
+	{
+		value = -value;
+	}
 	float range = (ClampCvar(s->minvalue, s->maxvalue, value) - s->minvalue) /
 			(s->maxvalue - s->minvalue);
 


### PR DESCRIPTION
This adds a couple of spin controls to invert yaw and pitch in the gyro options.
Now sliders are able to use the "absolute value" (ignore negative sign) of its associated cvar, if there's a need for it. This is because the "reversal" of the gyro axes is achieved by converting their sensitivities to a negative value; I believe it's better than adding a new cvar only for this.

Additionally, I resurrected the "in_initjoy" cvar from Quake II 3.21. Fixes #879 
Finally, I added myself to the credits. Thank you for this!