### PR TITLE
Added missing include, fixing compilation in Linux and MacOS

### DIFF
--- a/src/game/player/weapon.c
+++ b/src/game/player/weapon.c
@@ -26,6 +26,7 @@
 
 #include "../header/local.h"
 #include "../monster/misc/player.h"
+#include <limits.h>
 
 #define PLAYER_NOISE_SELF 0
 #define PLAYER_NOISE_IMPACT 1


### PR DESCRIPTION
https://github.com/yquake2/yquake2/pull/1049 had a definition (USHRT_MAX) included in limits.h, which has to be manually included in Linux and MacOS for it to work. The present PR fixes compilation in those platforms.
This replaces:
https://github.com/yquake2/yquake2/pull/1057
https://github.com/yquake2/yquake2/pull/1058
My apologies for the mistake.