### PR TITLE
Controller rumble support

### DIFF
--- a/src/client/header/keyboard.h
+++ b/src/client/header/keyboard.h
@@ -285,10 +285,8 @@ void Key_ReadConsoleHistory();
 void Key_WriteConsoleHistory();
 void Key_SetBinding(int keynum, char *binding);
 void Key_MarkAllUp(void);
-void Haptic_Feedback(char *name, int effect_volume, int effect_duration,
-				   int effect_begin, int effect_end,
-				   int effect_attack, int effect_fade,
-				   int effect_x, int effect_y, int effect_z);
+void Controller_Rumble(const char *name, vec3_t source, qboolean from_player,
+				unsigned int duration, unsigned short int volume);
 int Key_GetMenuKey(int key);
 
 #endif

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -806,6 +806,7 @@ IN_Update(void)
 					break;
 				}
 				if (event.cdevice.which == SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller))) {
+					Cvar_SetValue("paused", 1);
 					IN_Controller_Shutdown(true);
 					IN_Controller_Init(false);
 				}
@@ -819,6 +820,23 @@ IN_Update(void)
 					countdown_reason = REASON_CONTROLLERINIT;
 				}
 				break;
+
+#if SDL_VERSION_ATLEAST(2, 24, 0)	// support for battery status changes
+			case SDL_JOYBATTERYUPDATED:
+				if (!controller || event.jbattery.which != SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller)))
+				{
+					break;
+				}
+				if (event.jbattery.level == SDL_JOYSTICK_POWER_LOW)
+				{
+					Com_Printf("WARNING: Gamepad battery Low, it is recommended to connect it by cable.\n");
+				}
+				else if (event.jbattery.level == SDL_JOYSTICK_POWER_EMPTY)
+				{
+					SCR_CenterPrint("ALERT: Gamepad battery almost Empty, will disconnect anytime.\n");
+				}
+				break;
+#endif	// SDL_VERSION_ATLEAST(2, 24, 0)
 
 			case SDL_QUIT:
 				Com_Quit();

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -812,7 +812,7 @@ IN_Update(void)
 				}
 				else if (event.jbattery.level == SDL_JOYSTICK_POWER_EMPTY)
 				{
-					SCR_CenterPrint("ALERT: Gamepad battery almost Empty, will disconnect anytime.\n");
+					SCR_CenterPrint("ALERT: Gamepad battery almost Empty.\n");
 				}
 				break;
 #endif	// SDL_VERSION_ATLEAST(2, 24, 0)
@@ -1779,6 +1779,7 @@ IN_Controller_Shutdown(qboolean notify_user)
 		SDL_GameControllerClose(controller);
 		controller = NULL;
 		gyro_hardware = false;
+		show_haptic = false;
 		joystick_left_x = joystick_left_y = joystick_right_x = joystick_right_y = 0;
 		gyro_yaw = gyro_pitch = 0;
 		normalize_sdl_gyro = 1.0f / M_PI;

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -108,30 +108,9 @@ static cvar_t *windowed_mouse;
 
 // ----
 
-struct hapric_effects_cache {
-	int effect_volume;
-	int effect_duration;
-	int effect_begin;
-	int effect_end;
-	int effect_attack;
-	int effect_fade;
-	int effect_id;
-	int effect_x;
-	int effect_y;
-	int effect_z;
-};
+qboolean show_haptic = false;
 
-qboolean show_haptic;
-
-static SDL_Haptic *joystick_haptic = NULL;
 static SDL_GameController *controller = NULL;
-
-#define HAPTIC_EFFECT_LIST_SIZE 16
-
-static int last_haptic_volume = 0;
-static int last_haptic_efffect_size = HAPTIC_EFFECT_LIST_SIZE;
-static int last_haptic_efffect_pos = 0;
-static struct hapric_effects_cache last_haptic_efffect[HAPTIC_EFFECT_LIST_SIZE];
 
 // Joystick sensitivity
 static cvar_t *joy_yawsensitivity;
@@ -1386,232 +1365,138 @@ In_FlushQueue(void)
 
 /* ------------------------------------------------------------------ */
 
