### PR TITLE
Implement a simple stufftext filter

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -146,6 +146,16 @@ Set `0` by default.
 * **cl_model_preview_end**: end frame value in multiplayer model preview.
   `-1` - don't show animation. Defaults to `94` for show salute animation.
 
+* **cl_stufftext**: If set to `1` (the default) any stufftext is
+  allowed. Since stufftext can inject arbitrary data into the client
+  command buffer this can be harmful. A malicious server may execute
+  any console command, alter any cvar or even hijack the client with
+  potentially grave consequences. If set to `0` only known to be good
+  messages are allowed. This reduces the attack surface significantly.
+  However this will break compatibility with any server and mod which
+  requires non-standard stufftext. And there is no guarantee that an
+  attacker can't bypass the filter.
+
 * **in_grab**: Defines how the mouse is grabbed by Yamagi Quake IIs
   window. If set to `0` the mouse is never grabbed and if set to `1`
   it's always grabbed. If set to `2` (the default) the mouse is grabbed

--- a/doc/060_multiplayer.md
+++ b/doc/060_multiplayer.md
@@ -110,3 +110,22 @@ Quake II patch 3.15. The map list must be enclosed in quotation marks
 and all maps must exist. Start the game with the first map.
 
 For example: `q2ded +set sv_maplist '"q2dm1 q2dm2 q2dm3"' +map q2dm1`
+
+
+
+## Stufftext filter
+
+Stufftexts are messages which are send from the server to the client and
+executed as commands. Vanilla Quake II hasn't any protecting regarding
+the commands send to the client. A malicious server may execute any
+console command and alter any cvar.
+
+To prevent this Yamagi Quake II supports a 'filtered stuff text mode'.
+When `cl_stufftext` is set to `0` only known to be good stufftext is
+executed, everything else is discarded. This lowers the attack surface
+significantly, however it will break any server and mod which required
+random stufftext.
+
+Nevertheless, when connecting to servers which aren't trustworthy - this
+is any server not controlled by the player itself - it is a very good
+idea to set `cl_stufftext 0`.

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -68,7 +68,6 @@ cvar_t *rate;
 cvar_t *fov;
 cvar_t *horplus;
 cvar_t *windowed_mouse;
-cvar_t *msg;
 cvar_t *hand;
 cvar_t *gender;
 cvar_t *gender_auto;
@@ -533,7 +532,6 @@ CL_InitLocal(void)
 	name = Cvar_Get("name", "unnamed", CVAR_USERINFO | CVAR_ARCHIVE);
 	skin = Cvar_Get("skin", "male/grunt", CVAR_USERINFO | CVAR_ARCHIVE);
 	rate = Cvar_Get("rate", "8000", CVAR_USERINFO | CVAR_ARCHIVE);
-	msg = Cvar_Get("msg", "1", CVAR_USERINFO | CVAR_ARCHIVE);
 	hand = Cvar_Get("hand", "0", CVAR_USERINFO | CVAR_ARCHIVE);
 	fov = Cvar_Get("fov", "90", CVAR_USERINFO | CVAR_ARCHIVE);
 	horplus = Cvar_Get("horplus", "1", CVAR_ARCHIVE);

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -60,6 +60,7 @@ cvar_t *cl_loadpaused;
 cvar_t *cl_lightlevel;
 cvar_t *cl_r1q2_lightstyle;
 cvar_t *cl_limitsparksounds;
+cvar_t *cl_stufftext;
 
 /* userinfo */
 cvar_t *name;
@@ -527,6 +528,7 @@ CL_InitLocal(void)
 	cl_lightlevel = Cvar_Get("r_lightlevel", "0", 0);
 	cl_r1q2_lightstyle = Cvar_Get("cl_r1q2_lightstyle", "1", CVAR_ARCHIVE);
 	cl_limitsparksounds = Cvar_Get("cl_limitsparksounds", "0", CVAR_ARCHIVE);
+	cl_stufftext = Cvar_Get("cl_stufftext", "1", CVAR_ARCHIVE);
 
 	/* userinfo */
 	name = Cvar_Get("name", "unnamed", CVAR_USERINFO | CVAR_ARCHIVE);

--- a/src/client/cl_network.c
+++ b/src/client/cl_network.c
@@ -29,7 +29,6 @@
 
 void CL_ParseStatusMessage(void);
 
-extern cvar_t *msg;
 extern cvar_t *rcon_client_password;
 extern cvar_t *rcon_address;
 extern cvar_t *cl_timeout;

--- a/src/client/header/client.h
+++ b/src/client/header/client.h
@@ -314,6 +314,7 @@ extern  cvar_t  *vid_renderer;
 extern	cvar_t	*cl_kickangles;
 extern  cvar_t  *cl_r1q2_lightstyle;
 extern  cvar_t  *cl_limitsparksounds;
+extern  cvar_t  *cl_stufftext;
 
 typedef struct
 {

--- a/src/server/header/server.h
+++ b/src/server/header/server.h
@@ -126,7 +126,6 @@ typedef struct client_s
 
 	edict_t *edict;                     /* EDICT_NUM(clientnum+1) */
 	char name[32];                      /* extracted from userinfo, high bits masked */
-	int messagelevel;                   /* for filtering printed messages */
 
 	/* The datagram is written to by sound calls, prints, 
 	   temp ents, etc. It can be harmlessly overflowed. */

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -564,14 +564,6 @@ SV_UserinfoChanged(client_t *cl)
 	{
 		cl->rate = 5000;
 	}
-
-	/* msg command */
-	val = Info_ValueForKey(cl->userinfo, "msg");
-
-	if (strlen(val))
-	{
-		cl->messagelevel = (int)strtol(val, (char **)NULL, 10);
-	}
 }
 
 /*

--- a/src/server/sv_send.c
+++ b/src/server/sv_send.c
@@ -52,11 +52,6 @@ SV_ClientPrintf(client_t *cl, int level, char *fmt, ...)
 	va_list argptr;
 	char string[1024];
 
-	if (level < cl->messagelevel)
-	{
-		return;
-	}
-
 	va_start(argptr, fmt);
 	vsnprintf(string, sizeof(string), fmt, argptr);
 	va_end(argptr);
@@ -99,11 +94,6 @@ SV_BroadcastPrintf(int level, char *fmt, ...)
 
 	for (i = 0, cl = svs.clients; i < maxclients->value; i++, cl++)
 	{
-		if (level < cl->messagelevel)
-		{
-			continue;
-		}
-
 		if (cl->state != cs_spawned)
 		{
 			continue;


### PR DESCRIPTION
I have received a report of ongoing attacks against various Quake II clients by malicious servers exploiting stufftexts. Stufftexts are random strings which are send by the server and directly fed into the clients command buffer. Even in 1997 this was a bad idea... It looks like so far only cvars getting altered, however given the state of Quake IIs command parser nearly everything seems possible.

This pull requests implements a simple stufftext filter. When `cl_stufftext` is set to `0` only known to be good stufftexts are processed. These are the basic commands required by the server at connection time and the `spectator` commands send by baseq2, rogue and xatrix. ctf doesn't send any stifftext. Since this will break all servers and mods which require random stufftext the default stays at `1`. Documented in the cvar list and the multiplayer setup guide.