### PR TITLE
Fixed ungibbable makron parts

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -127,11 +127,6 @@ Killed(edict_t *targ, edict_t *inflictor, edict_t *attacker,
 		return;
 	}
 
-	if (targ->health < -999)
-	{
-		targ->health = -999;
-	}
-
 	targ->enemy = attacker;
 
 	if ((targ->svflags & SVF_MONSTER) && (targ->deadflag != DEAD_DEAD))

--- a/src/game/monster/boss3/boss32.c
+++ b/src/game/monster/boss3/boss32.c
@@ -847,24 +847,84 @@ makron_torso_think(edict_t *self)
 	self->nextthink = level.time + FRAMETIME;
 }
 
-void
-makron_torso(edict_t *ent)
+static void
+makron_torso_origin(edict_t *self, edict_t *torso)
 {
-	if (!ent)
+	vec3_t v;
+	trace_t tr;
+
+	AngleVectors(self->s.angles, v, NULL, NULL);
+	VectorMA(self->s.origin, -84.0f, v, v);
+
+	tr = gi.trace(self->s.origin, torso->mins, torso->maxs, v, self, MASK_SOLID);
+
+	VectorCopy (tr.endpos, torso->s.origin);
+}
+
+void
+makron_torso_die(edict_t *self, edict_t *inflictor /* unused */, edict_t *attacker /* unused */,
+		int damage /* unused */, vec3_t point /* unused */)
+{
+	int n;
+
+	if (self->health > self->gib_health)
 	{
 		return;
 	}
 
-	ent->movetype = MOVETYPE_NONE;
-	ent->solid = SOLID_NOT;
-	VectorSet(ent->mins, -8, -8, 0);
-	VectorSet(ent->maxs, 8, 8, 8);
-	ent->s.frame = FRAME_death301;
-	ent->s.modelindex = gi.modelindex("models/monsters/boss3/rider/tris.md2");
-	ent->think = makron_torso_think;
-	ent->nextthink = level.time + 2 * FRAMETIME;
-	ent->s.sound = gi.soundindex("makron/spine.wav");
-	gi.linkentity(ent);
+	gi.sound(self, CHAN_VOICE, gi.soundindex( "misc/udeath.wav"), 1, ATTN_NORM, 0);
+
+	ThrowGib(self, "models/objects/gibs/sm_meat/tris.md2",
+			damage, GIB_ORGANIC);
+
+	for (n = 0; n < 4; n++)
+	{
+		ThrowGib(self, "models/objects/gibs/sm_metal/tris.md2",
+				damage, GIB_METALLIC);
+	}
+
+	G_FreeEdict(self);
+}
+
+void
+makron_torso(edict_t *self)
+{
+	edict_t *torso;
+
+	if (!self)
+	{
+		return;
+	}
+
+	torso = G_SpawnOptional();
+
+	if (!torso)
+	{
+		return;
+	}
+
+	VectorCopy(self->s.angles, torso->s.angles);
+	VectorSet(torso->mins, -24, -24, 0);
+	VectorSet(torso->maxs, 24, 24, 16);
+	makron_torso_origin(self, torso);
+
+	torso->gib_health = -800;
+	torso->takedamage = DAMAGE_YES;
+	torso->die = makron_torso_die;
+	torso->deadflag = DEAD_DEAD;
+
+	torso->owner = self;
+	torso->movetype = MOVETYPE_TOSS;
+	torso->solid = SOLID_BBOX;
+	torso->svflags = SVF_MONSTER|SVF_DEADMONSTER;
+	torso->clipmask = MASK_MONSTERSOLID;
+	torso->s.frame = FRAME_death301;
+	torso->s.modelindex = gi.modelindex("models/monsters/boss3/rider/tris.md2");
+	torso->think = makron_torso_think;
+	torso->nextthink = level.time + 2 * FRAMETIME;
+	torso->s.sound = gi.soundindex("makron/spine.wav");
+
+	gi.linkentity(torso);
 }
 
 void
@@ -875,8 +935,8 @@ makron_dead(edict_t *self)
 		return;
 	}
 