-static void IN_Haptic_Shutdown(void);
-
 /*
- * Init haptic effects
- */
-static int
-IN_Haptic_Effect_Init(int effect_x, int effect_y, int effect_z,
-				 int period, int magnitude,
-				 int delay, int attack, int fade)
-{
-	static SDL_HapticEffect haptic_effect;
-
-	/* limit magnitude */
-	if (magnitude > SHRT_MAX)
-	{
-		magnitude = SHRT_MAX;
-	}
-	else if (magnitude < 0)
-	{
-		magnitude = 0;
-	}
-
-	SDL_memset(&haptic_effect, 0, sizeof(SDL_HapticEffect)); // 0 is safe default
-
-	haptic_effect.type = SDL_HAPTIC_SINE;
-	haptic_effect.periodic.direction.type = SDL_HAPTIC_CARTESIAN; // Cartesian/3d coordinates
-	haptic_effect.periodic.direction.dir[0] = effect_x;
-	haptic_effect.periodic.direction.dir[1] = effect_y;
-	haptic_effect.periodic.direction.dir[2] = effect_z;
-	haptic_effect.periodic.period = period;
-	haptic_effect.periodic.magnitude = magnitude;
-	haptic_effect.periodic.length = period;
-	haptic_effect.periodic.delay = delay;
-	haptic_effect.periodic.attack_length = attack;
-	haptic_effect.periodic.fade_length = fade;
-
-	int effect_id = SDL_HapticNewEffect(joystick_haptic, &haptic_effect);
-
-	if (effect_id < 0)
-	{
-		Com_Printf ("SDL_HapticNewEffect failed: %s\n", SDL_GetError());
-		Com_Printf ("Please try to rerun game. Effects will be disabled for now.\n");
-
-		IN_Haptic_Shutdown();
-	}
-
-	return effect_id;
-}
-
-static void
-IN_Haptic_Effects_Info(void)
-{
-	show_haptic = true;
-
-	Com_Printf ("Joystick/Mouse haptic:\n");
-	Com_Printf (" * %d effects\n", SDL_HapticNumEffects(joystick_haptic));
-	Com_Printf (" * %d effects in same time\n", SDL_HapticNumEffectsPlaying(joystick_haptic));
-	Com_Printf (" * %d haptic axis\n", SDL_HapticNumAxes(joystick_haptic));
-}
-
-static void
-IN_Haptic_Effects_Init(void)
-{
-	last_haptic_efffect_size = SDL_HapticNumEffectsPlaying(joystick_haptic);
-
-	if (last_haptic_efffect_size > HAPTIC_EFFECT_LIST_SIZE)
-	{
-		last_haptic_efffect_size = HAPTIC_EFFECT_LIST_SIZE;
-	}
-
-	for (int i=0; i<HAPTIC_EFFECT_LIST_SIZE; i++)
-	{
-		last_haptic_efffect[i].effect_id = -1;
-		last_haptic_efffect[i].effect_volume = 0;
-		last_haptic_efffect[i].effect_duration = 0;
-		last_haptic_efffect[i].effect_begin = 0;
-		last_haptic_efffect[i].effect_end = 0;
-		last_haptic_efffect[i].effect_attack = 0;
-		last_haptic_efffect[i].effect_fade = 0;
-		last_haptic_efffect[i].effect_x = 0;
-		last_haptic_efffect[i].effect_y = 0;
-		last_haptic_efffect[i].effect_z = 0;
-	}
-}
-
-/*
- * Shuts the backend down
- */
-static void
-IN_Haptic_Effect_Shutdown(int * effect_id)
-{
-	if (!effect_id)
-	{
-		return;
-	}
-
-	if (*effect_id >= 0)
-	{
-		SDL_HapticDestroyEffect(joystick_haptic, *effect_id);
-	}
-
-	*effect_id = -1;
-}
-
-static void
-IN_Haptic_Effects_Shutdown(void)
-{
-	for (int i=0; i<HAPTIC_EFFECT_LIST_SIZE; i++)
-	{
-		last_haptic_efffect[i].effect_volume = 0;
-		last_haptic_efffect[i].effect_duration = 0;
-		last_haptic_efffect[i].effect_begin = 0;
-		last_haptic_efffect[i].effect_end = 0;
-		last_haptic_efffect[i].effect_attack = 0;
-		last_haptic_efffect[i].effect_fade = 0;
-		last_haptic_efffect[i].effect_x = 0;
-		last_haptic_efffect[i].effect_y = 0;
-		last_haptic_efffect[i].effect_z = 0;
-
-		IN_Haptic_Effect_Shutdown(&last_haptic_efffect[i].effect_id);
-	}
-}
-
-/*
- * Haptic Feedback:
- *    effect_volume=0..SHRT_MAX
- *    effect{x,y,z} - effect direction
- *    name - sound file name
+ * Controller_Rumble:
+ *	name = sound file name
+ *	effect_volume = 0..USHRT_MAX
+ *	effect_duration is in ms
+ *	source = origin of audio
+ *	from_player = if source is the client (player)
  */
 void
