### PR TITLE
Pause on Minimized/Focus Lost is now in the options menu

### DIFF
--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -693,7 +693,7 @@ IN_Update(void)
 					{
 						S_Activate(false);
 
-						if (windowed_pauseonfocuslost->value != 2)
+						if (windowed_pauseonfocuslost->value != 1)
 						{
 						    Cvar_SetValue("paused", 1);
 						}
@@ -710,7 +710,7 @@ IN_Update(void)
 					{
 						S_Activate(true);
 
-						if (windowed_pauseonfocuslost->value == 0)
+						if (windowed_pauseonfocuslost->value == 2)
 						{
 						    Cvar_SetValue("paused", 0);
 						}
@@ -744,12 +744,6 @@ IN_Update(void)
 					{
 					    Cbuf_AddText("ogg toggle\n");
 					}
-
-				}
-				else if (event.window.event == SDL_WINDOWEVENT_MINIMIZED ||
-					event.window.event == SDL_WINDOWEVENT_HIDDEN)
-				{
-					Cvar_SetValue("paused", 1);
 				}
 				break;
 
@@ -2336,7 +2330,7 @@ IN_Init(void)
 		gyro_active = true;
 	}
 
-	windowed_pauseonfocuslost = Cvar_Get("w_pauseonfocuslost", "0", CVAR_USERINFO | CVAR_ARCHIVE);
+	windowed_pauseonfocuslost = Cvar_Get("vid_pauseonfocuslost", "0", CVAR_USERINFO | CVAR_ARCHIVE);
 	windowed_mouse = Cvar_Get("windowed_mouse", "1", CVAR_USERINFO | CVAR_ARCHIVE);
 
 	Cmd_AddCommand("+mlook", IN_MLookDown);

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -732,8 +732,8 @@ IN_Update(void)
 						Cvar_SetValue("paused", 0);
 					}
 				}
-				else if (event.window.event == SDL_WINDOWEVENT_MINIMIZED ||
-					event.window.event == SDL_WINDOWEVENT_HIDDEN)
+				else if (event.window.event == SDL_WINDOWEVENT_MINIMIZED && windowed_pauseonfocuslost->value > 0 ||
+					event.window.event == SDL_WINDOWEVENT_HIDDEN && windowed_pauseonfocuslost->value > 0)
 				{
 					Cvar_SetValue("paused", 1);
 				}
@@ -2322,7 +2322,7 @@ IN_Init(void)
 		gyro_active = true;
 	}
 
-	windowed_pauseonfocuslost = Cvar_Get("windowed_pauseonfocuslost", "0", CVAR_USERINFO | CVAR_ARCHIVE);
+	windowed_pauseonfocuslost = Cvar_Get("w_pauseonfocuslost", "0", CVAR_USERINFO | CVAR_ARCHIVE);
 	windowed_mouse = Cvar_Get("windowed_mouse", "1", CVAR_USERINFO | CVAR_ARCHIVE);
 
 	Cmd_AddCommand("+mlook", IN_MLookDown);

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2154,11 +2154,18 @@ static menuslider_s s_options_oggvolume_slider;
 static menulist_s s_options_oggenable_box;
 static menulist_s s_options_quality_list;
 static menulist_s s_options_console_action;
+static menulist_s s_options_pauseonfocus_box;
 
 static void
 CrosshairFunc(void *unused)
 {
     Cvar_SetValue("crosshair", (float)s_options_crosshair_box.curvalue);
+}
+
+static void
+PauseFocusFunc()
+{
+    Cvar_SetValue("w_pauseonfocuslost", (float)s_options_pauseonfocus_box.curvalue);
 }
 
 static void
@@ -2432,6 +2439,13 @@ Options_MenuInit(void)
     s_options_crosshair_box.generic.name = "crosshair";
     s_options_crosshair_box.generic.callback = CrosshairFunc;
     s_options_crosshair_box.itemnames = crosshair_names;
+	
+	s_options_pauseonfocus_box.generic.type = MTYPE_SPINCONTROL;
+    s_options_pauseonfocus_box.generic.x = 0;
+    s_options_pauseonfocus_box.generic.y = (y += 10);
+    s_options_pauseonfocus_box.generic.name = "pause on minimized";
+    s_options_pauseonfocus_box.generic.callback = PauseFocusFunc;
+    s_options_pauseonfocus_box.itemnames = yesno_names;
 
     y += 10;
     if (show_gamepad)
@@ -2475,6 +2489,7 @@ Options_MenuInit(void)
     Menu_AddItem(&s_options_menu, (void *)&s_options_lookstrafe_box);
     Menu_AddItem(&s_options_menu, (void *)&s_options_freelook_box);
     Menu_AddItem(&s_options_menu, (void *)&s_options_crosshair_box);
+	Menu_AddItem(&s_options_menu, (void*)&s_options_pauseonfocus_box);
 
     if (show_gamepad)
     {

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2164,7 +2164,7 @@ CrosshairFunc(void *unused)
 static void
 PauseFocusFunc()
 {
-    Cvar_SetValue("w_pauseonfocuslost", (float)s_options_pauseonfocus_box.curvalue);
+    Cvar_SetValue("vid_pauseonfocuslost", (float)s_options_pauseonfocus_box.curvalue);
 }
 
 static void
@@ -2202,6 +2202,7 @@ ControlsSetMenuItemValues(void)
     s_options_lookstrafe_box.curvalue = (lookstrafe->value != 0);
     s_options_freelook_box.curvalue = (freelook->value != 0);
     s_options_crosshair_box.curvalue = ClampCvar(0, 3, crosshair->value);
+    s_options_pauseonfocus_box.curvalue = ClampCvar(0, 2, Cvar_VariableValue("vid_pauseonfocuslost"));
 }
 
 static void
@@ -2341,6 +2342,14 @@ Options_MenuInit(void)
         0
     };
 
+    static const char* pause_names[] =
+    {
+        "yes",
+        "no",
+        "unpause on re-focus",
+        0
+    };
+
     static const char *crosshair_names[] =
     {
         "none",
@@ -2444,7 +2453,7 @@ Options_MenuInit(void)
     s_options_pauseonfocus_box.generic.y = (y += 10);
     s_options_pauseonfocus_box.generic.name = "pause on minimized";
     s_options_pauseonfocus_box.generic.callback = PauseFocusFunc;
-    s_options_pauseonfocus_box.itemnames = yesno_names;
+    s_options_pauseonfocus_box.itemnames = pause_names;
 
     y += 10;
     if (show_gamepad)


### PR DESCRIPTION
Hopefully closes #951 , ~~alternatively you could add a third option that unpauses when the window regains focus but I decided to just make it an override for simplicity's sake.~~ Added with [cd351a0](https://github.com/yquake2/yquake2/pull/1017/commits/cd351a06023ecbbbb7e2a99d40684a65688a0a3f) 

There are three options:
Unpause on re-focus
Pause
Don't pause at all

All are available in the regular "Options" menu.

`windowed_pauseonfocuslost` is now ~~`w_pauseonfocuslost`~~ ``vid_pauseonfocuslost`` to make it easier/faster/to type by the player and more consistent with other similar options.