### PR TITLE
Fix for crash with long player skin name

### DIFF
--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5849,6 +5849,7 @@ PlayerConfig_MenuDraw(void)
 static const char *
 PlayerConfig_MenuKey(int key)
 {
+    key = Key_GetMenuKey(key);
     if (key == K_ESCAPE)
     {
         char skin[MAX_QPATH];

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5517,8 +5517,6 @@ PlayerModelList(void)
         // sort skin names alphabetically
         qsort(s_skinnames[mdl].data, s_skinnames[mdl].num, sizeof(char**), Q_sort_strcomp);
 
-        s_skinnames[mdl].num++;         // guard pointer
-
         // at this point we have a valid player model
         s = (char*)malloc(MAX_DISPLAYNAME);
         t = strrchr(s_directory.data[i], '/');
@@ -5590,10 +5588,10 @@ PlayerConfig_MenuInit(void)
     extern cvar_t *skin;
     cvar_t *hand = Cvar_Get( "hand", "0", CVAR_USERINFO | CVAR_ARCHIVE );
     static const char *handedness[] = { "right", "left", "center", 0 };
-    char mdlname[MAX_DISPLAYNAME];
+    char mdlname[MAX_DISPLAYNAME * 2];
     char imgname[MAX_DISPLAYNAME];
-    int mdlindex = -1;
-    int imgindex = -1;
+    int mdlindex = 0;
+    int imgindex = 0;
     int i = 0;
     float scale = SCR_GetMenuScale();
 
@@ -5602,7 +5600,7 @@ PlayerConfig_MenuInit(void)
         return false;
     }
 
-    strcpy(mdlname, skin->string);
+    strncpy(mdlname, skin->string, (MAX_DISPLAYNAME * 2) - 1);
     ReplaceCharacters(mdlname, '\\', '/' );
 
     // MAX_DISPLAYNAME - 1, gcc warns about truncation
@@ -5613,11 +5611,8 @@ PlayerConfig_MenuInit(void)
     }
     else
     {
-        strncpy(mdlname, "male", MAX_DISPLAYNAME - 1);
-        mdlname[strlen("male")] = 0;
-
-        strncpy(imgname, "grunt", MAX_DISPLAYNAME - 1);
-        imgname[strlen("grunt")] = 0;
+        strcpy(mdlname, "male\0");
+        strcpy(imgname, "grunt\0");
     }
 
     for (i = 0; i < s_modelname.num; i++)
@@ -5629,11 +5624,6 @@ PlayerConfig_MenuInit(void)
         }
     }
 
-    if (mdlindex == -1)
-    {
-        mdlindex = 0;
-    }
-
     for (i = 0; i < s_skinnames[mdlindex].num; i++)
     {
         char* names = s_skinnames[mdlindex].data[i];
@@ -5642,11 +5632,6 @@ PlayerConfig_MenuInit(void)
             imgindex = i;
             break;
         }
-    }
-
-    if (imgindex == -1)
-    {
-        imgindex = 0;
     }
 
     if (hand->value < 0 || hand->value > 2)

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5387,7 +5387,7 @@ PlayerDirectoryList(void)
 
         YQ2_COM_CHECK_OOM(s, "malloc()", MAX_QPATH * sizeof(char))
         
-        strncpy(s, t, MAX_QPATH - 1);         // MAX_QPATH - 1, gcc warns about truncation
+        Q_strlcpy(s, t, MAX_QPATH);
         s[strlen(s)] = 0;
 
         data[i] = s;
@@ -5506,7 +5506,7 @@ PlayerModelList(void)
 
                     StripExtension(t);
 
-                    strncpy(s, t + 1, MAX_DISPLAYNAME - 1);         // MAX_DISPLAYNAME - 1, gcc warns about truncation
+                    Q_strlcpy(s, t + 1, MAX_DISPLAYNAME);
                     s[strlen(s)] = 0;
 
                     data[s_skinnames[mdl].num++] = s;
@@ -5523,7 +5523,7 @@ PlayerModelList(void)
 
         YQ2_COM_CHECK_OOM(s, "malloc()", MAX_DISPLAYNAME * sizeof(char))
 
-        strncpy(s, t + 1, MAX_DISPLAYNAME - 1);         // MAX_DISPLAYNAME - 1, gcc warns about truncation
+        Q_strlcpy(s, t + 1, MAX_DISPLAYNAME);
         s[strlen(s)] = 0;
 
         s_modelname.data[s_modelname.num++] = s;
@@ -5600,13 +5600,12 @@ PlayerConfig_MenuInit(void)
         return false;
     }
 
-    strncpy(mdlname, skin->string, (MAX_DISPLAYNAME * 2) - 1);
+    Q_strlcpy(mdlname, skin->string, MAX_DISPLAYNAME * 2);
     ReplaceCharacters(mdlname, '\\', '/' );
 
-    // MAX_DISPLAYNAME - 1, gcc warns about truncation
     if (strchr(mdlname, '/'))
     {
-        strncpy(imgname, strchr(mdlname, '/') + 1, MAX_DISPLAYNAME -1);
+        Q_strlcpy(imgname, strchr(mdlname, '/') + 1, MAX_DISPLAYNAME);
         *strchr(mdlname, '/') = 0;
     }
     else
@@ -5617,7 +5616,7 @@ PlayerConfig_MenuInit(void)
 
     for (i = 0; i < s_modelname.num; i++)
     {
-        if (strcmp(s_modelname.data[i], mdlname) == 0)
+        if (Q_stricmp(s_modelname.data[i], mdlname) == 0)
         {
             mdlindex = i;
             break;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5388,8 +5388,6 @@ PlayerDirectoryList(void)
         YQ2_COM_CHECK_OOM(s, "malloc()", MAX_QPATH * sizeof(char))
         
         Q_strlcpy(s, t, MAX_QPATH);
-        s[strlen(s)] = 0;
-
         data[i] = s;
     }
     
@@ -5505,9 +5503,7 @@ PlayerModelList(void)
                     YQ2_COM_CHECK_OOM(s, "malloc()", MAX_DISPLAYNAME * sizeof(char))
 
                     StripExtension(t);
-
                     Q_strlcpy(s, t + 1, MAX_DISPLAYNAME);
-                    s[strlen(s)] = 0;
 
                     data[s_skinnames[mdl].num++] = s;
                 }
@@ -5524,7 +5520,6 @@ PlayerModelList(void)
         YQ2_COM_CHECK_OOM(s, "malloc()", MAX_DISPLAYNAME * sizeof(char))
 
         Q_strlcpy(s, t + 1, MAX_DISPLAYNAME);
-        s[strlen(s)] = 0;
 
         s_modelname.data[s_modelname.num++] = s;
         mdl = s_modelname.num;


### PR DESCRIPTION
Skin names for players can have a total length of 32: 15 chars for model + "/" + 15 for skin + "\0". Fixes #918 
Also fixes "playermodels" cmd, which showed "(null)" as a final skin for every model.
Finally, gamepad allowed to select skin in menu.