### PR TITLE
Fix items already in water at level start playing splash sound

### DIFF
--- a/src/game/g_phys.c
+++ b/src/game/g_phys.c
@@ -1005,8 +1005,12 @@ SV_Physics_Toss(edict_t *ent)
 
 	if (!wasinwater && isinwater)
 	{
-		gi.positioned_sound(old_origin, g_edicts, CHAN_AUTO,
-				gi.soundindex("misc/h2ohit1.wav"), 1, 1, 0);
+		/* don't play splash sound for entities already in water on level start */
+		if (level.framenum > 3)
+		{
+			gi.positioned_sound(old_origin, g_edicts, CHAN_AUTO,
+					gi.soundindex("misc/h2ohit1.wav"), 1, 1, 0);
+		}
 	}
 	else if (wasinwater && !isinwater)
 	{


### PR DESCRIPTION
This PR addresses issue https://github.com/yquake2/yquake2/issues/903

The check for level.framenum > 3 ensures items fully settle their physics state before these sounds start playing.