### PR TITLE
T_Damage no longer modifies dir parameter

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -501,6 +501,24 @@ M_ReactToDamage(edict_t *targ, edict_t *attacker)
 	}
 }
 
+static void
+apply_knockback(edict_t *targ, vec3_t dir, float knockback, float scale)
+{
+	vec3_t kvel;
+	float mass;
+
+	if (!knockback)
+	{
+		return;
+	}
+
+	mass = (targ->mass < 50) ? 50.0f : (float)targ->mass;
+
+	VectorNormalize2 (dir, kvel);
+	VectorScale (kvel, scale * (knockback / mass), kvel);
+	VectorAdd (targ->velocity, kvel, targ->velocity);
+}
+
 void
 T_Damage(edict_t *targ, edict_t *inflictor, edict_t *attacker,
 		vec3_t dir, vec3_t point, vec3_t normal, int damage,
@@ -567,8 +585,6 @@ T_Damage(edict_t *targ, edict_t *inflictor, edict_t *attacker,
 		te_sparks = TE_SPARKS;
 	}
 
-	VectorNormalize(dir);
-
 	/* bonus damage for suprising a monster */
 	if (!(dflags & DAMAGE_RADIUS) && (targ->svflags & SVF_MONSTER) &&
 		(attacker->client) && (!targ->enemy) && (targ->health > 0))
@@ -582,37 +598,14 @@ T_Damage(edict_t *targ, edict_t *inflictor, edict_t *attacker,
 	}
 
 	/* figure momentum add */
-	if (!(dflags & DAMAGE_NO_KNOCKBACK))
+	if (!(dflags & DAMAGE_NO_KNOCKBACK) &&
+		(targ->movetype != MOVETYPE_NONE) &&
+		(targ->movetype != MOVETYPE_BOUNCE) &&
+		(targ->movetype != MOVETYPE_PUSH) &&
+		(targ->movetype != MOVETYPE_STOP))
 	{
-		if ((knockback) && (targ->movetype != MOVETYPE_NONE) &&
-			(targ->movetype != MOVETYPE_BOUNCE) &&
-			(targ->movetype != MOVETYPE_PUSH) &&
-			(targ->movetype != MOVETYPE_STOP))
-		{
-			vec3_t kvel;
-			float mass;
-
-			if (targ->mass < 50)
-			{
-				mass = 50;
-			}
-			else
-			{
-				mass = targ->mass;
-			}
-
-			if (targ->client && (attacker == targ))
-			{
-				/* This allows rocket jumps */
-				VectorScale(dir, 1600.0 * (float)knockback / mass, kvel);
-			}
-			else
-			{
-				VectorScale(dir, 500.0 * (float)knockback / mass, kvel);
-			}
-
-			VectorAdd(targ->velocity, kvel, targ->velocity);
-		}
+		apply_knockback (targ, dir, knockback,
+			((client && attacker == targ) ? 1600.0f : 500.0f));
 	}
 
 	take = damage;


### PR DESCRIPTION
So I never liked the `VectorNormalize(dir);` call in T_Damage since the dir vector passed is often static memory like vec3_origin or entity members like the velocity vector.

So I went ahead and traced how the dir vector is used. Turns out T_damage only needs it to calculate knockback, it never leaves T_Damage's scope. So I did a rewrite and moved the knockback calculations to their own function where dir is normalized into a local variable.

I did discover one piece of code that was breaking due to this unwanted side-effect:
`VectorMA(self->s.origin, -1 * FRAMETIME, self->velocity, self->s.origin);` in bfg_touch

Due to T_Damage normalizing the BFG ball's velocity vector, this line will move the origin back 0.1 units rather than the intended 40... except when nothing is hurt by the BFG ball, then it gets pushed back the full 40 since the normalize call is never reached inside T_Damage.

Currently I removed that VectorMA call. While id did intend it to be moved back, that working properly does alter the BFG's damage output a bit, in particular it reduces the damage done to the entity hit directly by the BFG ball since the distance between the victim and the ball origin is 40 units longer.

EDIT: Just did a compromise change:
If the entity touched is not takedamage, then move the BFG ball back 40 units, otherwise it explodes on the spot like before. I figured this is better because the BFG explosion effect could get cut off at angles if too close to walls.