### PR TITLE
Cheat to speed up "weapon change" animations

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -222,6 +222,13 @@ Set `0` by default.
   single player, the same way as in multiplayer.
   This cvar only works if the game.dll implements this behaviour.
 
+* **g_swap_speed**: Sets the speed of the "changing weapon" animation.
+  Default is `1`. If set to `2`, it will be double the speed, `3` is
+  the triple... up until the max of `8`, since there are at least 4
+  frames of animation that will be played compulsorily, on every weapon.
+  Cheat-protected, has to be a positive integer. As with the last one,
+  will only work if the game.dll implements this behaviour.
+
 * **g_disruptor (Ground Zero only)**: This boolean cvar controls the
   availability of the Disruptor weapon to players. The Disruptor is
   a weapon that was cut from Ground Zero during development but all

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -224,7 +224,7 @@ Set `0` by default.
 
 * **g_swap_speed**: Sets the speed of the "changing weapon" animation.
   Default is `1`. If set to `2`, it will be double the speed, `3` is
-  the triple... up until the max of `8`, since there are at least 4
+  the triple... up until the max of `8`, since there are at least 2
   frames of animation that will be played compulsorily, on every weapon.
   Cheat-protected, has to be a positive integer. As with the last one,
   will only work if the game.dll implements this behaviour.

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -686,6 +686,7 @@ cheatvar_t cheatvars[] = {
 	{"cl_kickangles", "1"},
 	{"g_footsteps", "1"},
 	{"g_machinegun_norecoil", "0"},
+	{"g_swap_speed", "1"},
 	{NULL, NULL}
 };
 

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -88,6 +88,7 @@ cvar_t *gib_on;
 
 cvar_t *aimfix;
 cvar_t *g_machinegun_norecoil;
+cvar_t *g_swap_speed;
 
 void G_RunFrame(void);
 

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -551,6 +551,7 @@ extern cvar_t *sv_maplist;
 
 extern cvar_t *aimfix;
 extern cvar_t *g_machinegun_norecoil;
+extern cvar_t *g_swap_speed;
 
 #define world (&g_edicts[0])
 

--- a/src/game/player/weapon.c
+++ b/src/game/player/weapon.c
@@ -619,7 +619,7 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 
 	if (ent->client->weaponstate == WEAPON_DROPPING)
 	{
-		if (ent->client->ps.gunframe == FRAME_DEACTIVATE_LAST)
+		if (ent->client->ps.gunframe >= FRAME_DEACTIVATE_LAST - change_speed + 1)
 		{
 			ChangeWeapon(ent);
 			return;
@@ -636,16 +636,12 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 		}
 
 		ent->client->ps.gunframe += change_speed;
-		if (ent->client->ps.gunframe > FRAME_DEACTIVATE_LAST)
-		{
-			ent->client->ps.gunframe = FRAME_DEACTIVATE_LAST;
-		}
 		return;
 	}
 
 	if (ent->client->weaponstate == WEAPON_ACTIVATING)
 	{
-		if (ent->client->ps.gunframe == FRAME_ACTIVATE_LAST)
+		if (ent->client->ps.gunframe >= FRAME_ACTIVATE_LAST - change_speed + 1)
 		{
 			ent->client->weaponstate = WEAPON_READY;
 			ent->client->ps.gunframe = FRAME_IDLE_FIRST;
@@ -653,10 +649,6 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 		}
 
 		ent->client->ps.gunframe += change_speed;
-		if (ent->client->ps.gunframe > FRAME_ACTIVATE_LAST)
-		{
-			ent->client->ps.gunframe = FRAME_ACTIVATE_LAST;
-		}
 		return;
 	}
 

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -246,6 +246,7 @@ InitGame(void)
 	/* others */
 	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
 	g_machinegun_norecoil = gi.cvar("g_machinegun_norecoil", "0", CVAR_ARCHIVE);
+	g_swap_speed = gi.cvar("g_swap_speed", "1", 0);
 
 	/* items */
 	InitItems();


### PR DESCRIPTION
I know gameplay related changes are questioned here, but I think this is a very popular issue with Quake 2, because one of the most criticized aspects of it (even among Quake series' fans) is the speed which you can change weapons. And since Quake 2 Remastered is near ([leaked by the Korean Game Rating and Administration Committee, just like with Q1 Remastered in 2021](https://www.gematsu.com/2023/06/quake-ii-remastered-rated-in-korea)), I bet that a similar option to speed up weapon switching will be included there.

Code is based on [Lithium II](https://github.com/mattayres/li2mod) and [Q2 25th Anniversary](https://github.com/glhrmfrts/q25_game). Although I say so myself, this PR has a less disruptive, better organized implementation of "fast weapon switching" than these 2 mods.