### PR TITLE
Fix savegame backward compatibility after cfb86ac.

### DIFF
--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2113,23 +2113,6 @@ static void
 OGGShuffleFunc(void *unused)
 {
     Cvar_SetValue("ogg_shuffle", s_options_oggshuffle_box.curvalue);
-
-    cvar_t *ogg_enable= Cvar_Get("ogg_enable", "1", CVAR_ARCHIVE);
-	int track = (int)strtol(cl.configstrings[CS_CDTRACK], (char **)NULL, 10);
-
-    if (s_options_oggshuffle_box.curvalue)
-    {
-        Cvar_Set("ogg_shuffle", "1");
-    }
-    else
-    {
-        Cvar_Set("ogg_shuffle", "0");
-    }
-
-	if (ogg_enable->value)
-	{
-		OGG_PlayTrack(track);
-	}
 }
 
 static void
@@ -2143,8 +2126,11 @@ EnableOGGMusic(void *unused)
         OGG_InitTrackList();
         OGG_Stop();
 
-        int track = (int)strtol(cl.configstrings[CS_CDTRACK], (char **)NULL, 10);
-        OGG_PlayTrack(track);
+		if (cls.state == ca_active)
+		{
+	        int track = (int)strtol(cl.configstrings[CS_CDTRACK], (char **)NULL, 10);
+	        OGG_PlayTrack(track);
+		}
     }
     else
     {

--- a/src/client/sound/ogg.c
+++ b/src/client/sound/ogg.c
@@ -349,6 +349,7 @@ OGG_PlayTrack(int trackNo)
 		if(ogg_ignoretrack0->value == 0)
 		{
 			OGG_Stop();
+			return;
 		}
 
 		// Special case: If ogg_ignoretrack0 is 0 we stopped the music (see above)

--- a/src/game/monster/berserker/berserker.c
+++ b/src/game/monster/berserker/berserker.c
@@ -43,6 +43,13 @@ berserk_footstep(edict_t *self)
 	if (!g_monsterfootsteps->value)
 		return;
 
+	// Lazy loading for savegame compatibility.
+	if (sound_step == 0 || sound_step2 == 0)
+	{
+		sound_step = gi.soundindex("berserk/step1.wav");
+		sound_step2 = gi.soundindex("berserk/step2.wav");
+	}
+
 	if (randk() % 2 == 0)
 	{
 		gi.sound(self, CHAN_BODY, sound_step, 1, ATTN_NORM, 0);
@@ -570,6 +577,11 @@ SP_monster_berserk(edict_t *self)
 		return;
 	}
 
+	// Force recaching at next footstep to ensure
+	// that the sound indices are correct.
+	sound_step = 0;
+	sound_step2 = 0;
+
 	/* pre-caches */
 	sound_pain = gi.soundindex("berserk/berpain2.wav");
 	sound_die = gi.soundindex("berserk/berdeth2.wav");
@@ -577,9 +589,6 @@ SP_monster_berserk(edict_t *self)
 	sound_punch = gi.soundindex("berserk/attack.wav");
 	sound_search = gi.soundindex("berserk/bersrch1.wav");
 	sound_sight = gi.soundindex("berserk/sight.wav");
-
-	sound_step = gi.soundindex("berserk/step1.wav");
-	sound_step2 = gi.soundindex("berserk/step2.wav");
 
 	self->s.modelindex = gi.modelindex("models/monsters/berserk/tris.md2");
 	VectorSet(self->mins, -16, -16, -24);

--- a/src/game/monster/brain/brain.c
+++ b/src/game/monster/brain/brain.c
@@ -51,6 +51,13 @@ brain_footstep(edict_t *self)
 	if (!g_monsterfootsteps->value)
 		return;
 
+	// Lazy loading for savegame compatibility.
+	if (sound_step == 0 || sound_step2 == 0)
+	{
+		sound_step = gi.soundindex("brain/step1.wav");
+		sound_step2 = gi.soundindex("brain/step2.wav");
+	}
+
 	if (randk() % 2 == 0)
 	{
 		gi.sound(self, CHAN_BODY, sound_step, 1, ATTN_NORM, 0);
@@ -817,6 +824,11 @@ SP_monster_brain(edict_t *self)
 		return;
 	}
 
+	// Force recaching at next footstep to ensure
+	// that the sound indices are correct.
+	sound_step = 0;
+	sound_step2 = 0;
+
 	sound_chest_open = gi.soundindex("brain/brnatck1.wav");
 	sound_tentacles_extend = gi.soundindex("brain/brnatck2.wav");
 	sound_tentacles_retract = gi.soundindex("brain/brnatck3.wav");
@@ -831,9 +843,6 @@ SP_monster_brain(edict_t *self)
 	sound_melee1 = gi.soundindex("brain/melee1.wav");
 	sound_melee2 = gi.soundindex("brain/melee2.wav");
 	sound_melee3 = gi.soundindex("brain/melee3.wav");
-
-	sound_step = gi.soundindex("brain/step1.wav");
-	sound_step2 = gi.soundindex("brain/step2.wav");
 
 	self->movetype = MOVETYPE_STEP;
 	self->solid = SOLID_BBOX;

--- a/src/game/monster/chick/chick.c
+++ b/src/game/monster/chick/chick.c
@@ -61,6 +61,13 @@ chick_footstep(edict_t *self)
 	if (!g_monsterfootsteps->value)
 		return;
 
+	// Lazy loading for savegame compatibility.
+	if (sound_step == 0 || sound_step2 == 0)
+	{
+		sound_step = gi.soundindex("bitch/step1.wav");
+		sound_step2 = gi.soundindex("bitch/step2.wav");
+	}
+
 	if (randk() % 2 == 0)
 	{
 		gi.sound(self, CHAN_BODY, sound_step, 1, ATTN_NORM, 0);
@@ -944,6 +951,11 @@ SP_monster_chick(edict_t *self)
 		return;
 	}
 
+	// Force recaching at next footstep to ensure
+	// that the sound indices are correct.
+	sound_step = 0;
+	sound_step2 = 0;
+
 	sound_missile_prelaunch = gi.soundindex("chick/chkatck1.wav");
 	sound_missile_launch = gi.soundindex("chick/chkatck2.wav");
 	sound_melee_swing = gi.soundindex("chick/chkatck3.wav");
@@ -959,9 +971,6 @@ SP_monster_chick(edict_t *self)
 	sound_pain3 = gi.soundindex("chick/chkpain3.wav");
 	sound_sight = gi.soundindex("chick/chksght1.wav");
 	sound_search = gi.soundindex("chick/chksrch1.wav");
-
-	sound_step = gi.soundindex("bitch/step1.wav");
-	sound_step2 = gi.soundindex("bitch/step2.wav");
 
 	self->movetype = MOVETYPE_STEP;
 	self->solid = SOLID_BBOX;

--- a/src/game/monster/gladiator/gladiator.c
+++ b/src/game/monster/gladiator/gladiator.c
@@ -47,6 +47,13 @@ gladiator_footstep(edict_t *self)
 	if (!g_monsterfootsteps->value)
 		return;
 
+	// Lazy loading for savegame compatibility.
+	if (sound_step == 0 || sound_step2 == 0)
+	{
+		sound_step = gi.soundindex("gladiator/step1.wav");
+		sound_step2 = gi.soundindex("gladiator/step2.wav");
+	}
+
 	if (randk() % 2 == 0)
 	{
 		gi.sound(self, CHAN_BODY, sound_step, 1, ATTN_NORM, 0);
@@ -534,6 +541,11 @@ SP_monster_gladiator(edict_t *self)
 		return;
 	}
 
+	// Force recaching at next footstep to ensure
+	// that the sound indices are correct.
+	sound_step = 0;
+	sound_step2 = 0;
+
 	sound_pain1 = gi.soundindex("gladiator/pain.wav");
 	sound_pain2 = gi.soundindex("gladiator/gldpain2.wav");
 	sound_die = gi.soundindex("gladiator/glddeth2.wav");
@@ -544,9 +556,6 @@ SP_monster_gladiator(edict_t *self)
 	sound_idle = gi.soundindex("gladiator/gldidle1.wav");
 	sound_search = gi.soundindex("gladiator/gldsrch1.wav");
 	sound_sight = gi.soundindex("gladiator/sight.wav");
-
-	sound_step = gi.soundindex("gladiator/step1.wav");
-	sound_step2 = gi.soundindex("gladiator/step2.wav");
 
 	self->movetype = MOVETYPE_STEP;
 	self->solid = SOLID_BBOX;

--- a/src/game/monster/gunner/gunner.c
+++ b/src/game/monster/gunner/gunner.c
@@ -44,6 +44,13 @@ gunner_footstep(edict_t *self)
 	if (!g_monsterfootsteps->value)
 		return;
 
+	// Lazy loading for savegame compatibility.
+	if (sound_step == 0 || sound_step2 == 0)
+	{
+		sound_step = gi.soundindex("gunner/step1.wav");
+		sound_step2 = gi.soundindex("gunner/step2.wav");
+	}
+
 	if (randk() % 2 == 0)
 	{
 		gi.sound(self, CHAN_BODY, sound_step, 1, ATTN_NORM, 0);
@@ -885,6 +892,11 @@ SP_monster_gunner(edict_t *self)
 		return;
 	}
 
+	// Force recaching at next footstep to ensure
+	// that the sound indices are correct.
+	sound_step = 0;
+	sound_step2 = 0;
+
 	sound_death = gi.soundindex("gunner/death1.wav");
 	sound_pain = gi.soundindex("gunner/gunpain2.wav");
 	sound_pain2 = gi.soundindex("gunner/gunpain1.wav");
@@ -892,9 +904,6 @@ SP_monster_gunner(edict_t *self)
 	sound_open = gi.soundindex("gunner/gunatck1.wav");
 	sound_search = gi.soundindex("gunner/gunsrch1.wav");
 	sound_sight = gi.soundindex("gunner/sight1.wav");
-
-	sound_step = gi.soundindex("gunner/step1.wav");
-	sound_step2 = gi.soundindex("gunner/step2.wav");
 
 	gi.soundindex("gunner/gunatck2.wav");
 	gi.soundindex("gunner/gunatck3.wav");

--- a/src/game/monster/infantry/infantry.c
+++ b/src/game/monster/infantry/infantry.c
@@ -51,6 +51,13 @@ infantry_footstep(edict_t *self)
 	if (!g_monsterfootsteps->value)
 		return;
 
+	// Lazy loading for savegame compatibility.
+	if (sound_step == 0 || sound_step2 == 0)
+	{
+		sound_step = gi.soundindex("infantry/step1.wav");
+		sound_step2 = gi.soundindex("infantry/step2.wav");
+	}
+
 	if (randk() % 2 == 0)
 	{
 		gi.sound(self, CHAN_BODY, sound_step, 1, ATTN_NORM, 0);
@@ -803,6 +810,11 @@ SP_monster_infantry(edict_t *self)
 		return;
 	}
 
+	// Force recaching at next footstep to ensure
+	// that the sound indices are correct.
+	sound_step = 0;
+	sound_step2 = 0;
+
 	sound_pain1 = gi.soundindex("infantry/infpain1.wav");
 	sound_pain2 = gi.soundindex("infantry/infpain2.wav");
 	sound_die1 = gi.soundindex("infantry/infdeth1.wav");
@@ -816,9 +828,6 @@ SP_monster_infantry(edict_t *self)
 	sound_sight = gi.soundindex("infantry/infsght1.wav");
 	sound_search = gi.soundindex("infantry/infsrch1.wav");
 	sound_idle = gi.soundindex("infantry/infidle1.wav");
-
-	sound_step = gi.soundindex("infantry/step1.wav");
-	sound_step2 = gi.soundindex("infantry/step2.wav");
 
 	self->movetype = MOVETYPE_STEP;
 	self->solid = SOLID_BBOX;

--- a/src/game/monster/insane/insane.c
+++ b/src/game/monster/insane/insane.c
@@ -45,6 +45,15 @@ insane_footstep(edict_t *self)
 	if (!g_monsterfootsteps->value)
 		return;
 
+	// Lazy loading for savegame compatibility.
+	if (sound_step == 0 || sound_step2 == 0 || sound_step3 == 0 || sound_step4 == 0)
+	{
+		sound_step = gi.soundindex("player/step1.wav");
+		sound_step2 = gi.soundindex("player/step2.wav");
+		sound_step3 = gi.soundindex("player/step3.wav");
+		sound_step4 = gi.soundindex("player/step4.wav");
+	}
+
 	int     i;
 	i = randk() % 4;
 
@@ -947,6 +956,13 @@ SP_misc_insane(edict_t *self)
 		return;
 	}
 
