### PR TITLE
Sound backend and ogg pause features

### DIFF
--- a/src/client/cl_console.c
+++ b/src/client/cl_console.c
@@ -96,6 +96,13 @@ Con_ToggleConsole_f(void)
 	{
 		M_ForceMenuOff();
 		Cvar_Set("paused", "0");
+
+		/* play music */
+		if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
+		    OGG_Status() == PAUSE)
+		{
+		    Cbuf_AddText("ogg toggle\n");
+		}
 	}
 	else
 	{
@@ -106,6 +113,13 @@ Con_ToggleConsole_f(void)
 			Com_ServerState())
 		{
 			Cvar_Set("paused", "1");
+
+			/* pause music */
+			if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
+			    OGG_Status() == PLAY)
+			{
+			    Cbuf_AddText("ogg toggle\n");
+			}
 		}
 	}
 }

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -309,6 +309,17 @@ CL_Pause_f(void)
 	}
 
 	Cvar_SetValue("paused", !cl_paused->value);
+
+	if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
+	    OGG_Status() == PAUSE && cl_paused->value == 0)			/* play music */
+	{
+	    Cbuf_AddText("ogg toggle\n");
+	}
+	else if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
+	    OGG_Status() == PLAY && cl_paused->value == 1)			/* pause music */
+	{
+	    Cbuf_AddText("ogg toggle\n");
+	}
 }
 
 void

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -124,6 +124,13 @@ M_ForceMenuOff(void)
 void
 M_PopMenu(void)
 {
+    /* play music */
+    if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
+        OGG_Status() == PAUSE && cl.attractloop == false)
+    {
+        Cbuf_AddText("ogg toggle\n");
+    }
+
     S_StartLocalSound(menu_out_sound);
 
     if (m_menudepth < 1)
@@ -178,6 +185,13 @@ M_PushMenu(void (*draw)(void), const char *(*key)(int))
         AL_UnqueueRawSamples();
     }
 #endif
+
+    /* pause music */
+    if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
+        OGG_Status() == PLAY && cl.attractloop == false)
+    {
+        Cbuf_AddText("ogg toggle\n");
+    }
 
     /* if this menu is already open (and on top),
        close it => toggling behaviour */

--- a/src/client/sound/header/sound.h
+++ b/src/client/sound/header/sound.h
@@ -30,6 +30,7 @@
 
 struct sfx_s;
 
+void S_Activate(qboolean active);
 void S_Init(void);
 void S_Shutdown(void);
 

--- a/src/client/sound/header/vorbis.h
+++ b/src/client/sound/header/vorbis.h
@@ -34,6 +34,7 @@ typedef enum
 	STOP
 } ogg_status_t;
 
+int OGG_Status(void);
 void OGG_InitTrackList(void);
 void OGG_Init(void);
 void OGG_PlayTrack(int trackNo, qboolean cdtrack, qboolean immediate);

--- a/src/client/sound/sound.c
+++ b/src/client/sound/sound.c
@@ -89,6 +89,7 @@ static sfx_t known_sfx[MAX_SFX];
 sndstarted_t sound_started = SS_NOT;
 sound_t sound;
 static qboolean s_registering;
+qboolean s_active;
 
 qboolean snd_is_underwater;
 qboolean snd_is_underwater_enabled;
@@ -1066,6 +1067,13 @@ S_StartSound(vec3_t origin, int entnum, int entchannel, sfx_t *sfx,
 		return;
 	}
 
+	/* A hack to prevent temporary entities generating sounds when the sound
+	   backend is not active and the game is not paused */
+	if (s_active == false)
+	{
+	    return;
+	}
+
 	if (!sfx)
 	{
 		return;
@@ -1412,6 +1420,11 @@ S_Update(vec3_t origin, vec3_t forward, vec3_t right, vec3_t up)
 		return;
 	}
 
+	if (s_active == false)
+	{
+	    return;
+	}
+
 	VectorCopy(origin, listener_origin);
 	VectorCopy(forward, listener_forward);
 	VectorCopy(right, listener_right);
@@ -1565,6 +1578,19 @@ S_SoundInfo_f(void)
 }
 
 /*
+ * Activate or deactivate sound backend
+ */
+void S_Activate(qboolean active)
+{
+	s_active = active;
+
+	if (active == false)
+	{
+	    S_StopAllSounds();
+	}
+}
+
+/*
  * Initializes the sound system
  * and it's requested backend
  */
@@ -1630,6 +1656,7 @@ S_Init(void)
 	num_sfx = 0;
 	paintedtime = 0;
 	sound_max = 0;
+	s_active = true;
 
 	OGG_Init();
 


### PR DESCRIPTION
Playback features outlined in issue #715 .

Reintroduce activate\deactivate sound backend when window focus in changed. Added "windowed_pauseonfocuslost" cvar to allowing user control of pause when the window changes focus. Added "ogg_pausewithgame" cvar to allow user control of ogg playback whenever the game is paused. Introduced ogg playback command "mute" as an additional playback option for the console, command buffer and key binds.

If the window focus is changed all sound playback will stop and resume as expected. Setting "window_pauseonfocuslost" to 1 will force the game to pause when the window focus is lost, "cl_paused" is ignored in multiplayer. Setting "ogg_pausewithgame" to 1 will force ogg playback to pause whenever the game is paused. Toggling ogg mute through "ogg mute" sets the volume to 0 while playback resumes.