### PR TITLE
Rename min\max to avoid conflict with c-plus plus

### DIFF
--- a/src/backends/windows/network.c
+++ b/src/backends/windows/network.c
@@ -1255,8 +1255,8 @@ NET_Sleep(int msec)
 
 	timeout.tv_sec = msec / 1000;
 	timeout.tv_usec = (msec % 1000) * 1000;
-	i = max(ip_sockets[NS_SERVER], ip6_sockets[NS_SERVER]);
-	i = max(i, ipx_sockets[NS_SERVER]);
+	i = Q_max(ip_sockets[NS_SERVER], ip6_sockets[NS_SERVER]);
+	i = Q_max(i, ipx_sockets[NS_SERVER]);
 	select(i + 1, &fdset, NULL, NULL, &timeout);
 }
 

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -1045,8 +1045,8 @@ static thumbstick_t
 IN_RadialDeadzone(thumbstick_t stick, float deadzone)
 {
 	thumbstick_t result = {0};
-	float magnitude = min(IN_StickMagnitude(stick), 1.0f);
-	deadzone = min( max(deadzone, 0.0f), 0.9f);		// clamp to [0.0, 0.9]
+	float magnitude = Q_min(IN_StickMagnitude(stick), 1.0f);
+	deadzone = Q_min( Q_max(deadzone, 0.0f), 0.9f);		// clamp to [0.0, 0.9]
 
 	if ( magnitude > deadzone )
 	{
@@ -1070,7 +1070,7 @@ IN_SlopedAxialDeadzone(thumbstick_t stick, float deadzone)
 	float abs_y = fabsf(stick.y);
 	float sign_x = copysignf(1.0f, stick.x);
 	float sign_y = copysignf(1.0f, stick.y);
-	deadzone = min(deadzone, 0.5f);
+	deadzone = Q_min(deadzone, 0.5f);
 	float deadzone_x = deadzone * abs_y;	// deadzone of one axis depends...
 	float deadzone_y = deadzone * abs_x;	// ...on the value of the other axis
 
@@ -1141,7 +1141,7 @@ IN_SmoothedStickRotation(float value)
 	//				0 for immediate consumption
 	float immediate_weight = (fabsf(value) - bottom_threshold)
 					/ (top_threshold - bottom_threshold);
-	immediate_weight = min( max(immediate_weight, 0.0f), 1.0f ); // clamp to [0, 1] range
+	immediate_weight = Q_min( Q_max(immediate_weight, 0.0f), 1.0f ); // clamp to [0, 1] range
 
 	// now we can push the smooth sample
 	float smooth_weight = 1.0f - immediate_weight;
@@ -1171,7 +1171,7 @@ IN_FlickStick(thumbstick_t stick, float axial_deadzone)
 	thumbstick_t processed = stick;
 	float angle_change = 0;
 
-	if (IN_StickMagnitude(stick) > min(joy_flick_threshold->value, 1.0f))	// flick!
+	if (IN_StickMagnitude(stick) > Q_min(joy_flick_threshold->value, 1.0f))	// flick!
 	{
 		// Make snap-to-axis only if player wasn't already flicking
 		if (!is_flicking || flick_progress < FLICK_TIME)
@@ -2005,8 +2005,8 @@ Controller_Rumble(const char *name, vec3_t source, qboolean from_player,
 	}
 
 	effect_volume = joy_haptic_magnitude->value * intens * dist_prop * volume;
-	low_freq = min(effect_volume * low_freq, USHRT_MAX);
-	hi_freq = min(effect_volume * hi_freq, USHRT_MAX);
+	low_freq = Q_min(effect_volume * low_freq, USHRT_MAX);
+	hi_freq = Q_min(effect_volume * hi_freq, USHRT_MAX);
 
 	// Com_Printf("%-29s: vol %5u - %4u ms - dp %.3f l %5.0f h %5.0f\n",
 	//	name, effect_volume, duration, dist_prop, low_freq, hi_freq);

--- a/src/client/refresh/gl1/gl1_image.c
+++ b/src/client/refresh/gl1/gl1_image.c
@@ -240,7 +240,7 @@ R_TextureMode(char *string)
 			if (gl_config.anisotropic && gl_anisotropic->value)
 			{
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT,
-						max(gl_anisotropic->value, 1.f));
+						Q_max(gl_anisotropic->value, 1.f));
 			}
 		}
 		else /* texture has no mipmaps */
@@ -778,7 +778,7 @@ R_Upload32(unsigned *data, int width, int height, qboolean mipmap)
 	if (mipmap && gl_config.anisotropic && gl_anisotropic->value)
 	{
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT,
-				max(gl_anisotropic->value, 1.f));
+				Q_max(gl_anisotropic->value, 1.f));
 	}
 	return res;
 }

