### PR TITLE
Fix coop power cube related bugs

### DIFF
--- a/src/game/g_items.c
+++ b/src/game/g_items.c
@@ -1638,7 +1638,7 @@ SpawnItem(edict_t *ent, gitem_t *item)
 		}
 	}
 
-	if (coop->value && (strcmp(ent->classname, "key_power_cube") == 0))
+	if (coop->value && !(ent->spawnflags & ITEM_NO_TOUCH) && (strcmp(ent->classname, "key_power_cube") == 0))
 	{
 		ent->spawnflags |= (1 << (8 + level.power_cubes));
 		level.power_cubes++;

--- a/src/game/player/hud.c
+++ b/src/game/player/hud.c
@@ -132,13 +132,15 @@ BeginIntermission(edict_t *targ)
 				}
 
 				/* strip players of all keys between units */
-				for (n = 0; n < MAX_ITEMS; n++)
+				for (n = 0; n < game.num_items; n++)
 				{
 					if (itemlist[n].flags & IT_KEY)
 					{
 						client->client->pers.inventory[n] = 0;
 					}
 				}
+
+				client->client->pers.power_cubes = 0;
 			}
 		}
 	}


### PR DESCRIPTION
This PR addresses issue https://github.com/yquake2/yquake2/issues/905.

Other things addressed:
* Out of bounds memory read in loop where keys are removed from player inventory
* Made no-touch power cubes not count towards level.power_cubes, as they will never be picked up anyways