### PR TITLE
Ogg Playback Features

### DIFF
--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -1095,7 +1095,9 @@ CL_ParseConfigString(void)
 	{
 		if (cl.refresh_prepped)
 		{
-			OGG_PlayTrack((int)strtol(cl.configstrings[CS_CDTRACK], (char **)NULL, 10));
+			int track = (int)strtol(cl.configstrings[CS_CDTRACK], (char **)NULL, 10);
+			
+			OGG_PlayTrack(track, true, true);
 		}
 	}
 	else if ((i >= CS_MODELS) && (i < CS_MODELS + MAX_MODELS))

--- a/src/client/cl_view.c
+++ b/src/client/cl_view.c
@@ -363,8 +363,8 @@ CL_PrepRefresh(void)
 
 	/* start the cd track */
 	int track = (int)strtol(cl.configstrings[CS_CDTRACK], (char **)NULL, 10);
-
-	OGG_PlayTrack(track);
+	
+	OGG_PlayTrack(track, true, true);
 }
 
 float

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2174,7 +2174,7 @@ FreeLookFunc(void *unused)
 static void
 ControlsSetMenuItemValues(void)
 {
-    s_options_oggshuffle_box.curvalue = (Cvar_VariableValue("ogg_shuffle") != 0);
+    s_options_oggshuffle_box.curvalue = Cvar_VariableValue("ogg_shuffle");
     s_options_oggenable_box.curvalue = (Cvar_VariableValue("ogg_enable") != 0);
     s_options_quality_list.curvalue = (Cvar_VariableValue("s_loadas8bit") == 0);
     s_options_alwaysrun_box.curvalue = (cl_run->value != 0);
@@ -2192,6 +2192,7 @@ ControlsResetDefaultsFunc(void *unused)
     Cbuf_Execute();
 
     ControlsSetMenuItemValues();
+    s_options_oggshuffle_box.curvalue = 0;
 }
 
 static void
@@ -2226,7 +2227,7 @@ EnableOGGMusic(void *unused)
 		if (cls.state == ca_active)
 		{
 	        int track = (int)strtol(cl.configstrings[CS_CDTRACK], (char **)NULL, 10);
-	        OGG_PlayTrack(track);
+	        OGG_PlayTrack(track, true, true);
 		}
     }
     else
@@ -2292,6 +2293,15 @@ Options_MenuInit(void)
 {
     extern qboolean show_gamepad;
 
+    static const char *ogg_shuffle_items[] =
+    {
+        "default",
+        "play once",
+        "sequential",
+        "random",
+        0
+    };
+
     static const char *able_items[] =
     {
         "disabled",
@@ -2356,7 +2366,7 @@ Options_MenuInit(void)
     s_options_oggshuffle_box.generic.y = (y += 10);
     s_options_oggshuffle_box.generic.name = "OGG shuffle";
     s_options_oggshuffle_box.generic.callback = OGGShuffleFunc;
-    s_options_oggshuffle_box.itemnames = able_items;
+    s_options_oggshuffle_box.itemnames = ogg_shuffle_items;
 
     s_options_quality_list.generic.type = MTYPE_SPINCONTROL;
     s_options_quality_list.generic.x = 0;

--- a/src/client/sound/header/vorbis.h
+++ b/src/client/sound/header/vorbis.h
@@ -36,7 +36,7 @@ typedef enum
 
 void OGG_InitTrackList(void);
 void OGG_Init(void);
-void OGG_PlayTrack(int trackNo);
+void OGG_PlayTrack(int trackNo, qboolean cdtrack, qboolean immediate);
 void OGG_RecoverState(void);
 void OGG_SaveState(void);
 void OGG_Shutdown(void);


### PR DESCRIPTION
Playback features outlined in issue #729.

Added shuffle playback parameters to the menu:

- default - Ogg track currently active repeats. This is the quake2 default behaviour.
- play once - Ogg track currently active plays once then stops.
- sequential - Ogg tracks play in numerical order, from the currently playing track and like default, repeats.
- random - Ogg tracks play randomly, but never the same track twice.

Ogg tracks can be played from a full-screen console and tracks played will adhere to the shuffle parameter.

Loading a game map the map cd-track takes precedence as the first played track then subsequent playback of tracks will adhere to the shuffle parameter.

Any currently playing track can be overridden from the console with "`ogg play <track>`" command and subsequent playback of tracks will adhere to the shuffle parameter.

If a sound restart occurs the ogg backend will attempt to save and recover the currently playing track, though some data in the audio queue may be lost in the process.