### PR TITLE
Faster "weapprev" and "weapnext" behavior

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -222,6 +222,12 @@ Set `0` by default.
   single player, the same way as in multiplayer.
   This cvar only works if the game.dll implements this behaviour.
 
+* **g_quick_weap**: If set to `1`, both *weapprev* and *weapnext*
+  commands will "count" how many times they have been called, making
+  possible to skip weapons by quickly tapping one of these keys.
+  By default this cvar is set to `0`, and will only work if the
+  game.dll implements this behaviour.
+
 * **g_swap_speed**: Sets the speed of the "changing weapon" animation.
   Default is `1`. If set to `2`, it will be double the speed, `3` is
   the triple... up until the max of `8`, since there are at least 2

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -732,17 +732,25 @@ Cmd_WeapPrev_f(edict_t *ent)
 
 	cl = ent->client;
 
-	if (!cl->pers.weapon)
+	if (g_quick_weap->value && cl->newweapon)
+	{
+		it = cl->newweapon;
+	}
+	else if (cl->pers.weapon)
+	{
+		it = cl->pers.weapon;
+	}
+	else
 	{
 		return;
 	}
 
-	selected_weapon = ITEM_INDEX(cl->pers.weapon);
+	selected_weapon = ITEM_INDEX(it);
 
-	/* scan  for the next valid one */
+	/* scan for the next valid one */
 	for (i = 1; i <= MAX_ITEMS; i++)
 	{
-		index = (selected_weapon + i) % MAX_ITEMS;
+		index = (selected_weapon + MAX_ITEMS - i) % MAX_ITEMS;
 
 		if (!cl->pers.inventory[index])
 		{
@@ -751,19 +759,14 @@ Cmd_WeapPrev_f(edict_t *ent)
 
 		it = &itemlist[index];
 
-		if (!it->use)
-		{
-			continue;
-		}
-
-		if (!(it->flags & IT_WEAPON))
+		if (!it->use || !(it->flags & IT_WEAPON))
 		{
 			continue;
 		}
 
 		it->use(ent, it);
 
-		if (cl->pers.weapon == it)
+		if (cl->newweapon == it)
 		{
 			return; /* successful */
 		}
@@ -785,17 +788,25 @@ Cmd_WeapNext_f(edict_t *ent)
 
 	cl = ent->client;
 
-	if (!cl->pers.weapon)
+	if (g_quick_weap->value && cl->newweapon)
+	{
+		it = cl->newweapon;
+	}
+	else if (cl->pers.weapon)
+	{
+		it = cl->pers.weapon;
+	}
+	else
 	{
 		return;
 	}
 
-	selected_weapon = ITEM_INDEX(cl->pers.weapon);
+	selected_weapon = ITEM_INDEX(it);
 
-	/* scan  for the next valid one */
+	/* scan for the next valid one */
 	for (i = 1; i <= MAX_ITEMS; i++)
 	{
-		index = (selected_weapon + MAX_ITEMS - i) % MAX_ITEMS;
+		index = (selected_weapon + i) % MAX_ITEMS;
 
 		if (!cl->pers.inventory[index])
 		{
@@ -804,19 +815,14 @@ Cmd_WeapNext_f(edict_t *ent)
 
 		it = &itemlist[index];
 
-		if (!it->use)
-		{
-			continue;
-		}
-
-		if (!(it->flags & IT_WEAPON))
+		if (!it->use || !(it->flags & IT_WEAPON))
 		{
 			continue;
 		}
 
 		it->use(ent, it);
 
-		if (cl->pers.weapon == it)
+		if (cl->newweapon == it)
 		{
 			return; /* successful */
 		}

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -768,6 +768,12 @@ Cmd_WeapPrev_f(edict_t *ent)
 
 		if (cl->newweapon == it)
 		{
+			if (g_quick_weap->value)
+			{
+				cl->ps.stats[STAT_PICKUP_ICON] = gi.imageindex(cl->newweapon->icon);
+				cl->ps.stats[STAT_PICKUP_STRING] = CS_ITEMS + ITEM_INDEX(cl->newweapon);
+				cl->pickup_msg_time = level.time + 0.9f;
+			}
 			return; /* successful */
 		}
 	}
@@ -824,6 +830,12 @@ Cmd_WeapNext_f(edict_t *ent)
 
 		if (cl->newweapon == it)
 		{
+			if (g_quick_weap->value)
+			{
+				cl->ps.stats[STAT_PICKUP_ICON] = gi.imageindex(cl->newweapon->icon);
+				cl->ps.stats[STAT_PICKUP_STRING] = CS_ITEMS + ITEM_INDEX(cl->newweapon);
+				cl->pickup_msg_time = level.time + 0.9f;
+			}
 			return; /* successful */
 		}
 	}

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -88,6 +88,7 @@ cvar_t *gib_on;
 
 cvar_t *aimfix;
 cvar_t *g_machinegun_norecoil;
+cvar_t *g_quick_weap;
 cvar_t *g_swap_speed;
 
 void G_RunFrame(void);

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -551,6 +551,7 @@ extern cvar_t *sv_maplist;
 
 extern cvar_t *aimfix;
 extern cvar_t *g_machinegun_norecoil;
+extern cvar_t *g_quick_weap;
 extern cvar_t *g_swap_speed;
 
 #define world (&g_edicts[0])

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -246,6 +246,7 @@ InitGame(void)
 	/* others */
 	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
 	g_machinegun_norecoil = gi.cvar("g_machinegun_norecoil", "0", CVAR_ARCHIVE);
+	g_quick_weap = gi.cvar("g_quick_weap", "0", CVAR_ARCHIVE);
 	g_swap_speed = gi.cvar("g_swap_speed", "1", 0);
 
 	/* items */


### PR DESCRIPTION
These commands can now "count" how many times they have been called. This allows for changing to different weapons when quickly tapping their keys (or scrolling the mouse wheel), instead of going just "one down" or "one up" at a time. This is similar to how these commands operate on the recent rerelease of the game, or the old PS1 version of Q2.
The code for this is based on #865, where I did the same for `cycleweap`.

A new cvar, `g_quick_weap`, allows to enable or disable this behavior. By default, it is disabled.

This has been tested on Windows and Raspberry Pi OS.