### PR TITLE
macOS: Fix compilation of weapon.c

### DIFF
--- a/src/game/player/weapon.c
+++ b/src/game/player/weapon.c
@@ -24,9 +24,7 @@
  * =======================================================================
  */
 
-#ifdef __APPLE__
 #include <limits.h>
-#endif
 
 #include "../header/local.h"
 #include "../monster/misc/player.h"

--- a/src/game/player/weapon.c
+++ b/src/game/player/weapon.c
@@ -24,6 +24,10 @@
  * =======================================================================
  */
 
+#ifdef __APPLE__
+#include <limits.h>
+#endif
+
 #include "../header/local.h"
 #include "../monster/misc/player.h"
 


### PR DESCRIPTION
On the current master branch, weapon.c fails to compile on macOS due to the following:

```
===> CC src/game/player/weapon.c
src/game/player/weapon.c:609:26: error: use of undeclared identifier 'USHRT_MAX'
                (g_swap_speed->value < USHRT_MAX)? (unsigned short int)g_swap_speed->value : 1
                                       ^
1 error generated.
```

This is because on macOS, the include file 'limits.h' must be present for the compiler to find this definition.

Tested on both an Intel Mac running BigSur and Apple Silicon running the latest.  This PR fixes the compilation.