### PR TITLE
Fixed despawning makron torso

### DIFF
--- a/src/game/monster/boss3/boss32.c
+++ b/src/game/monster/boss3/boss32.c
@@ -833,7 +833,14 @@ makron_torso_think(edict_t *self)
 		return;
 	}
 
-	if (self->owner && self->owner->inuse && self->owner->deadflag != DEAD_DEAD)
+	/* detach from the makron if the legs are gone completely */
+	if (self->owner && (!self->owner->inuse || (self->owner->health <= self->owner->gib_health)))
+	{
+		self->owner = NULL;
+	}
+
+	/* if the makron is revived the torso was put back on him */
+	if (self->owner && self->owner->deadflag != DEAD_DEAD)
 	{
 		G_FreeEdict(self);
 		return;


### PR DESCRIPTION
Discovered a bug that was causing the makron torso to despawn. When the legs were gibbed, the makron entity went away, allowing a future entity like a projectile or debris, to become the new owner (same edict index as the makron was).

The fix clears the torso owner if the owner is gibbed or despawns. A more reliable fix would be to make the relationship between the legs and torso bidirectional, but this is simpler and I don't think normal gameplay can fall between the ship and the dock.

The other versions of the gibbable makron fix will have this hotfix already applied.