### PR TITLE
Fixed gl1_overbrightbits limiter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ Quake II 8.20 to 8.30:
 - Use the same model loading code in all renderers. (by 0lvin)
 - Remove the unused `msg` cvar and the corresponding server side
   infrastructure. The cvar was never implemented in Quake II, but
-  existing bits clould be used for attacks against the client.
+  existing bits could be used for attacks against the client.
 - Add `cl_audiopaused`. When set to `1` the audio stops when the
   game is paused. (by David Carlier)
 - Add `ogg_pausewithgame`. When set to `1` the background music stops
@@ -11,16 +11,16 @@ Quake II 8.20 to 8.30:
 - New logo files, matching the original Quake II logo. (by SirYodaJedi)
 - Support for RISCV64 (by David Carlier)
 - Fix resetting Mods back to baseq2 when running with `-portable`.
-- Alternative playback modes for OGG/Vorbis backgrounf music: once,
+- Alternative playback modes for OGG/Vorbis background music: once,
   sequential, random. (by apartfromtime)
 - Support gyro aiming for Switch controllers with SDL < 2.0.14. (by
   protocultor)
 - Fixed stand-ground gladiators not attacking within a certain range.
   (by BjossiAlfreds)
 - Fixed monsters seeing players during intermissions. (by BjossiAlfreds)
-- Several fixes to Macron. (by BjossiAlfreds)
+- Several fixes to Makron. (by BjossiAlfreds)
 - Optional high dpi awareness when running under Wayland. Requires a
-  Wayland compistor supporting fractional-scale-v1 and at least SDL
+  Wayland compositor supporting fractional-scale-v1 and at least SDL
   2.26. Set `vid_highdpiawareness 1` to enable.
 - Fix lava surfaces not glowing.
 - Add a cheat protected cvar `g_swap_speed`. Allows to skip frames of

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -287,6 +287,7 @@ Set `0` by default.
 
 * **cl_audiopaused**: If set to `1` the sounds pause when the game does.
 
+
 ## Graphics (all renderers)
 
 * **cin_force43**: If set to `1` (the default) cinematics are displayed
@@ -436,6 +437,7 @@ Set `0` by default.
   Other supported values: `GL_NEAREST_MIPMAP_NEAREST`,
   `GL_NEAREST_MIPMAP_LINEAR`, `GL_LINEAR_MIPMAP_LINEAR`
 
+
 ## Graphics (OpenGL 1.4 only)
 
 * **gl1_intensity**: Sets the color intensity. Must be a floating point
@@ -445,8 +447,9 @@ Set `0` by default.
 * **gl1_overbrightbits**: Enables overbright bits, brightness scaling of
   lightmaps and models. Higher values make shadows less dark. Possible
   values are `0` (no overbright bits), `1` (more correct lighting for
-  water), `2` (scale by factor 2) and `3` (scale by factor 3). Applied
-  in realtime, does not need `vid_restart`.
+  water), `2` (scale by factor 2), `3` (scale lighting by 3 only for the
+  dynamic meshes, like enemies and items), and `4` (scale lighting of
+  everything by 4). Applied in realtime, does not need `vid_restart`.
 
 * **gl1_particle_square**: If set to `1` particles are rendered as
   squares.
@@ -588,6 +591,7 @@ Set `0` by default.
   this cvar is `0`. Possible values:
   `0`: Rumble feedback,
   `1`: Haptic feedback.
+
 
 ## cvar operations
 

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -1616,13 +1616,13 @@ RI_BeginFrame(float camera_separation)
 	// Clamp overbrightbits
 	if (gl1_overbrightbits->modified)
 	{
-		if (gl1_overbrightbits->value > 2 && gl1_overbrightbits->value < 4)
+		if (gl1_overbrightbits->value < 0)
 		{
-			ri.Cvar_Set("r_overbrightbits", "2");
+			ri.Cvar_Set("gl1_overbrightbits", "0");
 		}
 		else if (gl1_overbrightbits->value > 4)
 		{
-			ri.Cvar_Set("r_overbrightbits", "4");
+			ri.Cvar_Set("gl1_overbrightbits", "4");
 		}
 
 		gl1_overbrightbits->modified = false;

--- a/src/client/refresh/gl3/gl3_sdl.c
+++ b/src/client/refresh/gl3/gl3_sdl.c
@@ -343,7 +343,7 @@ int GL3_InitContext(void* win)
 	// Enable vsync if requested.
 	GL3_SetVsync();
 
-	// Load GL pointrs through GLAD and check context.
+	// Load GL pointers through GLAD and check context.
 #ifdef YQ2_GL3_GLES
 	if( !gladLoadGLES2Loader(SDL_GL_GetProcAddress))
 #else // Desktop GL


### PR DESCRIPTION
As discussed in #1065, allowed values for this cvar are between 0 and 4, but now the game actually enforces these limits. Documentation was updated to reflect this, and the difference between `3` and `4`.

P.D.: sorry about the last commit ;)