### PR TITLE
Fixed VectorNormalize2 not writing 0-length vectors to out

### DIFF
--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -521,20 +521,9 @@ VectorNormalize(vec3_t v)
 vec_t
 VectorNormalize2(vec3_t v, vec3_t out)
 {
-	float length, ilength;
+	VectorCopy(v, out);
 
-	length = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
-	length = (float)sqrt(length);
-
-	if (length)
-	{
-		ilength = 1 / length;
-		out[0] = v[0] * ilength;
-		out[1] = v[1] * ilength;
-		out[2] = v[2] * ilength;
-	}
-
-	return length;
+	return VectorNormalize(out);
 }
 
 void


### PR DESCRIPTION
Noticed that VecorNormalize2 does not output a vector if the length is 0 which is just asking for undefined behavior (my T_Damage fix made the false assumption in fact, that out would always be modified).

Its code was also redundant so I made it call the 1-arg variant to carry out the normalization.

I added these changes into the other 3 games through the T_Damage fixes.

Btw, optimization thought: Couldn't we move the sqrt call behind the length != 0 check? Would avoid sqrt for blank vectors like vec3_origin.