### PR TITLE
Rename functions r_dlightframecount parameter to lightframecount

### DIFF
--- a/src/client/refresh/files/surf.c
+++ b/src/client/refresh/files/surf.c
@@ -80,7 +80,7 @@ if surface is affected by this light
 =============
 */
 void
-R_MarkLights(dlight_t *light, int bit, mnode_t *node, int r_dlightframecount,
+R_MarkLights(dlight_t *light, int bit, mnode_t *node, int lightframecount,
 	marksurfacelights_t mark_surface_lights)
 {
 	cplane_t	*splitplane;
@@ -97,23 +97,23 @@ R_MarkLights(dlight_t *light, int bit, mnode_t *node, int r_dlightframecount,
 
 	if (dist > intensity - DLIGHT_CUTOFF)	// (dist > light->intensity)
 	{
-		R_MarkLights (light, bit, node->children[0], r_dlightframecount,
+		R_MarkLights (light, bit, node->children[0], lightframecount,
 			mark_surface_lights);
 		return;
 	}
 
 	if (dist < -intensity + DLIGHT_CUTOFF)	// (dist < -light->intensity)
 	{
-		R_MarkLights(light, bit, node->children[1], r_dlightframecount,
+		R_MarkLights(light, bit, node->children[1], lightframecount,
 			mark_surface_lights);
 		return;
 	}
 
-	mark_surface_lights(light, bit, node, r_dlightframecount);
+	mark_surface_lights(light, bit, node, lightframecount);
 
-	R_MarkLights(light, bit, node->children[0], r_dlightframecount,
+	R_MarkLights(light, bit, node->children[0], lightframecount,
 		mark_surface_lights);
-	R_MarkLights(light, bit, node->children[1], r_dlightframecount,
+	R_MarkLights(light, bit, node->children[1], lightframecount,
 		mark_surface_lights);
 }
 

--- a/src/client/refresh/gl1/gl1_light.c
+++ b/src/client/refresh/gl1/gl1_light.c
@@ -119,7 +119,7 @@ R_RenderDlights(void)
 }
 
 void
-R_MarkSurfaceLights(dlight_t *light, int bit, mnode_t *node, int r_dlightframecount)
+R_MarkSurfaceLights(dlight_t *light, int bit, mnode_t *node, int lightframecount)
 {
 	msurface_t	*surf;
 	int			i;
@@ -148,10 +148,10 @@ R_MarkSurfaceLights(dlight_t *light, int bit, mnode_t *node, int r_dlightframeco
 			continue;
 		}
 
-		if (surf->dlightframe != r_dlightframecount)
+		if (surf->dlightframe != lightframecount)
 		{
 			surf->dlightbits = 0;
-			surf->dlightframe = r_dlightframecount;
+			surf->dlightframe = lightframecount;
 		}
 
 		surf->dlightbits |= bit;

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -279,7 +279,7 @@ void R_AddSkySurface(msurface_t *fa);
 void R_ClearSkyBox(void);
 void R_DrawSkyBox(void);
 void R_MarkSurfaceLights(dlight_t *light, int bit, mnode_t *node,
-	int r_dlightframecount);
+	int lightframecount);
 
 void COM_StripExtension(char *in, char *out);
 

--- a/src/client/refresh/ref_shared.h
+++ b/src/client/refresh/ref_shared.h
@@ -213,8 +213,8 @@ extern mleaf_t *Mod_PointInLeaf(const vec3_t p, mnode_t *node);
 #define DLIGHT_CUTOFF 64
 
 typedef void (*marksurfacelights_t)(dlight_t *light, int bit, mnode_t *node,
-	int r_dlightframecount);
-extern void R_MarkLights (dlight_t *light, int bit, mnode_t *node, int r_dlightframecount,
+	int lightframecount);
+extern void R_MarkLights(dlight_t *light, int bit, mnode_t *node, int lightframecount,
 	marksurfacelights_t mark_surface_lights);
 extern struct image_s *R_TextureAnimation(const entity_t *currententity,
 	const mtexinfo_t *tex);

--- a/src/client/refresh/soft/sw_light.c
+++ b/src/client/refresh/soft/sw_light.c
@@ -30,7 +30,7 @@ DYNAMIC LIGHTS
 */
 
 static void
-R_MarkSurfaceLights(dlight_t *light, int bit, mnode_t *node, int r_dlightframecount)
+R_MarkSurfaceLights(dlight_t *light, int bit, mnode_t *node, int lightframecount)
 {
 	msurface_t	*surf;
 	int			i;
@@ -39,10 +39,10 @@ R_MarkSurfaceLights(dlight_t *light, int bit, mnode_t *node, int r_dlightframeco
 	surf = r_worldmodel->surfaces + node->firstsurface;
 	for (i = 0; i < node->numsurfaces; i++, surf++)
 	{
-		if (surf->dlightframe != r_dlightframecount)
+		if (surf->dlightframe != lightframecount)
 		{
 			surf->dlightbits = 0;
-			surf->dlightframe = r_dlightframecount;
+			surf->dlightframe = lightframecount;
 		}
 		surf->dlightbits |= bit;
 	}


### PR DESCRIPTION
Renders has global variable with the such name that used as parameters for R_MarkLights shared function.

Found by @BraXi 

Fixes:
 * https://github.com/yquake2/yquake2remaster/issues/17
 * https://github.com/yquake2/yquake2/issues/1093