### PR TITLE
Fixed gl1_overbrightbits limiter (for real now)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ endif
 # Highest supported optimizations are -O2, higher levels
 # will likely break this crappy code.
 ifdef DEBUG
-CFLAGS ?= -O0 -g -Wall -pipe
+CFLAGS ?= -O0 -g -Wall -pipe -DDEBUG
 ifdef ASAN
 override CFLAGS += -fsanitize=address -DUSE_SANITIZER
 endif

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -453,9 +453,8 @@ Set `0` by default.
 * **gl1_overbrightbits**: Enables overbright bits, brightness scaling of
   lightmaps and models. Higher values make shadows less dark. Possible
   values are `0` (no overbright bits), `1` (more correct lighting for
-  water), `2` (scale by factor 2), `3` (scale lighting by 3 only for the
-  dynamic meshes, like enemies and items), and `4` (scale lighting of
-  everything by 4). Applied in realtime, does not need `vid_restart`.
+  liquids), `2` (scale lighting by factor 2), and `4` (scale by factor
+  4). Applied in realtime, does not need `vid_restart`.
 
 * **gl1_particle_square**: If set to `1` particles are rendered as
   squares.

--- a/src/client/header/keyboard.h
+++ b/src/client/header/keyboard.h
@@ -220,8 +220,6 @@ enum QKEYS {
 	K_STICK_RIGHT,
 	K_SHOULDER_LEFT,
 	K_SHOULDER_RIGHT,
-	K_TRIG_LEFT,
-	K_TRIG_RIGHT,
 	K_DPAD_UP,
 	K_DPAD_DOWN,
 	K_DPAD_LEFT,
@@ -231,11 +229,13 @@ enum QKEYS {
 	K_PADDLE_2,
 	K_PADDLE_3,
 	K_PADDLE_4,
-	K_TOUCHPAD,
+	K_TOUCHPAD,	// SDL_CONTROLLER_BUTTON_MAX - 1
+	K_TRIG_LEFT,	// buttons for triggers (axes)
+	K_TRIG_RIGHT,
 
 	// add other joystick/controller keys before this one
 	// and adjust it accordingly, also remember to add corresponding _ALT key below!
-	K_JOY_LAST_REGULAR = K_TOUCHPAD,
+	K_JOY_LAST_REGULAR = K_TRIG_RIGHT,
 
 	/* Can't be mapped to any action (=> not regular) */
 	K_JOY_BACK,
@@ -252,8 +252,6 @@ enum QKEYS {
 	K_STICK_RIGHT_ALT,
 	K_SHOULDER_LEFT_ALT,
 	K_SHOULDER_RIGHT_ALT,
-	K_TRIG_LEFT_ALT,
-	K_TRIG_RIGHT_ALT,
 	K_DPAD_UP_ALT,
 	K_DPAD_DOWN_ALT,
 	K_DPAD_LEFT_ALT,
@@ -264,6 +262,8 @@ enum QKEYS {
 	K_PADDLE_3_ALT,
 	K_PADDLE_4_ALT,
 	K_TOUCHPAD_ALT,
+	K_TRIG_LEFT_ALT,
+	K_TRIG_RIGHT_ALT,
 
 	K_LAST
 };

--- a/src/client/input/sdl.c
+++ b/src/client/input/sdl.c
@@ -78,7 +78,7 @@ typedef enum
 // IN_Update() called at the beginning of a frame to the
 // actual movement functions called at a later time.
 static float mouse_x, mouse_y;
-static int sdl_back_button = SDL_CONTROLLER_BUTTON_BACK;
+static unsigned char sdl_back_button = SDL_CONTROLLER_BUTTON_BACK;
 static int joystick_left_x, joystick_left_y, joystick_right_x, joystick_right_y;
 static float gyro_yaw, gyro_pitch;
 static qboolean mlooking;
@@ -495,45 +495,6 @@ IN_TranslateScancodeToQ2Key(SDL_Scancode sc)
 	return 0;
 }
 
-static int
-IN_TranslateGamepadBtnToQ2Key(int btn)
-{
-
-#define MY_BTN_CASE(X,Y) case SDL_CONTROLLER_BUTTON_ ## X : return K_ ## Y;
-
-	switch( btn )
-	{
-		// case SDL_CONTROLLER_BUTTON_A : return K_BTN_A;
-		MY_BTN_CASE(A,BTN_A)
-		MY_BTN_CASE(B,BTN_B)
-		MY_BTN_CASE(X,BTN_X)
-		MY_BTN_CASE(Y,BTN_Y)
-		MY_BTN_CASE(LEFTSHOULDER,SHOULDER_LEFT)
-		MY_BTN_CASE(RIGHTSHOULDER,SHOULDER_RIGHT)
-		MY_BTN_CASE(LEFTSTICK,STICK_LEFT)
-		MY_BTN_CASE(RIGHTSTICK,STICK_RIGHT)
-		MY_BTN_CASE(DPAD_UP,DPAD_UP)
-		MY_BTN_CASE(DPAD_DOWN,DPAD_DOWN)
-		MY_BTN_CASE(DPAD_LEFT,DPAD_LEFT)
-		MY_BTN_CASE(DPAD_RIGHT,DPAD_RIGHT)
-#if SDL_VERSION_ATLEAST(2, 0, 14)	// support for newer buttons
-		MY_BTN_CASE(PADDLE1,PADDLE_1)
-		MY_BTN_CASE(PADDLE2,PADDLE_2)
-		MY_BTN_CASE(PADDLE3,PADDLE_3)
-		MY_BTN_CASE(PADDLE4,PADDLE_4)
-		MY_BTN_CASE(MISC1,BTN_MISC1)
-		MY_BTN_CASE(TOUCHPAD,TOUCHPAD)
-#endif
-		MY_BTN_CASE(BACK,BTN_BACK)
-		MY_BTN_CASE(GUIDE,BTN_GUIDE)
-		MY_BTN_CASE(START,BTN_START)
-	}
-
-#undef MY_BTN_CASE
-
-	return 0;
-}
-
 static void IN_Controller_Init(qboolean notify_user);
 static void IN_Controller_Shutdown(qboolean notify_user);
 
@@ -763,20 +724,16 @@ IN_Update(void)
 			case SDL_CONTROLLERBUTTONDOWN:
 			{
 				qboolean down = (event.type == SDL_CONTROLLERBUTTONDOWN);
+				unsigned char btn = event.cbutton.button;
 
 				// Handle Back Button first, to override its original key
-				if (event.cbutton.button == sdl_back_button)
+				if (btn == sdl_back_button)
 				{
 					Key_Event(K_JOY_BACK, down, true);
 					break;
 				}
 
-				key = IN_TranslateGamepadBtnToQ2Key(event.cbutton.button);
-				if(key != 0)
-				{
-					Key_Event(key, down, true);
-				}
-
+				Key_Event(K_BTN_A + btn, down, true);
 				break;
 			}
 

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -582,7 +582,7 @@ VID_MenuInit(void)
 		s_gl1_overbrightbits_slider.generic.y = (y += 10);
 		s_gl1_overbrightbits_slider.cvar = "gl1_overbrightbits";
 		s_gl1_overbrightbits_slider.minvalue = 0;
-		s_gl1_overbrightbits_slider.maxvalue = 3;
+		s_gl1_overbrightbits_slider.maxvalue = 2;
 		s_gl1_overbrightbits_slider.slidestep = 1;
 		s_gl1_overbrightbits_slider.printformat = "%.0f";
 

--- a/src/client/refresh/gl1/gl1_image.c
+++ b/src/client/refresh/gl1/gl1_image.c
@@ -559,11 +559,11 @@ R_Upload32Native(unsigned *data, int width, int height, qboolean mipmap)
 			break;
 		}
 	}
