### PR TITLE
Add a player speed display (speedometer) as an optional feature

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -43,6 +43,7 @@ cvar_t *cl_footsteps;
 cvar_t *cl_timeout;
 cvar_t *cl_predict;
 cvar_t *cl_showfps;
+cvar_t *cl_showspeed;
 cvar_t *cl_gun;
 cvar_t *cl_add_particles;
 cvar_t *cl_add_lights;
@@ -513,6 +514,7 @@ CL_InitLocal(void)
 	cl_noskins = Cvar_Get("cl_noskins", "0", 0);
 	cl_predict = Cvar_Get("cl_predict", "1", 0);
 	cl_showfps = Cvar_Get("cl_showfps", "0", CVAR_ARCHIVE);
+	cl_showspeed = Cvar_Get("cl_showspeed", "0", CVAR_ARCHIVE);	
 
 	cl_upspeed = Cvar_Get("cl_upspeed", "200", 0);
 	cl_forwardspeed = Cvar_Get("cl_forwardspeed", "200", 0);

--- a/src/client/cl_screen.c
+++ b/src/client/cl_screen.c
@@ -66,6 +66,8 @@ int crosshair_width, crosshair_height;
 
 extern cvar_t *cl_showfps;
 extern cvar_t *crosshair_scale;
+extern cvar_t *cl_showspeed;
+extern float GetPlayerSpeed(); 
 
 void SCR_TimeRefresh_f(void);
 void SCR_Loading_f(void);
@@ -1447,6 +1449,32 @@ SCR_DrawLayout(void)
 
 // ----
 
+void 
+SCR_DrawSpeed(void) {
+	if (cl_showspeed->value < 1)
+		return;
+	float speed, speedxy;  // speed, horizontal ground speed
+	GetPlayerSpeed(&speed, &speedxy);
+
+	// Assuming viddef.width is the width of the screen
+	float scale = SCR_GetConsoleScale();
+	char str[64]; 
+	snprintf(str, sizeof(str), "Speed: %7.2f (%7.2f) QU/s", speed, speedxy);
+
+	int yPos = 0;
+	// If showfps is on, position the speedometer underneath it
+	if (cl_showfps->value == 1 || cl_showfps->value == 2)
+		yPos = scale * 10;
+	if (cl_showfps->value > 2)
+		yPos = scale * 20;
+
+	DrawStringScaled(viddef.width - scale * (strlen(str) * 8 + 2), yPos, str, scale);
+	//Unsure if these are necessary
+	SCR_AddDirtyPoint(viddef.width - scale * (strlen(str) * 8 + 2), yPos); 
+	SCR_AddDirtyPoint(viddef.width, yPos);
+}
+
+
 void
 SCR_Framecounter(void) {
 	long long newtime;
@@ -1684,6 +1712,7 @@ SCR_UpdateScreen(void)
 	}
 
 	SCR_Framecounter();
+	SCR_DrawSpeed();
 	R_EndFrame();
 }
 

--- a/src/common/pmove.c
+++ b/src/common/pmove.c
@@ -341,6 +341,12 @@ PM_Friction(void)
 	vel[2] = vel[2] * newspeed;
 }
 
+//Used for speedoomter display.
+void GetPlayerSpeed(float* speed, float* speedxy) {
+	*speedxy = sqrt(pml.velocity[0] * pml.velocity[0] + pml.velocity[1] * pml.velocity[1]);
+	*speed = VectorLength(pml.velocity);
+}
+
 /*
  * Handles user intended acceleration
  */


### PR DESCRIPTION
Added a player speed display that prints the players speed and ground speed at the top right corner.  The function can be toggled on using cl_showspeed 1.

I wasn't quite sure how to implement it without adding GetPlayerSpeed() to pmove.c.  I'm unsure if there is a cleaner way to do this without accessing pmove.c while keeping it inside cl_screen.c.  I also wasn't sure if the SCR_AddDirtyPoint() calls were necessary inside of SCR_DrawSpeed(), it seemed to work fine without them but decided to err on the side of caution in the case that it aids performance.