### PR TITLE
Fix sound characteristics calculations

### DIFF
--- a/src/client/sound/sound.c
+++ b/src/client/sound/sound.c
@@ -525,10 +525,10 @@ S_LoadSound(sfx_t *s)
 		s->is_silenced_muzzle_flash = true;
 	}
 
-	S_GetVolume(data + info.dataofs, info.samples * info.channels,
+	S_GetVolume(data + info.dataofs, info.samples,
 		info.width, &sound_volume);
 
-	S_GetStatistics(data + info.dataofs, info.samples * info.channels,
+	S_GetStatistics(data + info.dataofs, info.samples,
 		info.width, info.channels, sound_volume, &begin_length, &end_length,
 		&attack_length, &fade_length);
 


### PR DESCRIPTION
Ogg file has incorrectly calculated size and samples as result calculation of volume and timings have used incorrect test samples for sterio sound.

Checked with compare ogg and wav samples from 25th Anniversary mod:
```
ffmpeg -i 25acu/sound/world/goreshit.wav 25acu/sound/world/goreshit-ogg.wav
```

Soundlist:
```
]/soundlist
 (16b)  1404340(2 ch) world/goreshit.wav -11.7 dB 351.1s:15.0..0.3..1.1..2.0
 (16b)  1404340(2 ch) world/goreshit-ogg.wav -11.5 dB 351.1s:15.0..18.4..1.4..2.0
```

Fixes:
* https://github.com/glhrmfrts/q25_game/issues/8
* https://github.com/yquake2/yquake2/issues/991