### PR TITLE
Fix duplicate menu key keyboard entries

### DIFF
--- a/src/client/cl_keyboard.c
+++ b/src/client/cl_keyboard.c
@@ -360,6 +360,7 @@ Key_Console(int key)
 		case K_KP_HOME:
 		case K_KP_UPARROW:
 		case K_KP_PGUP:
+		case K_KP_LEFTARROW:
 		case K_KP_5:
 		case K_KP_RIGHTARROW:
 		case K_KP_END:

--- a/src/client/cl_keyboard.c
+++ b/src/client/cl_keyboard.c
@@ -360,7 +360,6 @@ Key_Console(int key)
 		case K_KP_HOME:
 		case K_KP_UPARROW:
 		case K_KP_PGUP:
-		case K_KP_LEFTARROW:
 		case K_KP_5:
 		case K_KP_RIGHTARROW:
 		case K_KP_END:

--- a/src/client/header/keyboard.h
+++ b/src/client/header/keyboard.h
@@ -276,6 +276,7 @@ extern int		chat_bufferlen;
 extern int		chat_cursorpos;
 extern qboolean	chat_team;
 
+qboolean IN_NumpadIsOn();
 void Char_Event(int key);
 void Key_Event(int key, qboolean down, qboolean special);
 void Key_Init(void);

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -537,6 +537,18 @@ IN_TranslateGamepadBtnToQ2Key(int btn)
 static void IN_Controller_Init(qboolean notify_user);
 static void IN_Controller_Shutdown(qboolean notify_user);
 
