### PR TITLE
SDL2: Fix definition of NATIVE_SDL_GYRO

### DIFF
--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -171,12 +171,12 @@ static cvar_t *gyro_calibration_x;
 static cvar_t *gyro_calibration_y;
 static cvar_t *gyro_calibration_z;
 
-#if SDL_VERSION_ATLEAST(2, 0, 14)	// support for controller sensors (gyro, accelerometer)
+#if SDL_VERSION_ATLEAST(2, 0, 16)	// support for controller sensors (gyro, accelerometer)
 
 static unsigned int num_samples;
 #define NATIVE_SDL_GYRO	// uses SDL_CONTROLLERSENSORUPDATE to read gyro
 
-#else	// for SDL < 2.0.14, gyro can be read as a "secondary joystick" exposed by dkms-hid-nintendo
+#else	// for SDL < 2.0.16, gyro can be read as a "secondary joystick" exposed by dkms-hid-nintendo
 
 static unsigned int num_samples[3];
 static SDL_Joystick *imu_joystick = NULL;	// gyro "joystick"


### PR DESCRIPTION
I tried to build YQuake 2 on a Raspberry PI 4 but I got this error:

```
/usr/bin/ld: CMakeFiles/quake2.dir/src/client/input/sdl.c.o: in function `IN_Controller_Init':
/home/carlo/yquake2/src/client/input/sdl.c:2179: undefined reference to `SDL_GameControllerGetSensorDataRate'
collect2: error: ld returned 1 exit status
```

The latest version of SDL2 provided by Debian RaspiOS 64-bit is 2.0.14.
By looking the code into `src/client/input/sdl.c`, I have seen the definition of `NATIVE_SDL_GYRO` activated by `SDL_VERSION_ATLEAST(2, 0, 14)`. However, those functions are not provided by 2.0.14 but they need at least 2.0.16, as you can see here:

https://wiki.libsdl.org/SDL2/SDL_GameControllerGetSensorDataRate

After fixing the minimal version to 2.0.16, I have been able to compile the whole source code successfully.