### PR TITLE
Fixed ignoretrack0 and ogg menu option bugs

### DIFF
--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2113,23 +2113,6 @@ static void
 OGGShuffleFunc(void *unused)
 {
     Cvar_SetValue("ogg_shuffle", s_options_oggshuffle_box.curvalue);
-
-    cvar_t *ogg_enable= Cvar_Get("ogg_enable", "1", CVAR_ARCHIVE);
-	int track = (int)strtol(cl.configstrings[CS_CDTRACK], (char **)NULL, 10);
-
-    if (s_options_oggshuffle_box.curvalue)
-    {
-        Cvar_Set("ogg_shuffle", "1");
-    }
-    else
-    {
-        Cvar_Set("ogg_shuffle", "0");
-    }
-
-	if (ogg_enable->value)
-	{
-		OGG_PlayTrack(track);
-	}
 }
 
 static void
@@ -2143,8 +2126,11 @@ EnableOGGMusic(void *unused)
         OGG_InitTrackList();
         OGG_Stop();
 
-        int track = (int)strtol(cl.configstrings[CS_CDTRACK], (char **)NULL, 10);
-        OGG_PlayTrack(track);
+		if (cls.state == ca_active)
+		{
+	        int track = (int)strtol(cl.configstrings[CS_CDTRACK], (char **)NULL, 10);
+	        OGG_PlayTrack(track);
+		}
     }
     else
     {

--- a/src/client/sound/ogg.c
+++ b/src/client/sound/ogg.c
@@ -349,6 +349,7 @@ OGG_PlayTrack(int trackNo)
 		if(ogg_ignoretrack0->value == 0)
 		{
 			OGG_Stop();
+			return;
 		}
 
 		// Special case: If ogg_ignoretrack0 is 0 we stopped the music (see above)


### PR DESCRIPTION
This PR addresses issues in https://github.com/yquake2/yquake2/issues/920

Added the missing return statement to playTrack() so ignoretrack0 works as intended.
Added a safety check to ogg music menu option.
Removed playTrack() code from shuffle menu option.