-Haptic_Feedback(char *name, int effect_volume, int effect_duration,
-			   int effect_begin, int effect_end,
-			   int effect_attack, int effect_fade,
-			   int effect_x, int effect_y, int effect_z)
+Controller_Rumble(const char *name, vec3_t source, qboolean from_player,
+		unsigned int duration, unsigned short int volume)
 {
-	if (!joystick_haptic)
+	vec_t intens = 0.0f, low_freq = 1.0f, hi_freq = 1.0f, dist_prop;
+	unsigned short int max_distance = 4;
+	unsigned int effect_volume;
+
+	if (!show_haptic || !controller || joy_haptic_magnitude->value <= 0
+		|| volume == 0 || duration == 0)
 	{
 		return;
 	}
 
-	if (joy_haptic_magnitude->value <= 0)
+	if (strstr(name, "weapons/"))
 	{
-		return;
-	}
+		intens = 1.75f;
 
-	if (effect_volume <= 0)
-	{
-		return;
-	}
-
-	if (effect_duration <= 0)
-	{
-		return;
-	}
-
-	if (last_haptic_volume != (int)(joy_haptic_magnitude->value * 255))
-	{
-		IN_Haptic_Effects_Shutdown();
-		IN_Haptic_Effects_Init();
-	}
-
-	last_haptic_volume = joy_haptic_magnitude->value * 255;
-
-	if (
-		strstr(name, "misc/menu") ||
-		strstr(name, "weapons/") ||
-		/* detect pain for any player model */
-		((
-			strstr(name, "player/") ||
-			strstr(name, "players/")
-		) && (
-			strstr(name, "/pain")
-		)) ||
-		strstr(name, "player/step") ||
-		strstr(name, "player/land")
-	)
-	{
-		// check last effect for reuse
-		if (
-		    last_haptic_efffect[last_haptic_efffect_pos].effect_volume != effect_volume ||
-		    last_haptic_efffect[last_haptic_efffect_pos].effect_duration != effect_duration ||
-		    last_haptic_efffect[last_haptic_efffect_pos].effect_begin != effect_begin ||
-		    last_haptic_efffect[last_haptic_efffect_pos].effect_end != effect_end ||
-		    last_haptic_efffect[last_haptic_efffect_pos].effect_attack != effect_attack ||
-		    last_haptic_efffect[last_haptic_efffect_pos].effect_fade != effect_fade ||
-		    last_haptic_efffect[last_haptic_efffect_pos].effect_x != effect_x ||
-		    last_haptic_efffect[last_haptic_efffect_pos].effect_y != effect_y ||
-		    last_haptic_efffect[last_haptic_efffect_pos].effect_z != effect_z)
+		if (strstr(name, "/blastf") || strstr(name, "/hyprbf") || strstr(name, "/nail"))
 		{
-			if ((SDL_HapticQuery(joystick_haptic) & SDL_HAPTIC_SINE)==0)
-			{
-				return;
-			}
-
-			int hapric_volume = joy_haptic_magnitude->value * effect_volume; // 32767 max strength;
-
-			if (effect_duration <= 0)
-			{
-				return;
-			}
-
-			/*
-			Com_Printf("%s: volume %d: %d ms %d:%d:%d ms speed: %.2f\n",
-				name,  effect_volume, effect_duration - effect_end,
-				effect_begin, effect_attack, effect_fade,
-				(float)effect_volume / effect_fade);
-			*/
-
-			// FIFO for effects
-			last_haptic_efffect_pos = (last_haptic_efffect_pos+1) % last_haptic_efffect_size;
-			IN_Haptic_Effect_Shutdown(&last_haptic_efffect[last_haptic_efffect_pos].effect_id);
-			last_haptic_efffect[last_haptic_efffect_pos].effect_volume = effect_volume;
-			last_haptic_efffect[last_haptic_efffect_pos].effect_duration = effect_duration;
-			last_haptic_efffect[last_haptic_efffect_pos].effect_attack = effect_attack;
-			last_haptic_efffect[last_haptic_efffect_pos].effect_fade = effect_fade;
-			last_haptic_efffect[last_haptic_efffect_pos].effect_x = effect_x;
-			last_haptic_efffect[last_haptic_efffect_pos].effect_y = effect_y;
-			last_haptic_efffect[last_haptic_efffect_pos].effect_z = effect_z;
-			last_haptic_efffect[last_haptic_efffect_pos].effect_id = IN_Haptic_Effect_Init(
-				effect_x, effect_y, effect_z,
-				effect_duration - effect_end, hapric_volume,
-				effect_begin, effect_attack, effect_fade);
+			intens = 0.125f;	// dampen blasters and nailgun's fire
+			low_freq = 0.7f;
+			hi_freq = 1.2f;
 		}
-
-		SDL_HapticRunEffect(joystick_haptic, last_haptic_efffect[last_haptic_efffect_pos].effect_id, 1);
+		else if (strstr(name, "/shotgf") || strstr(name, "/rocklf"))
+		{
+			low_freq = 1.1f;	// shotgun & RL shouldn't feel so weak
+			duration *= 0.7;
+		}
+		else if (strstr(name, "/sshotf"))
+		{
+			duration *= 0.6;	// the opposite for super shotgun
+		}
+		else if (strstr(name, "/machgf") || strstr(name, "/disint"))
+		{
+			intens = 1.125f;	// machine gun & disruptor fire
+		}
+		else if (strstr(name, "/grenlb") || strstr(name, "/hgrenb")	// bouncing grenades
+			|| strstr(name, "open") || strstr(name, "warn"))	// rogue's items
+		{
+			return;	// ... don't have feedback
+		}
+		else if (strstr(name, "/plasshot"))	// phalanx cannon
+		{
+			intens = 1.0f;
+			hi_freq = 0.3f;
+			duration *= 0.5;
+		}
+		else if (strstr(name, "x"))		// explosions...
+		{
+			low_freq = 1.1f;
+			hi_freq = 0.9f;
+			max_distance = 550;		// can be felt far away
+		}
+		else if (strstr(name, "r"))		// reloads & ion ripper fire
+		{
+			low_freq = 0.1f;
+			hi_freq = 0.6f;
+		}
 	}
+	else if ( (strstr(name, "player/") || strstr(name, "players/")) &&
+		(strstr(name, "/death") || strstr(name, "/fall") || strstr(name, "/pain")) )
+	{
+		intens = 3.5f;	// exaggerate player damage
+		low_freq = 1.1f;
+	}
+	else if (strstr(name, "player/land"))
+	{
+		intens = 2.5f;	// fall without injury
+	}
+	else if (strstr(name, "doors/"))
+	{
+		intens = 0.125f;
+		low_freq = 0.4f;
+		max_distance = 280;
+	}
+	else if (strstr(name, "plats/"))
+	{
+		intens = 1.0f;			// platforms rumble...
+		max_distance = 200;		// when player near them
+	}
+	else if (strstr(name, "world/"))
+	{
+		max_distance = 3000;	// ambient events
+		if (strstr(name, "/dish") || strstr(name, "/drill2a") || strstr(name, "/dr_")
+			|| strstr(name, "/explod1") || strstr(name, "/rocks") || strstr(name, "/rumble"))
+		{
+			intens = 0.25f;
+			low_freq = 0.7f;
+		}
+		else if (strstr(name, "/quake"))
+		{
+			intens = 0.625f;	// (earth)quakes are more evident
+			low_freq = 1.2f;
+		}
+	}
+
+	if (intens == 0.0f)
+	{
+		return;
+	}
+
+	if (from_player)
+	{
+		dist_prop = 1.0f;
+	}
+	else
+	{
+		dist_prop = VectorLength(source);
+		if (dist_prop > max_distance)
+		{
+			return;
+		}
+		dist_prop = (max_distance - dist_prop) / max_distance;
+	}
+
+	effect_volume = joy_haptic_magnitude->value * intens * dist_prop * volume;
+	low_freq = min(effect_volume * low_freq, USHRT_MAX);
+	hi_freq = min(effect_volume * hi_freq, USHRT_MAX);
+
+	// Com_Printf("%s: vol %d | %d ms | prop:%.3f | l:%.0f h:%.0f\n",
+	//	name, effect_volume, duration, dist_prop, low_freq, hi_freq);
+
+	SDL_GameControllerRumble(controller, low_freq, hi_freq, duration);
 }
 
 /*
@@ -1673,7 +1558,7 @@ IN_Controller_Init(qboolean notify_user)
 		Com_Printf("- Game Controller init attempt -\n");
 	}
 
-	if (!SDL_WasInit(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC))
+	if (!SDL_WasInit(SDL_INIT_GAMECONTROLLER))
 	{
 
 #ifdef SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE	// extended input reports on PS controllers (enables gyro thru bluetooth)
@@ -1683,7 +1568,7 @@ IN_Controller_Init(qboolean notify_user)
 		SDL_SetHint( SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1" );
 #endif
 
-		if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC) == -1)
+		if (SDL_Init(SDL_INIT_GAMECONTROLLER) == -1)
 		{
 			Com_Printf ("Couldn't init SDL joystick: %s.\n", SDL_GetError ());
 			return;
@@ -1694,17 +1579,6 @@ IN_Controller_Init(qboolean notify_user)
 
 	if (!SDL_NumJoysticks())
 	{
-		joystick_haptic = SDL_HapticOpenFromMouse();
-
-		if (joystick_haptic == NULL)
-		{
-			Com_Printf("Most likely mouse isn't haptic.\n");
-		}
-		else
-		{
-			IN_Haptic_Effects_Info();
-		}
-
 		return;
 	}
 
@@ -1770,17 +1644,6 @@ IN_Controller_Init(qboolean notify_user)
 			Com_Printf (" * snap-to-axis ratio = %.3f\n", joy_right_snapaxis->value);
 			Com_Printf (" * inner deadzone = %.3f\n", joy_right_deadzone->value);
 
-			joystick_haptic = SDL_HapticOpenFromJoystick(SDL_GameControllerGetJoystick(controller));
-
-			if (joystick_haptic == NULL)
-			{
-				Com_Printf("Most likely controller isn't haptic.\n");
-			}
-			else
-			{
-				IN_Haptic_Effects_Info();
-			}
-
 #if SDL_VERSION_ATLEAST(2, 0, 16)	// support for controller sensors
 
 			if ( SDL_GameControllerHasSensor(controller, SDL_SENSOR_GYRO)
@@ -1809,6 +1672,22 @@ IN_Controller_Init(qboolean notify_user)
 			}
 
 #endif	// SDL_VERSION_ATLEAST(2, 0, 16)
+
+#if SDL_VERSION_ATLEAST(2, 0, 18)	// support for query on features from controller
+			if (SDL_GameControllerHasRumble(controller))
+			{
+				show_haptic = true;
+				Com_Printf("Rumble support available.\n");
+			}
+			else
+			{
+				show_haptic = false;
+				Com_Printf("Controller doesn't support rumble.\n");
+			}
+#else
+			show_haptic = true;		// when in doubt, say yes
+			Com_Printf("Controller might support rumble.\n");
+#endif	// SDL_VERSION_ATLEAST(2, 0, 18)
 
 			break;
 		}
@@ -1887,21 +1766,6 @@ IN_Init(void)
 	Com_Printf("------------------------------------\n\n");
 }
 
-/*
- * Shuts the backend down
- */
-static void
-IN_Haptic_Shutdown(void)
-{
-	if (joystick_haptic)
-	{
-		IN_Haptic_Effects_Shutdown();
-
-		SDL_HapticClose(joystick_haptic);
-		joystick_haptic = NULL;
-	}
-}
-
 static void
 IN_Controller_Shutdown(qboolean notify_user)
 {
@@ -1909,8 +1773,6 @@ IN_Controller_Shutdown(qboolean notify_user)
 	{
 		Com_Printf("- Game Controller disconnected -\n");
 	}
-
-	IN_Haptic_Shutdown();
 
 	if (controller)
 	{
@@ -1923,6 +1785,9 @@ IN_Controller_Shutdown(qboolean notify_user)
 	}
 }
 