+	// Force recaching at next footstep to ensure
+	// that the sound indices are correct.
+	sound_step = 0;
+	sound_step2 = 0;
+	sound_step3 = 0;
+	sound_step4 = 0;
+
 	sound_fist = gi.soundindex("insane/insane11.wav");
 	sound_shake = gi.soundindex("insane/insane5.wav");
 	sound_moan = gi.soundindex("insane/insane7.wav");
@@ -958,11 +974,6 @@ SP_misc_insane(edict_t *self)
 	sound_scream[5] = gi.soundindex("insane/insane8.wav");
 	sound_scream[6] = gi.soundindex("insane/insane9.wav");
 	sound_scream[7] = gi.soundindex("insane/insane10.wav");
-
-	sound_step = gi.soundindex("player/step1.wav");
-	sound_step2 = gi.soundindex("player/step2.wav");
-	sound_step3 = gi.soundindex("player/step3.wav");
-	sound_step4 = gi.soundindex("player/step4.wav");
 
 	self->movetype = MOVETYPE_STEP;
 	self->solid = SOLID_BBOX;

--- a/src/game/monster/medic/medic.c
+++ b/src/game/monster/medic/medic.c
@@ -49,6 +49,13 @@ medic_footstep(edict_t *self)
 	if (!g_monsterfootsteps->value)
 		return;
 