+qboolean IN_NumpadIsOn()
+{
+    SDL_Keymod mod = SDL_GetModState();
+
+    if ((mod & KMOD_NUM) == KMOD_NUM)
+    {
+        return true;
+    }
+
+    return false;
+}
+
 /* ------------------------------------------------------------------ */
 
 /*

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -664,19 +664,41 @@ IN_Update(void)
 					else
 					{
 						int key = IN_TranslateSDLtoQ2Key(kc);
-						if(key == 0)
+						if (key == 0)
 						{
 							// fallback to scancodes if we don't know the keycode
 							key = IN_TranslateScancodeToQ2Key(sc);
 						}
-						if(key != 0)
-						{
-							Key_Event(key, down, true);
-						}
-						else
-						{
-							Com_DPrintf("Pressed unknown key with SDL_Keycode %d, SDL_Scancode %d.\n", kc, (int)sc);
-						}
+
+                        // normal character events
+                        if ((event.key.keysym.mod & KMOD_NUM) == KMOD_NUM)
+                        {
+                            switch (key)
+                            {
+                            case K_KP_HOME:
+                            case K_KP_UPARROW:
+                            case K_KP_PGUP:
+                            case K_KP_LEFTARROW:
+                            case K_KP_5:
+                            case K_KP_RIGHTARROW:
+                            case K_KP_END:
+                            case K_KP_DOWNARROW:
+                            case K_KP_PGDN:
+                            case K_KP_INS:
+                            case K_KP_DEL:
+                                key = 0;
+                                break;
+                            }
+                        }
+
+                        if (key != 0)
+                        {
+                            Key_Event(key, down, true);
+                        }
+                        else
+                        {
+                            Com_DPrintf("Pressed unknown key with SDL_Keycode %d, SDL_Scancode %d.\n", kc, (int)sc);
+                        }
 					}
 				}
 

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -664,41 +664,19 @@ IN_Update(void)
 					else
 					{
 						int key = IN_TranslateSDLtoQ2Key(kc);
-						if (key == 0)
+						if(key == 0)
 						{
 							// fallback to scancodes if we don't know the keycode
 							key = IN_TranslateScancodeToQ2Key(sc);
 						}
-
-                        // normal character events
-                        if ((event.key.keysym.mod & KMOD_NUM) == KMOD_NUM)
-                        {
-                            switch (key)
-                            {
-                            case K_KP_HOME:
-                            case K_KP_UPARROW:
-                            case K_KP_PGUP:
-                            case K_KP_LEFTARROW:
-                            case K_KP_5:
-                            case K_KP_RIGHTARROW:
-                            case K_KP_END:
-                            case K_KP_DOWNARROW:
-                            case K_KP_PGDN:
-                            case K_KP_INS:
-                            case K_KP_DEL:
-                                key = 0;
-                                break;
-                            }
-                        }
-
-                        if (key != 0)
-                        {
-                            Key_Event(key, down, true);
-                        }
-                        else
-                        {
-                            Com_DPrintf("Pressed unknown key with SDL_Keycode %d, SDL_Scancode %d.\n", kc, (int)sc);
-                        }
+						if(key != 0)
+						{
+							Key_Event(key, down, true);
+						}
+						else
+						{
+							Com_DPrintf("Pressed unknown key with SDL_Keycode %d, SDL_Scancode %d.\n", kc, (int)sc);
+						}
 					}
 				}
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -242,31 +242,31 @@ Key_GetMenuKey(int key)
 	switch (key)
 	{
 		case K_KP_UPARROW:
-                    if (IN_NumpadIsOn() == true) { break; }
+		    if (IN_NumpadIsOn() == true) { break; }
 		case K_UPARROW:
 		case K_DPAD_UP:
-			return K_UPARROW;
+		    return K_UPARROW;
 
 		case K_TAB:
 		case K_KP_DOWNARROW:
-                    if (IN_NumpadIsOn() == true) { break; }
+		    if (IN_NumpadIsOn() == true) { break; }
 		case K_DOWNARROW:
 		case K_DPAD_DOWN:
-			return K_DOWNARROW;
+		    return K_DOWNARROW;
 
 		case K_KP_LEFTARROW:
                     if (IN_NumpadIsOn() == true) { break; }
 		case K_LEFTARROW:
 		case K_DPAD_LEFT:
 		case K_SHOULDER_LEFT:
-			return K_LEFTARROW;
+		    return K_LEFTARROW;
 
 		case K_KP_RIGHTARROW:
-                    if (IN_NumpadIsOn() == true) { break; }
+		    if (IN_NumpadIsOn() == true) { break; }
 		case K_RIGHTARROW:
 		case K_DPAD_RIGHT:
 		case K_SHOULDER_RIGHT:
-			return K_RIGHTARROW;
+		    return K_RIGHTARROW;
 
 		case K_MOUSE1:
 		case K_MOUSE2:
@@ -277,23 +277,23 @@ Key_GetMenuKey(int key)
 		case K_KP_ENTER:
 		case K_ENTER:
 		case K_BTN_A:
-			return K_ENTER;
+		    return K_ENTER;
 
 		case K_ESCAPE:
 		case K_JOY_BACK:
 		case K_BTN_B:
-			return K_ESCAPE;
+		    return K_ESCAPE;
 
 		case K_BACKSPACE:
 		case K_DEL:
 		case K_KP_DEL:
-                    if (IN_NumpadIsOn() == true) { break; }
+		    if (IN_NumpadIsOn() == true) { break; }
 		case K_BTN_Y:
-			return K_BACKSPACE;
-                case K_KP_INS:
-                    if (IN_NumpadIsOn() == true) { break; }
-                case K_INS:
-                    return K_INS;
+		    return K_BACKSPACE;
+		case K_KP_INS:
+		    if (IN_NumpadIsOn() == true) { break; }
+		case K_INS:
+		    return K_INS;
 	}
 
 	return key;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -242,23 +242,27 @@ Key_GetMenuKey(int key)
 	switch (key)
 	{
 		case K_KP_UPARROW:
+                    if (IN_NumpadIsOn() == true) { break; }
 		case K_UPARROW:
 		case K_DPAD_UP:
 			return K_UPARROW;
 
 		case K_TAB:
 		case K_KP_DOWNARROW:
+                    if (IN_NumpadIsOn() == true) { break; }
 		case K_DOWNARROW:
 		case K_DPAD_DOWN:
 			return K_DOWNARROW;
 
 		case K_KP_LEFTARROW:
+                    if (IN_NumpadIsOn() == true) { break; }
 		case K_LEFTARROW:
 		case K_DPAD_LEFT:
 		case K_SHOULDER_LEFT:
 			return K_LEFTARROW;
 
 		case K_KP_RIGHTARROW:
+                    if (IN_NumpadIsOn() == true) { break; }
 		case K_RIGHTARROW:
 		case K_DPAD_RIGHT:
 		case K_SHOULDER_RIGHT:
@@ -283,12 +287,18 @@ Key_GetMenuKey(int key)
 		case K_BACKSPACE:
 		case K_DEL:
 		case K_KP_DEL:
+                    if (IN_NumpadIsOn() == true) { break; }
 		case K_BTN_Y:
 			return K_BACKSPACE;
+                case K_KP_INS:
+                    if (IN_NumpadIsOn() == true) { break; }
+                case K_INS:
+                    return K_INS;
 	}
 
 	return key;
 }
+
 const char *
 Default_MenuKey(menuframework_s *m, int key)
 {

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -223,51 +223,31 @@ extern int keydown[];
 qboolean
 Field_Key(menufield_s *f, int key)
 {
-	switch (key)
-	{
-		case K_KP_SLASH:
-			key = '/';
-			break;
-		case K_KP_MINUS:
-			key = '-';
-			break;
-		case K_KP_PLUS:
-			key = '+';
-			break;
-		case K_KP_HOME:
-			key = '7';
-			break;
-		case K_KP_UPARROW:
-			key = '8';
-			break;
-		case K_KP_PGUP:
-			key = '9';
-			break;
-		case K_KP_LEFTARROW:
-			key = '4';
-			break;
-		case K_KP_5:
-			key = '5';
-			break;
-		case K_KP_RIGHTARROW:
-			key = '6';
-			break;
-		case K_KP_END:
-			key = '1';
-			break;
-		case K_KP_DOWNARROW:
-			key = '2';
-			break;
-		case K_KP_PGDN:
-			key = '3';
-			break;
-		case K_KP_INS:
-			key = '0';
-			break;
-		case K_KP_DEL:
-			key = '.';
-			break;
-	}
+    /*
+     * Ignore keypad in field to prevent duplicate
+     * entries through key presses processed as a
+     * normal char event and additionally as key
+     * event.
+     */
+    switch (key)
+    {
+        case K_KP_SLASH:
+        case K_KP_MINUS:
+        case K_KP_PLUS:
+        case K_KP_HOME:
+        case K_KP_UPARROW:
+        case K_KP_PGUP:
+        case K_KP_LEFTARROW:
+        case K_KP_5:
+        case K_KP_RIGHTARROW:
+        case K_KP_END:
+        case K_KP_DOWNARROW:
+        case K_KP_PGDN:
+        case K_KP_INS:
+        case K_KP_DEL:
+        default:
+            break;
+    }
 
 	if (key > 127)
 	{

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -223,79 +223,109 @@ extern int keydown[];
 qboolean
 Field_Key(menufield_s *f, int key)
 {
-    /*
-     * Ignore keypad in field to prevent duplicate
-     * entries through key presses processed as a
-     * normal char event and additionally as key
-     * event.
-     */
 	switch (key)
 	{
 		case K_KP_SLASH:
+			key = '/';
+			break;
 		case K_KP_MINUS:
+			key = '-';
+			break;
 		case K_KP_PLUS:
+			key = '+';
+			break;
 		case K_KP_HOME:
+			key = '7';
+			break;
 		case K_KP_UPARROW:
+			key = '8';
+			break;
 		case K_KP_PGUP:
+			key = '9';
+			break;
+		case K_KP_LEFTARROW:
+			key = '4';
+			break;
 		case K_KP_5:
+			key = '5';
+			break;
 		case K_KP_RIGHTARROW:
+			key = '6';
+			break;
 		case K_KP_END:
+			key = '1';
+			break;
 		case K_KP_DOWNARROW:
+			key = '2';
+			break;
 		case K_KP_PGDN:
+			key = '3';
+			break;
 		case K_KP_INS:
+			key = '0';
+			break;
 		case K_KP_DEL:
+			key = '.';
 			break;
 	}
 
-    if ((key == K_BACKSPACE) || (key == K_LEFTARROW) || (key == K_KP_LEFTARROW))
-    {
-        if (f->cursor > 0)
-        {
-            memmove(&f->buffer[f->cursor - 1], &f->buffer[f->cursor],
-                strlen(&f->buffer[f->cursor]) + 1);
-            f->cursor--;
+	if (key > 127)
+	{
+		return false;
+	}
 
-            if (f->visible_offset)
-            {
-                f->visible_offset--;
-            }
-        }
+	switch (key)
+	{
+		case K_KP_LEFTARROW:
+		case K_LEFTARROW:
+		case K_BACKSPACE:
 
-        return true;
-    }
+			if (f->cursor > 0)
+			{
+				memmove(&f->buffer[f->cursor - 1],
+						&f->buffer[f->cursor],
+						strlen(&f->buffer[f->cursor]) + 1);
+				f->cursor--;
 
-    if ((key == K_DEL) || (key == K_KP_DEL))
-    {
-        memmove(&f->buffer[f->cursor], &f->buffer[f->cursor + 1],
-            strlen(&f->buffer[f->cursor + 1]) + 1);
-        return true;
-    }
+				if (f->visible_offset)
+				{
+					f->visible_offset--;
+				}
+			}
 
-    if (key == K_ENTER || key == K_KP_ENTER || key == K_ESCAPE || key == K_TAB)
-    {
-        return false;
-    }
+			break;
 
-    if ((key < 32) || (key > 127))
-    {
-        return false;           /* non printable character */
-    }
+		case K_KP_DEL:
+		case K_DEL:
+			memmove(&f->buffer[f->cursor], &f->buffer[f->cursor + 1],
+				strlen(&f->buffer[f->cursor + 1]) + 1);
+			break;
 
-    if (!isdigit(key) && (f->generic.flags & QMF_NUMBERSONLY))
-    {
-        return false;
-    }
+		case K_KP_ENTER:
+		case K_ENTER:
+		case K_ESCAPE:
+		case K_TAB:
+			return false;
 
-    if (f->cursor < f->length)
-    {
-        f->buffer[f->cursor++] = key;
-        f->buffer[f->cursor] = 0;
+		case K_SPACE:
+		default:
 
-        if (f->cursor > f->visible_length)
-        {
-            f->visible_offset++;
-        }
-    }
+			if (!isdigit(key) && (f->generic.flags & QMF_NUMBERSONLY))
+			{
+				return false;
+			}
+
+			if (f->cursor < f->length)
+			{
+				f->buffer[f->cursor++] = key;
+				f->buffer[f->cursor] = 0;
+
+				if (f->cursor > f->visible_length)
+				{
+					f->visible_offset++;
+				}
+			}
+	}
 
 	return true;
 }

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -223,32 +223,6 @@ extern int keydown[];
 qboolean
 Field_Key(menufield_s *f, int key)
 {
-    /*
-     * Ignore keypad in field to prevent duplicate
-     * entries through key presses processed as a
-     * normal char event and additionally as key
-     * event.
-     */
-    switch (key)
-    {
-        case K_KP_SLASH:
-        case K_KP_MINUS:
-        case K_KP_PLUS:
-        case K_KP_HOME:
-        case K_KP_UPARROW:
-        case K_KP_PGUP:
-        case K_KP_LEFTARROW:
-        case K_KP_5:
-        case K_KP_RIGHTARROW:
-        case K_KP_END:
-        case K_KP_DOWNARROW:
-        case K_KP_PGDN:
-        case K_KP_INS:
-        case K_KP_DEL:
-        default:
-            break;
-    }
-
 	if (key > 127)
 	{
 		return false;


### PR DESCRIPTION
Fixes a bug where duplicate keyboard entries would occur in menu fields when using the keypad keys with num-lock on.
Menu fields now mirror behaviour of the console field.
Removed keypad left arrow case from console key ignore list.