+/*
+ * Shuts the backend down
+ */
 void
 IN_Shutdown(void)
 {
@@ -1939,7 +1804,7 @@ IN_Shutdown(void)
 
 	IN_Controller_Shutdown(false);
 
-	const Uint32 subsystems = SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC;
+	const Uint32 subsystems = SDL_INIT_GAMECONTROLLER;
 	if (SDL_WasInit(subsystems) == subsystems)
 		SDL_QuitSubSystem(subsystems);
 }

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -1436,12 +1436,12 @@ Controller_Rumble(const char *name, vec3_t source, qboolean from_player,
 	else if ( (strstr(name, "player/") || strstr(name, "players/")) &&
 		(strstr(name, "/death") || strstr(name, "/fall") || strstr(name, "/pain")) )
 	{
-		intens = 3.5f;	// exaggerate player damage
+		intens = 3.2f;	// exaggerate player damage
 		low_freq = 1.1f;
 	}
 	else if (strstr(name, "player/land"))
 	{
-		intens = 2.5f;	// fall without injury
+		intens = 2.3f;	// fall without injury
 	}
 	else if (strstr(name, "doors/"))
 	{
@@ -1456,16 +1456,17 @@ Controller_Rumble(const char *name, vec3_t source, qboolean from_player,
 	}
 	else if (strstr(name, "world/"))
 	{
-		max_distance = 3000;	// ambient events
+		max_distance = 3500;	// ambient events
 		if (strstr(name, "/dish") || strstr(name, "/drill2a") || strstr(name, "/dr_")
-			|| strstr(name, "/explod1") || strstr(name, "/rocks") || strstr(name, "/rumble"))
+			|| strstr(name, "/explod1") || strstr(name, "/rocks")
+			|| strstr(name, "/rumble") || strstr(name, "/train2"))
 		{
-			intens = 0.25f;
+			intens = 0.28f;
 			low_freq = 0.7f;
 		}
 		else if (strstr(name, "/quake"))
 		{
-			intens = 0.625f;	// (earth)quakes are more evident
+			intens = 0.67f;		// (earth)quakes are more evident
 			low_freq = 1.2f;
 		}
 	}
@@ -1493,7 +1494,7 @@ Controller_Rumble(const char *name, vec3_t source, qboolean from_player,
 	low_freq = min(effect_volume * low_freq, USHRT_MAX);
 	hi_freq = min(effect_volume * hi_freq, USHRT_MAX);
 
-	// Com_Printf("%s: vol %d | %d ms | prop:%.3f | l:%.0f h:%.0f\n",
+	// Com_Printf("%-29s: vol %5u - %4u ms - dp %.3f l %5.0f h %5.0f\n",
 	//	name, effect_volume, duration, dist_prop, low_freq, hi_freq);
 
 	SDL_GameControllerRumble(controller, low_freq, hi_freq, duration);

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -1433,15 +1433,26 @@ Controller_Rumble(const char *name, vec3_t source, qboolean from_player,
 			hi_freq = 0.6f;
 		}
 	}
-	else if ( (strstr(name, "player/") || strstr(name, "players/")) &&
-		(strstr(name, "/death") || strstr(name, "/fall") || strstr(name, "/pain")) )
-	{
-		intens = 3.2f;	// exaggerate player damage
-		low_freq = 1.1f;
-	}
 	else if (strstr(name, "player/land"))
 	{
-		intens = 2.3f;	// fall without injury
+		intens = 2.2f;	// fall without injury
+		low_freq = 1.1f;
+	}
+	else if (strstr(name, "player/") || strstr(name, "players/"))
+	{
+		low_freq = 1.2f;	// exaggerate player damage
+		if (strstr(name, "/burn") || strstr(name, "/pain100") || strstr(name, "/pain75"))
+		{
+			intens = 2.4f;
+		}
+		else if (strstr(name, "/fall") || strstr(name, "/pain50") || strstr(name, "/pain25"))
+		{
+			intens = 2.7f;
+		}
+		else if (strstr(name, "/death"))
+		{
+			intens = 2.9f;
+		}
 	}
 	else if (strstr(name, "doors/"))
 	{
@@ -1459,7 +1470,7 @@ Controller_Rumble(const char *name, vec3_t source, qboolean from_player,
 		max_distance = 3500;	// ambient events
 		if (strstr(name, "/dish") || strstr(name, "/drill2a") || strstr(name, "/dr_")
 			|| strstr(name, "/explod1") || strstr(name, "/rocks")
-			|| strstr(name, "/rumble") || strstr(name, "/train2"))
+			|| strstr(name, "/rumble"))
 		{
 			intens = 0.28f;
 			low_freq = 0.7f;
@@ -1468,6 +1479,11 @@ Controller_Rumble(const char *name, vec3_t source, qboolean from_player,
 		{
 			intens = 0.67f;		// (earth)quakes are more evident
 			low_freq = 1.2f;
+		}
+		else if (strstr(name, "/train2"))
+		{
+			intens = 0.28f;
+			max_distance = 290;	// just machinery
 		}
 	}
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -1942,10 +1942,10 @@ Joy_MenuInit(void)
         s_joy_haptic_slider.generic.x = 0;
         s_joy_haptic_slider.generic.y = y;
         y += 10;
-        s_joy_haptic_slider.generic.name = "haptic magnitude";
+        s_joy_haptic_slider.generic.name = "rumble intensity";
         s_joy_haptic_slider.cvar = "joy_haptic_magnitude";
         s_joy_haptic_slider.minvalue = 0.0f;
-        s_joy_haptic_slider.maxvalue = 2.2f;
+        s_joy_haptic_slider.maxvalue = 2.0f;
         Menu_AddItem(&s_joy_menu, (void *)&s_joy_haptic_slider);
     }
 

--- a/src/client/sound/sound.c
+++ b/src/client/sound/sound.c
@@ -1109,33 +1109,17 @@ S_StartSound(vec3_t origin, int entnum, int entchannel, sfx_t *sfx,
 
 	if (sfx->name[0])
 	{
-		vec3_t orientation, direction;
-		vec_t distance_direction;
-		int dir_x, dir_y, dir_z;
-		int effect_duration = 0;
-		int effect_volume = -1;
+		vec3_t direction = {0};
+		unsigned int effect_duration = 0;
+		unsigned short int effect_volume = 0;
 
-		VectorSubtract(listener_forward, listener_up, orientation);
-
-		// with !fixed we have all sounds related directly to player,
+		// with !ps->fixed we have all sounds related directly to player,
 		// e.g. players fire, pain, menu
-		if (!ps->fixed_origin)
-		{
-			VectorCopy(orientation, direction);
-			distance_direction = 0;
-		}
-		else
+		// else, they come from the environment
+		if (ps->fixed_origin)
 		{
 			VectorSubtract(listener_origin, ps->origin, direction);
-			distance_direction = VectorLength(direction);
 		}
-
-		VectorNormalize(direction);
-		VectorNormalize(orientation);
-
-		dir_x = 16 * orientation[0] * direction[0];
-		dir_y = 16 * orientation[1] * direction[1];
-		dir_z = 16 * orientation[2] * direction[2];
 
 		if (sfx->cache)
 		{
@@ -1146,16 +1130,11 @@ S_StartSound(vec3_t origin, int entnum, int entchannel, sfx_t *sfx,
 				effect_duration /= 2;
 			}
 
-			/* sound near player has 16 points */
-			effect_volume = sfx->cache->volume / 16;
+			effect_volume = sfx->cache->volume;
 		}
 
-		Haptic_Feedback(
-			sfx->name, (16 - distance_direction / 32) * effect_volume,
-			effect_duration,
-			sfx->cache->begin, sfx->cache->end,
-			sfx->cache->attack, sfx->cache->fade,
-			dir_x, dir_y, dir_z);
+		Controller_Rumble(sfx->name, direction, !ps->fixed_origin,
+			effect_duration, effect_volume);
 	}
 
 	ps->entnum = entnum;

--- a/src/client/sound/sound.c
+++ b/src/client/sound/sound.c
@@ -1130,6 +1130,14 @@ S_StartSound(vec3_t origin, int entnum, int entchannel, sfx_t *sfx,
 				effect_duration /= 2;
 			}
 
+			// The following may be ugly: cache length in SDL is much, much bigger
+			// than the one in OpenAL, so much that it's definitely not in ms.
+			// If that changes in the future, this must be removed.
+			if (sound_started == SS_SDL)
+			{
+				effect_duration /= 45;
+			}
+
 			effect_volume = sfx->cache->volume;
 		}
 


### PR DESCRIPTION
This PR replaces the current haptic support, "deprecated" (*) since SDL2.0.14 for gamepads, for a more traditional rumble, supported on a wide range of controllers by SDL2.

I must warn that this development makes visible some issues, but those were already present in the classic haptic work, as tested in a Raspberry Pi 3 B+, the only platform I have an old version of SDL available (2.0.10), where gamepads were still supported by haptic. These are:

- Difficulty to properly identify which sounds come from the player and which come from the environment; the most evident example is that every player's shooting and pain sound will count for feedback in multiplayer. Likewise, a few monster's shots are identified as "from the player"; at least the Phalanx shots from the Gladiator Beta of the xatrix expansion count for this.
- Weapons from the rogue expansion behave differently, so they don't have rumble. The Plasma Beam uses the "laser hit" sound, common in the game to represent missed enemy laser fire (e.g. from the Flyer), but it doesn't come from the player, it comes from where the weapon hits, making it unable to distinguish itself from the mentioned case. On the other hand, the Chainfist doesn't play its sounds from S_StartSound() like the rest, so it's not calling the rumble function.
- OpenAL's cache length is in milliseconds, which properly sets the duration of the rumble. However, the SDL sound system provides this length in... another format (?) which is 40 to 50 times bigger, and it's not clear which "unit of time" uses (if that's a unit of time at all). Sidestepped this by dividing the length by 45, but it still doesn't provide the real length of the sound played, so rumble doesn't have an accurate duration. Sticking to OpenAL is the true solution for this.

Even with these problems (which, again, share with "haptic" implementation), I must say this improves quite a bit the single player experience for controller people.
Tested with a DualShock 4 (PS4) and a Switch Pro Controller, and in both rumble works wired and wireless, in Ubuntu 20.04, Windows 7, and even the very same Raspberry Pi 3 B+.

It's worth mentioning this is not a completely straight conversion "from haptic to rumble"; I've "re-filtered" which sounds provide feedback or not. For example, eliminated the "menu" sounds, and added the "quake" sounds, so earthquakes will have the proper feeling :) . Another example: ride a platform, then get off it.

This (hopefully) closes #858 
If this is accepted, I wanted to ask for a testbuild.

(*) Classic haptic SDL2 support has been reduced to target racing wheels and flightsticks, while gamepads must use the rumble function used in this PR:
https://github.com/libsdl-org/SDL/issues/4435#issuecomment-896432954
At this point, I don't even know if force feedback mice work with haptic.