-    glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, mipmap);
+	glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, mipmap);
 	glTexImage2D(GL_TEXTURE_2D, 0, comp, width,
 			height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
 			data);
-    glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, false);
+	glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, false);
 	return samples == gl_alpha_format;
 }
 

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -1405,6 +1405,10 @@ RI_Init(void)
 	R_Printf(PRINT_ALL, "Refresh: " REF_VERSION "\n");
 	R_Printf(PRINT_ALL, "Client: " YQ2VERSION "\n\n");
 
+#ifdef DEBUG
+	R_Printf(PRINT_ALL, "ref_gl1::R_Init() - DEBUG mode enabled\n");
+#endif
+
 	GetPCXPalette (&colormap, d_8to24table);
 	free(colormap);
 
@@ -1981,3 +1985,32 @@ Com_Printf(const char *msg, ...)
 	ri.Com_VPrintf(PRINT_ALL, msg, argptr);
 	va_end(argptr);
 }
+
+#ifdef DEBUG
+void
+glCheckError_(const char *file, const char *function, int line)
+{
+	GLenum errorCode;
+	const char * msg;
+
+#define MY_ERROR_CASE(X) case X : msg = #X; break;
+
+	while ((errorCode = glGetError()) != GL_NO_ERROR)
+	{
+		switch(errorCode)
+		{
+			MY_ERROR_CASE(GL_INVALID_ENUM);
+			MY_ERROR_CASE(GL_INVALID_VALUE);
+			MY_ERROR_CASE(GL_INVALID_OPERATION);
+			MY_ERROR_CASE(GL_STACK_OVERFLOW);
+			MY_ERROR_CASE(GL_STACK_UNDERFLOW);
+			MY_ERROR_CASE(GL_OUT_OF_MEMORY);
+			default: msg = "UNKNOWN";
+		}
+		R_Printf(PRINT_ALL, "glError: %s in %s (%s, %d)\n", msg, function, file, line);
+	}
+
+#undef MY_ERROR_CASE
+
+}
+#endif

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -1620,15 +1620,22 @@ RI_BeginFrame(float camera_separation)
 	// Clamp overbrightbits
 	if (gl1_overbrightbits->modified)
 	{
-		if (gl1_overbrightbits->value < 0)
+		int obb_val = (int)gl1_overbrightbits->value;
+
+		if (obb_val < 0)
 		{
-			ri.Cvar_Set("gl1_overbrightbits", "0");
+			obb_val = 0;
 		}
-		else if (gl1_overbrightbits->value > 4)
+		else if (obb_val == 3)
 		{
-			ri.Cvar_Set("gl1_overbrightbits", "4");
+			obb_val = 2;
+		}
+		else if (obb_val > 4)
+		{
+			obb_val = 4;
 		}
 
+		ri.Cvar_SetValue("gl1_overbrightbits", obb_val);
 		gl1_overbrightbits->modified = false;
 	}
 

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -303,6 +303,55 @@ void R_TextureAlphaMode(char *string);
 void R_TextureSolidMode(char *string);
 int Scrap_AllocBlock(int w, int h, int *x, int *y);
 