+	// Lazy loading for savegame compatibility.
+	if (sound_step == 0 || sound_step2 == 0)
+	{
+		sound_step = gi.soundindex("medic/step1.wav");
+		sound_step2 = gi.soundindex("medic/step2.wav");
+	}
+
 	if (randk() % 2 == 0)
 	{
 		gi.sound(self, CHAN_BODY, sound_step, 1, ATTN_NORM, 0);
@@ -1015,6 +1022,11 @@ SP_monster_medic(edict_t *self)
 		return;
 	}
 
+	// Force recaching at next footstep to ensure
+	// that the sound indices are correct.
+	sound_step = 0;
+	sound_step2 = 0;
+
 	sound_idle1 = gi.soundindex("medic/idle.wav");
 	sound_pain1 = gi.soundindex("medic/medpain1.wav");
 	sound_pain2 = gi.soundindex("medic/medpain2.wav");
@@ -1025,9 +1037,6 @@ SP_monster_medic(edict_t *self)
 	sound_hook_hit = gi.soundindex("medic/medatck3.wav");
 	sound_hook_heal = gi.soundindex("medic/medatck4.wav");
 	sound_hook_retract = gi.soundindex("medic/medatck5.wav");
-
-	sound_step = gi.soundindex("medic/step1.wav");
-	sound_step2 = gi.soundindex("medic/step2.wav");
 
 	gi.soundindex("medic/medatck1.wav");
 