--- a/src/client/refresh/gl3/gl3_image.c
+++ b/src/client/refresh/gl3/gl3_image.c
@@ -116,7 +116,7 @@ GL3_TextureMode(char *string)
 			/* Set anisotropic filter if supported and enabled */
 			if (gl3config.anisotropic && gl_anisotropic->value)
 			{
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, max(gl_anisotropic->value, 1.f));
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, Q_max(gl_anisotropic->value, 1.f));
 			}
 		}
 		else /* texture has no mipmaps */
@@ -227,7 +227,7 @@ GL3_Upload32(unsigned *data, int width, int height, qboolean mipmap)
 
 	if (mipmap && gl3config.anisotropic && gl_anisotropic->value)
 	{
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, max(gl_anisotropic->value, 1.f));
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, Q_max(gl_anisotropic->value, 1.f));
 	}
 
 	return res;

--- a/src/client/refresh/gl3/gl3_shaders.c
+++ b/src/client/refresh/gl3/gl3_shaders.c
@@ -576,7 +576,7 @@ static const char* fragmentSrc3Dlm = MULTILINE_STRING(
 
 					vec3 lightToPos = dynLights[i].lightOrigin - passWorldCoord;
 					float distLightToPos = length(lightToPos);
-					float fact = max(0.0, intens - distLightToPos - 52.0);
+					float fact = Q_max(0.0, intens - distLightToPos - 52.0);
 
 					// move the light source a bit further above the surface
 					// => helps if the lightsource is so close to the surface (e.g. grenades, rockets)
@@ -585,7 +585,7 @@ static const char* fragmentSrc3Dlm = MULTILINE_STRING(
 					lightToPos += passNormal*32.0;
 
 					// also factor in angle between light and point on surface
-					fact *= max(0.0, dot(passNormal, normalize(lightToPos)));
+					fact *= Q_max(0.0, dot(passNormal, normalize(lightToPos)));
 
 
 					lmTex.rgb += dynLights[i].lightColor.rgb * fact * (1.0/256.0);
@@ -663,7 +663,7 @@ static const char* fragmentSrc3DlmNoColor = MULTILINE_STRING(
 
 					vec3 lightToPos = dynLights[i].lightOrigin - passWorldCoord;
 					float distLightToPos = length(lightToPos);
-					float fact = max(0.0, intens - distLightToPos - 52.0);
+					float fact = Q_max(0.0, intens - distLightToPos - 52.0);
 
 					// move the light source a bit further above the surface
 					// => helps if the lightsource is so close to the surface (e.g. grenades, rockets)
@@ -672,7 +672,7 @@ static const char* fragmentSrc3DlmNoColor = MULTILINE_STRING(
 					lightToPos += passNormal*32.0;
 
 					// also factor in angle between light and point on surface
-					fact *= max(0.0, dot(passNormal, normalize(lightToPos)));
+					fact *= Q_max(0.0, dot(passNormal, normalize(lightToPos)));
 
 
 					lmTex.rgb += dynLights[i].lightColor.rgb * fact * (1.0/256.0);
@@ -801,7 +801,7 @@ static const char* fragmentSrcAlias = MULTILINE_STRING(
 			// apply gamma correction and intensity
 			texel.rgb *= intensity;
 			texel.a *= alpha; // is alpha even used here?
-			texel *= min(vec4(1.5), passColor);
+			texel *= Q_min(vec4(1.5), passColor);
 
 			outColor.rgb = pow(texel.rgb, vec3(gamma));
 			outColor.a = texel.a; // I think alpha shouldn't be modified by gamma and intensity
@@ -864,7 +864,7 @@ static const char* fragmentSrcParticles = MULTILINE_STRING(
 			outColor.rgb = pow(texel.rgb, vec3(gamma));
 
 			// I want the particles to fade out towards the edge, the following seems to look nice
-			texel.a *= min(1.0, particleFadeFactor*(1.0 - distSquared));
+			texel.a *= Q_min(1.0, particleFadeFactor*(1.0 - distSquared));
 
 			outColor.a = texel.a; // I think alpha shouldn't be modified by gamma and intensity
 		}

--- a/src/client/refresh/gl3/gl3_shaders.c
+++ b/src/client/refresh/gl3/gl3_shaders.c
@@ -576,7 +576,7 @@ static const char* fragmentSrc3Dlm = MULTILINE_STRING(
 
 					vec3 lightToPos = dynLights[i].lightOrigin - passWorldCoord;
 					float distLightToPos = length(lightToPos);
-					float fact = Q_max(0.0, intens - distLightToPos - 52.0);
+					float fact = max(0.0, intens - distLightToPos - 52.0);
 
 					// move the light source a bit further above the surface
 					// => helps if the lightsource is so close to the surface (e.g. grenades, rockets)
@@ -585,7 +585,7 @@ static const char* fragmentSrc3Dlm = MULTILINE_STRING(
 					lightToPos += passNormal*32.0;
 
 					// also factor in angle between light and point on surface
-					fact *= Q_max(0.0, dot(passNormal, normalize(lightToPos)));
+					fact *= max(0.0, dot(passNormal, normalize(lightToPos)));
 
 
 					lmTex.rgb += dynLights[i].lightColor.rgb * fact * (1.0/256.0);
@@ -663,7 +663,7 @@ static const char* fragmentSrc3DlmNoColor = MULTILINE_STRING(
 
 					vec3 lightToPos = dynLights[i].lightOrigin - passWorldCoord;
 					float distLightToPos = length(lightToPos);
-					float fact = Q_max(0.0, intens - distLightToPos - 52.0);
+					float fact = max(0.0, intens - distLightToPos - 52.0);
 
 					// move the light source a bit further above the surface
 					// => helps if the lightsource is so close to the surface (e.g. grenades, rockets)
@@ -672,7 +672,7 @@ static const char* fragmentSrc3DlmNoColor = MULTILINE_STRING(
 					lightToPos += passNormal*32.0;
 
 					// also factor in angle between light and point on surface
-					fact *= Q_max(0.0, dot(passNormal, normalize(lightToPos)));
+					fact *= max(0.0, dot(passNormal, normalize(lightToPos)));
 
 
 					lmTex.rgb += dynLights[i].lightColor.rgb * fact * (1.0/256.0);
@@ -801,7 +801,7 @@ static const char* fragmentSrcAlias = MULTILINE_STRING(
 			// apply gamma correction and intensity
 			texel.rgb *= intensity;
 			texel.a *= alpha; // is alpha even used here?
-			texel *= Q_min(vec4(1.5), passColor);
+			texel *= min(vec4(1.5), passColor);
 
 			outColor.rgb = pow(texel.rgb, vec3(gamma));
 			outColor.a = texel.a; // I think alpha shouldn't be modified by gamma and intensity
@@ -864,7 +864,7 @@ static const char* fragmentSrcParticles = MULTILINE_STRING(
 			outColor.rgb = pow(texel.rgb, vec3(gamma));
 
 			// I want the particles to fade out towards the edge, the following seems to look nice
-			texel.a *= Q_min(1.0, particleFadeFactor*(1.0 - distSquared));
+			texel.a *= min(1.0, particleFadeFactor*(1.0 - distSquared));
 
 			outColor.a = texel.a; // I think alpha shouldn't be modified by gamma and intensity
 		}

--- a/src/client/refresh/soft/sw_draw.c
+++ b/src/client/refresh/soft/sw_draw.c
@@ -235,7 +235,7 @@ RE_Draw_StretchPicImplementation (int x, int y, int w, int h, const image_t *pic
 				if (picupscale > 1)
 				{
 					int i;
-					int pu = min(height-v, picupscale);
+					int pu = Q_min(height-v, picupscale);
 					pixel_t	*dest_orig = dest;
 
 					// copy first line to fill whole sector

--- a/src/client/refresh/soft/sw_sprite.c
+++ b/src/client/refresh/soft/sw_sprite.c
@@ -53,8 +53,8 @@ R_DrawSprite(entity_t *currententity, const model_t *currentmodel)
 	}
 
 	r_polydesc.pixels       = skin->pixels[0];
-	r_polydesc.pixel_width  = min(s_psprframe->width, skin->width);
-	r_polydesc.pixel_height = min(s_psprframe->height, skin->height);
+	r_polydesc.pixel_width  = Q_min(s_psprframe->width, skin->width);
+	r_polydesc.pixel_height = Q_min(s_psprframe->height, skin->height);
 	r_polydesc.dist         = 0;
 
 	// generate the sprite's axes, completely parallel to the viewplane.

--- a/src/client/sound/openal.c
+++ b/src/client/sound/openal.c
@@ -643,7 +643,7 @@ AL_Spatialize(channel_t *ch)
 
 				final = 1.0 - ((dist / 1000) * (1.0 - s_occlusion_strength->value));
 
-				qalSourcef(ch->srcnum, AL_GAIN, min(max(final, 0), 1));
+				qalSourcef(ch->srcnum, AL_GAIN, Q_min(Q_max(final, 0), 1));
 
 				qalSourcei(ch->srcnum, AL_DIRECT_FILTER, underwaterFilter);
 

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -124,12 +124,8 @@ typedef unsigned char byte;
 #define YAW 1                       /* left / right */
 #define ROLL 2                      /* fall over */
 
-#ifndef min
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#endif
-#ifndef max
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#endif
+#define Q_min(a, b) (((a) < (b)) ? (a) : (b))
+#define Q_max(a, b) (((a) > (b)) ? (a) : (b))
 
 #define MAX_STRING_CHARS 2048       /* max length of a string passed to Cmd_TokenizeString */
 #define MAX_STRING_TOKENS 80        /* max tokens resulting from Cmd_TokenizeString */


### PR DESCRIPTION
While trying to compile the yquake2 rebased heretic2 source from @0lvin, a name conflict with min\max of different parameter counts included by a std::cpp library occurred.