+#ifdef DEBUG
+void glCheckError_(const char *file, const char *function, int line);
+// Ideally, the following list should contain all OpenGL calls.
+// Either way, errors are caught, since error flags are persisted until the next glGetError() call.
+// So they show, even if the location of the error is inaccurate.
+#define glDrawArrays(...) glDrawArrays(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glTexImage2D(...) glTexImage2D(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glTexSubImage2D(...) glTexSubImage2D(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glTexEnvf(...) glTexEnvf(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glTexEnvi(...) glTexEnvi(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glVertexPointer(...) glVertexPointer(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glTexCoordPointer(...) glTexCoordPointer(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glColorPointer(...) glColorPointer(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glTexParameteri(...) glTexParameteri(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glBindTexture(...) glBindTexture(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glFrustum(...) glFrustum(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glTranslatef(...) glTranslatef(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glRotatef(...) glRotatef(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glScalef(...) glScalef(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glScissor(...) glScissor(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glBlendFunc(...) glBlendFunc(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glDepthFunc(...) glDepthFunc(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glDepthMask(...) glDepthMask(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glDepthRange(...) glDepthRange(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glEnable(...) glEnable(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glDisable(...) glDisable(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glEnableClientState(...) glEnableClientState(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glDisableClientState(...) glDisableClientState(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glPushMatrix(...) glPushMatrix(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glPopMatrix(...) glPopMatrix(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glMatrixMode(...) glMatrixMode(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glOrtho(...) glOrtho(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glColorMask(...) glColorMask(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glStencilOp(...) glStencilOp(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glStencilFunc(...) glStencilFunc(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glDrawBuffer(...) glDrawBuffer(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glReadPixels(...) glReadPixels(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glClear(...) glClear(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glClearColor(...) glClearColor(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glClearStencil(...) glClearStencil(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glDeleteTextures(...) glDeleteTextures(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glFinish() glFinish(); glCheckError_(__FILE__, __func__, __LINE__)
+#define glAlphaFunc(...) glAlphaFunc(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glHint(...) glHint(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glLoadIdentity() glLoadIdentity(); glCheckError_(__FILE__, __func__, __LINE__)
+#define glBegin(...) glBegin(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glEnd() glEnd(); glCheckError_(__FILE__, __func__, __LINE__)
+#endif
+
 /* GL extension emulation functions */
 void R_DrawParticles2(int n,
 		const particle_t particles[],


### PR DESCRIPTION
Allowed values are now `0`, `1`, `2` and `4` only, since values like "3" and "0.5" generate OpenGL errors.

About the latter, these errors can finally be visible, by using the only supported method on old OpenGL: by calling `glGetError()` manually.
We do not have available something like `glDebugMessageCallbackARB` here, so by using some preprocessor magic we call `glGetError()` after every OpenGL function. Because of the ridiculous overhead this produces, this is only available when compiling with `DEBUG=1`.
At least, now there's a practical way to see if something's wrong with OpenGL 1.

This is based on the first method described here:
https://learnopengl.com/In-Practice/Debugging
You can test it by commenting the `gl1_overbrightbits` validator of the second commit, and set it to "3", "0.7", "8" or any other wrong value.

Now, the only issue remaining is that the GL1 "overbrightbits" slider in the video options is limited from 0 to 2.
That's because the new validator will avoid setting it to `3`, which means its maximum value of `4` can never be reached.
Typing it in console (or a script) is the only way to get it to `4` now.

This fixes #1080.

P.S.: just as an extra, gamepad buttons are read in a more succinct, efficient manner now.