--- a/src/game/monster/soldier/soldier.c
+++ b/src/game/monster/soldier/soldier.c
@@ -51,6 +51,15 @@ soldier_footstep(edict_t *self)
 	if (!g_monsterfootsteps->value)
 		return;
 
+	// Lazy loading for savegame compatibility.
+	if (sound_step == 0 || sound_step2 == 0 || sound_step3 == 0 || sound_step4 == 0)
+	{
+		sound_step = gi.soundindex("player/step1.wav");
+		sound_step2 = gi.soundindex("player/step2.wav");
+		sound_step3 = gi.soundindex("player/step3.wav");
+		sound_step4 = gi.soundindex("player/step4.wav");
+	}
+
 	int i;
 	i = randk() % 4;
 
@@ -1580,6 +1589,13 @@ SP_monster_soldier_x(edict_t *self)
 		return;
 	}
 
+	// Force recaching at next footstep to ensure
+	// that the sound indices are correct.
+	sound_step = 0;
+	sound_step2 = 0;
+	sound_step3 = 0;
+	sound_step4 = 0;
+
 	self->s.modelindex = gi.modelindex("models/monsters/soldier/tris.md2");
 	self->monsterinfo.scale = MODEL_SCALE;
 	VectorSet(self->mins, -16, -16, -24);
@@ -1591,10 +1607,6 @@ SP_monster_soldier_x(edict_t *self)
 	sound_sight1 = gi.soundindex("soldier/solsght1.wav");
 	sound_sight2 = gi.soundindex("soldier/solsrch1.wav");
 	sound_cock = gi.soundindex("infantry/infatck3.wav");
-	sound_step = gi.soundindex("player/step1.wav");
-	sound_step2 = gi.soundindex("player/step2.wav");
-	sound_step3 = gi.soundindex("player/step3.wav");
-	sound_step4 = gi.soundindex("player/step4.wav");
 
 	self->mass = 100;
 


### PR DESCRIPTION
The steps when loading a savegame are:

1. The server loads the map.
2. Loading the map spawns all entities, i.e. their spawn func is called. This loads the models, precaches the sounds, etc.
3. The savegame is loaded and all the entities in the edict are replaced by the entities read from game.ssv.

When the monster footstep sound were added in cfb86ac, new sounds were added to the spawn functions of most monster entities. This alters the sound indices of all sounds precached at a later time. When a savegame from an older version is loaded, the entities read from game.svv still reference the old sound indices. This leads to the wrong sound getting played.

Work around this by lazy loading the footstep sounds. Instead of loading (precaching) them in the spawn function, load them at their first use. This has the nice side effect of preventing the "missing sound" messages when running without the footsteps.pkz file in baseq2/. It might lead to short stuttering when the sound is played for the first time, though.

Closes #917.