### PR TITLE
fix clang 16 build as C11 _NoReturn/noreturn attributes conflict.

### DIFF
--- a/src/client/sound/ogg.c
+++ b/src/client/sound/ogg.c
@@ -455,14 +455,12 @@ static void
 OGG_Info(void)
 {
 	Com_Printf("Tracks:\n");
-	int numFiles = 0;
 
 	for (int i = 2; i <= ogg_maxfileindex; i++)
 	{
 		if(ogg_tracks[i])
 		{
 			Com_Printf(" - %02d %s\n", i, ogg_tracks[i]);
-			++numFiles;
 		}
 		else
 		{

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -745,7 +745,7 @@ void Com_Printf(char *fmt, ...) PRINTF_ATTR(1, 2);
 void Com_DPrintf(char *fmt, ...) PRINTF_ATTR(1, 2);
 void Com_VPrintf(int print_level, const char *fmt, va_list argptr); /* print_level is PRINT_ALL or PRINT_DEVELOPER */
 void Com_MDPrintf(char *fmt, ...) PRINTF_ATTR(1, 2);
-YQ2_ATTR_NORETURN void Com_Error(int code, char *fmt, ...) PRINTF_ATTR(2, 3);
+YQ2_ATTR_NORETURN_FUNCPTR void Com_Error(int code, char *fmt, ...) PRINTF_ATTR(2, 3);
 YQ2_ATTR_NORETURN void Com_Quit(void);
 
 /* Ugly work around for unsupported

--- a/src/server/sv_entities.c
+++ b/src/server/sv_entities.c
@@ -513,7 +513,6 @@ SV_BuildClientFrame(client_t *client)
 	int l;
 	int clientarea, clientcluster;
 	int leafnum;
-	int c_fullsend;
 	byte *clientphs;
 	byte *bitvector;
 
@@ -552,8 +551,6 @@ SV_BuildClientFrame(client_t *client)
 	/* build up the list of visible entities */
 	frame->num_entities = 0;
 	frame->first_entity = svs.next_client_entities;
-
-	c_fullsend = 0;
 
 	for (e = 1; e < ge->num_edicts; e++)
 	{
@@ -608,8 +605,6 @@ SV_BuildClientFrame(client_t *client)
 					{
 						continue;
 					}
-
-					c_fullsend++;
 				}
 				else
 				{

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -149,7 +149,7 @@ PF_centerprintf(edict_t *ent, char *fmt, ...)
 /*
  * Abort the server with a game error
  */
-YQ2_ATTR_NORETURN void
+YQ2_ATTR_NORETURN_FUNCPTR void
 PF_error(char *fmt, ...)
 {
 	char msg[1024];


### PR DESCRIPTION
And remove a handful of unused vars.