-	VectorSet(self->mins, -60, -60, 0);
-	VectorSet(self->maxs, 60, 60, 72);
+	VectorSet(self->mins, -48, -48, 0);
+	VectorSet(self->maxs, 48, 48, 24);
 	self->movetype = MOVETYPE_TOSS;
 	self->svflags |= SVF_DEADMONSTER;
 	self->nextthink = 0;
@@ -887,7 +947,6 @@ void
 makron_die(edict_t *self, edict_t *inflictor /* unused */, edict_t *attacker /* unused */,
 		int damage /* unused */, vec3_t point /* unused */)
 {
-	edict_t *tempent;
 	int n;
 
 	if (!self)
@@ -927,12 +986,11 @@ makron_die(edict_t *self, edict_t *inflictor /* unused */, edict_t *attacker /* 
 	self->deadflag = DEAD_DEAD;
 	self->takedamage = DAMAGE_YES;
 
-	tempent = G_Spawn();
-	VectorCopy(self->s.origin, tempent->s.origin);
-	VectorCopy(self->s.angles, tempent->s.angles);
-	tempent->s.origin[1] -= 84;
-	tempent->owner = self;
-	makron_torso(tempent);
+	makron_torso(self);
+
+	/* lower bbox since the torso is gone */
+	self->maxs[2] = 64;
+	gi.linkentity (self);
 
 	self->monsterinfo.currentmove = &makron_move_death2;
 }

--- a/src/game/player/hud.c
+++ b/src/game/player/hud.c
@@ -422,7 +422,7 @@ G_SetStats(edict_t *ent)
 
 	/* health */
 	ent->client->ps.stats[STAT_HEALTH_ICON] = level.pic_health;
-	ent->client->ps.stats[STAT_HEALTH] = ent->health;
+	ent->client->ps.stats[STAT_HEALTH] = (ent->health < -99) ? -99 : ent->health;
 
 	/* ammo */
 	if (!ent->client->ammo_index)

--- a/src/game/savegame/tables/gamefunc_decs.h
+++ b/src/game/savegame/tables/gamefunc_decs.h
@@ -542,6 +542,7 @@ extern void SP_monster_makron ( edict_t * self ) ;
 extern void MakronPrecache ( void ) ;
 extern qboolean Makron_CheckAttack ( edict_t * self ) ;
 extern void makron_die ( edict_t * self , edict_t * inflictor , edict_t * attacker , int damage , vec3_t point ) ;
+extern void makron_torso_die ( edict_t * self , edict_t * inflictor , edict_t * attacker , int damage , vec3_t point ) ;
 extern void makron_dead ( edict_t * self ) ;
 extern void makron_torso ( edict_t * ent ) ;
 extern void makron_torso_think ( edict_t * self ) ;

--- a/src/game/savegame/tables/gamefunc_list.h
+++ b/src/game/savegame/tables/gamefunc_list.h
@@ -542,6 +542,7 @@
 {"MakronPrecache", (byte *)MakronPrecache},
 {"Makron_CheckAttack", (byte *)Makron_CheckAttack},
 {"makron_die", (byte *)makron_die},
+{"makron_torso_die", (byte *)makron_torso_die},
 {"makron_dead", (byte *)makron_dead},
 {"makron_torso", (byte *)makron_torso},
 {"makron_torso_think", (byte *)makron_torso_think},


### PR DESCRIPTION
This PR addresses issue https://github.com/yquake2/yquake2/issues/889.

The following changes are made:
* Removed the -999 check in Killed function to make the makron legs gibbable. Its purpose was for HUD display. Instead I added a -99 cap in the HUD code, which also fixes confusing display of negative health that is between -100 and -989, where playrs would only see the first 2 digits.

* Made the makron torso shootable and gibbable

* Makron torso is no longer spawned in a fixed location relative to the legs, now it gets traced. This prevents it from spawning inside walls.

* Makron torso is affected by gravity, so if it spawns in the air it will fall down.

* Adjusted makron legs' obscenely large hitbox to match its visual appearance better

I have tested the following scenarios:
1. Killing the makron and gibbing the parts
2. Killing the makron, saving, loading the save and gibbing the parts
3. Killing the makron right up against a wall to test the new trace code
4. Walk into a laser to test the -99 HUD display cap

All seems to work for me, but I invite others to verify.