### PR TITLE
GL1 multitexture

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -464,6 +464,12 @@ Set `0` by default.
   value, at least `1.0` - default is `2.0`. Applied when textures are
   loaded, so it needs a `vid_restart`.
 
+* **gl1_multitexture**: Enables (`1`) the blending of color and light
+  textures on a single drawing pass; disabling this (`0`) does one pass
+  for color and another for light. Default is `2`, which also enables
+  texture combine mode (`GL_ARB_texture_env_combine`) when supported.
+  Requires a `vid_restart` when changed.
+
 * **gl1_overbrightbits**: Enables overbright bits, brightness scaling of
   lightmaps and models. Higher values make shadows less dark. Possible
   values are `0` (no overbright bits), `1` (more correct lighting for

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -164,6 +164,7 @@ R_DrawSpriteModel(entity_t *currententity, const model_t *currentmodel)
 	dsprite_t *psprite;
 	image_t *skin;
 
+	R_EnableMultitexture(false);
 	/* don't even bother culling, because it's just
 	   a single polygon without a surface cache */
 	psprite = (dsprite_t *)currentmodel->extradata;

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -1468,17 +1468,29 @@ RI_Init(void)
 	/* Point parameters */
 	R_Printf(PRINT_ALL, " - Point parameters: ");
 
-	if (strstr(gl_config.extensions_string, "GL_ARB_point_parameters"))
+	if ( strstr(gl_config.extensions_string, "GL_ARB_point_parameters") ||
+		strstr(gl_config.extensions_string, "GL_EXT_point_parameters") )	// should exist for all OGL 1.4 hw...
 	{
-			qglPointParameterfARB = (void (APIENTRY *)(GLenum, GLfloat))RI_GetProcAddress ( "glPointParameterfARB" );
-			qglPointParameterfvARB = (void (APIENTRY *)(GLenum, const GLfloat *))RI_GetProcAddress ( "glPointParameterfvARB" );
+		qglPointParameterf = (void (APIENTRY *)(GLenum, GLfloat))RI_GetProcAddress ( "glPointParameterf" );
+		qglPointParameterfv = (void (APIENTRY *)(GLenum, const GLfloat *))RI_GetProcAddress ( "glPointParameterfv" );
+
+		if (!qglPointParameterf || !qglPointParameterfv)
+		{
+			qglPointParameterf = (void (APIENTRY *)(GLenum, GLfloat))RI_GetProcAddress ( "glPointParameterfARB" );
+			qglPointParameterfv = (void (APIENTRY *)(GLenum, const GLfloat *))RI_GetProcAddress ( "glPointParameterfvARB" );
+		}
+		if (!qglPointParameterf || !qglPointParameterfv)
+		{
+			qglPointParameterf = (void (APIENTRY *)(GLenum, GLfloat))RI_GetProcAddress ( "glPointParameterfEXT" );
+			qglPointParameterfv = (void (APIENTRY *)(GLenum, const GLfloat *))RI_GetProcAddress ( "glPointParameterfvEXT" );
+		}
 	}
 
 	gl_config.pointparameters = false;
 
 	if (gl1_pointparameters->value)
 	{
-		if (qglPointParameterfARB && qglPointParameterfvARB)
+		if (qglPointParameterf && qglPointParameterfv)
 		{
 			gl_config.pointparameters = true;
 			R_Printf(PRINT_ALL, "Okay\n");

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -90,6 +90,7 @@ cvar_t *gl1_particle_square;
 
 cvar_t *gl1_palettedtexture;
 cvar_t *gl1_pointparameters;
+cvar_t *gl1_multitexture;
 
 cvar_t *gl_drawbuffer;
 cvar_t *gl_lightmap;
@@ -1211,6 +1212,7 @@ R_Register(void)
 
 	gl1_palettedtexture = ri.Cvar_Get("r_palettedtextures", "0", CVAR_ARCHIVE);
 	gl1_pointparameters = ri.Cvar_Get("gl1_pointparameters", "1", CVAR_ARCHIVE);
+	gl1_multitexture = ri.Cvar_Get("gl1_multitexture", "2", CVAR_ARCHIVE);
 
 	gl_drawbuffer = ri.Cvar_Get("gl_drawbuffer", "GL_BACK", 0);
 	r_vsync = ri.Cvar_Get("r_vsync", "1", CVAR_ARCHIVE);
@@ -1569,6 +1571,65 @@ RI_Init(void)
 	else
 	{
 		gl_config.npottextures = false;
+		R_Printf(PRINT_ALL, "Failed\n");
+	}
+
+	// ----
+
+	/* Multitexturing */
+	gl_config.multitexture = gl_config.mtexcombine = false;
+
+	R_Printf(PRINT_ALL, " - Multitexturing: ");
+
+	if (strstr(gl_config.extensions_string, "GL_ARB_multitexture"))
+	{
+		qglActiveTexture = (void (APIENTRY *)(GLenum))RI_GetProcAddress ("glActiveTexture");
+		qglClientActiveTexture = (void (APIENTRY *)(GLenum))RI_GetProcAddress ("glClientActiveTexture");
+
+		if (!qglActiveTexture || !qglClientActiveTexture)
+		{
+			qglActiveTexture = (void (APIENTRY *)(GLenum))RI_GetProcAddress ("glActiveTextureARB");
+			qglClientActiveTexture = (void (APIENTRY *)(GLenum))RI_GetProcAddress ("glClientActiveTextureARB");
+		}
+	}
+
+	if (gl1_multitexture->value)
+	{
+		if (qglActiveTexture && qglClientActiveTexture)
+		{
+			gl_config.multitexture = true;
+			R_Printf(PRINT_ALL, "Okay\n");
+		}
+		else
+		{
+			R_Printf(PRINT_ALL, "Failed\n");
+		}
+	}
+	else
+	{
+		R_Printf(PRINT_ALL, "Disabled\n");
+	}
+
+	// ----
+
+	/* Multi texturing combine */
+	R_Printf(PRINT_ALL, " - Multitexturing combine: ");
+
+	if ( ( strstr(gl_config.extensions_string, "GL_ARB_texture_env_combine")
+		|| strstr(gl_config.extensions_string, "GL_EXT_texture_env_combine") ) )
+	{
+		if (gl_config.multitexture && gl1_multitexture->value > 1)
+		{
+			gl_config.mtexcombine = true;
+			R_Printf(PRINT_ALL, "Okay\n");
+		}
+		else
+		{
+			R_Printf(PRINT_ALL, "Disabled\n");
+		}
+	}
+	else
+	{
 		R_Printf(PRINT_ALL, "Failed\n");
 	}
 

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -144,6 +144,8 @@ cvar_t *gl1_stereo_convergence;
 
 refimport_t ri;
 
+void LM_FreeLightmapBuffers(void);
+
 void
 R_RotateForEntity(entity_t *e)
 {
@@ -261,6 +263,7 @@ R_DrawNullModel(entity_t *currententity)
 		R_LightPoint(currententity, currententity->origin, shadelight);
 	}
 
+	R_EnableMultitexture(false);
 	glPushMatrix();
 	R_RotateForEntity(currententity);
 
@@ -1654,6 +1657,7 @@ RI_Shutdown(void)
 	ri.Cmd_RemoveCommand("imagelist");
 	ri.Cmd_RemoveCommand("gl_strings");
 
+	LM_FreeLightmapBuffers();
 	Mod_FreeAll();
 
 	R_ShutdownImages();
@@ -1909,6 +1913,7 @@ R_DrawBeam(entity_t *e)
 		VectorAdd(start_points[i], direction, end_points[i]);
 	}
 
+	R_EnableMultitexture(false);
 	glDisable(GL_TEXTURE_2D);
 	glEnable(GL_BLEND);
 	glDepthMask(GL_FALSE);

--- a/src/client/refresh/gl1/gl1_mesh.c
+++ b/src/client/refresh/gl1/gl1_mesh.c
@@ -557,6 +557,7 @@ R_DrawAliasModel(entity_t *currententity, const model_t *currentmodel)
 		}
 	}
 
+	R_EnableMultitexture(false);
 	paliashdr = (dmdl_t *)currentmodel->extradata;
 
 	/* get lighting information */

--- a/src/client/refresh/gl1/gl1_misc.c
+++ b/src/client/refresh/gl1/gl1_misc.c
@@ -208,9 +208,9 @@ R_SetDefaultState(void)
 		attenuations[1] = gl1_particle_att_b->value;
 		attenuations[2] = gl1_particle_att_c->value;
 
-		qglPointParameterfARB(GL_POINT_SIZE_MIN_EXT, gl1_particle_min_size->value);
-		qglPointParameterfARB(GL_POINT_SIZE_MAX_EXT, gl1_particle_max_size->value);
-		qglPointParameterfvARB(GL_DISTANCE_ATTENUATION_EXT, attenuations);
+		qglPointParameterf(GL_POINT_SIZE_MIN, gl1_particle_min_size->value);
+		qglPointParameterf(GL_POINT_SIZE_MAX, gl1_particle_max_size->value);
+		qglPointParameterfv(GL_POINT_DISTANCE_ATTENUATION, attenuations);
 
 		/* GL_POINT_SMOOTH is not implemented by some OpenGL
 		   drivers, especially the crappy Mesa3D backends like

--- a/src/client/refresh/gl1/gl1_sdl.c
+++ b/src/client/refresh/gl1/gl1_sdl.c
@@ -33,12 +33,6 @@
 #include <SDL2/SDL.h>
 #endif
 
-#if defined(__APPLE__)
-#include <OpenGL/gl.h>
-#else
-#include <GL/gl.h>
-#endif
-
 static SDL_Window* window = NULL;
 static SDL_GLContext context = NULL;
 qboolean IsHighDPIaware = false;

--- a/src/client/refresh/gl1/gl1_surf.c
+++ b/src/client/refresh/gl1/gl1_surf.c
@@ -762,8 +762,6 @@ R_DrawBrushModel(entity_t *currententity, const model_t *currentmodel)
 	currententity->angles[0] = -currententity->angles[0];
 	currententity->angles[2] = -currententity->angles[2];
 
-	R_TexEnv(GL_REPLACE);
-
 	if (gl_lightmap->value)
 	{
 		R_TexEnv(GL_REPLACE);

--- a/src/client/refresh/gl1/gl1_surf.c
+++ b/src/client/refresh/gl1/gl1_surf.c
@@ -238,13 +238,8 @@ R_BlendLightmaps(const model_t *currentmodel)
 	int i;
 	msurface_t *surf, *newdrawsurf = 0;
 
-	/* don't bother if we're set to fullbright */
-	if (r_fullbright->value)
-	{
-		return;
-	}
-
-	if (!r_worldmodel->lightdata)
+	/* don't bother if we're set to fullbright or multitexture is enabled */
+	if (gl_config.multitexture || r_fullbright->value || !r_worldmodel->lightdata)
 	{
 		return;
 	}
@@ -466,6 +461,11 @@ R_RenderBrushPoly(entity_t *currententity, msurface_t *fa)
 		R_DrawGLPoly(fa->polys);
 	}
 
+	if (gl_config.multitexture)
+	{
+		return;	// lighting already done at this point for mtex
+	}
+
 	/* check for lightmap modification */
 	for (maps = 0; maps < MAXLIGHTMAPS && fa->styles[maps] != 255; maps++)
 	{
@@ -589,6 +589,149 @@ R_DrawAlphaSurfaces(void)
 	r_alpha_surfaces = NULL;
 }
 
+static qboolean
+R_HasDynamicLights(msurface_t *surf, int *mapNum)
+{
+	int map;
+	qboolean is_dynamic = false;
+
+	if ( r_fullbright->value || !gl1_dynamic->value ||
+		(surf->texinfo->flags & (SURF_SKY | SURF_TRANS33 | SURF_TRANS66 | SURF_WARP)) )
+	{
+		return false;
+	}
+
+	// Any dynamic lights on this surface?
+	for (map = 0; map < MAXLIGHTMAPS && surf->styles[map] != 255; map++)
+	{
+		if (r_newrefdef.lightstyles[surf->styles[map]].white != surf->cached_light[map])
+		{
+			is_dynamic = true;
+			break;
+		}
+	}
+
+	if ( !is_dynamic && surf->dlightframe == r_framecount )
+	{
+		is_dynamic = true;
+	}
+
+	if (mapNum)
+	{
+		*mapNum = map;
+	}
+	return is_dynamic;
+}
+
+static void
+R_RenderLightmappedPoly(entity_t *currententity, msurface_t *surf)
+{
+	int i, map, smax, tmax;
+	int nv = surf->polys->numverts;
+	float scroll;
+	float *v;
+	unsigned lmtex = surf->lightmaptexturenum;
+	unsigned temp[128 * 128];
+
+	if ( R_HasDynamicLights(surf, &map) )
+	{
+		smax = (surf->extents[0] >> 4) + 1;
+		tmax = (surf->extents[1] >> 4) + 1;
+		R_BuildLightMap(surf, (void *) temp, smax * 4);
+
+		// Dynamic lights on a surface
+		if (((surf->styles[map] >= 32) || (surf->styles[map] == 0)) && (surf->dlightframe != r_framecount))
+		{
+			R_SetCacheState(surf);
+		}
+		else // Normal dynamic lights
+		{
+			lmtex = 0;
+		}
+
+		R_MBind(GL_TEXTURE1, gl_state.lightmap_textures + lmtex);
+		glTexSubImage2D(GL_TEXTURE_2D, 0, surf->light_s, surf->light_t, smax,
+						tmax, GL_LIGHTMAP_FORMAT, GL_UNSIGNED_BYTE, temp);
+	}
+	else
+	{
+		R_MBind(GL_TEXTURE1, gl_state.lightmap_textures + lmtex);
+	}
+
+	// Apply overbrightbits to TMU 1 (lightmap)
+	if (gl1_overbrightbits->value)
+	{
+		R_TexEnv(GL_COMBINE);
+		glTexEnvi(GL_TEXTURE_ENV, GL_RGB_SCALE, gl1_overbrightbits->value);
+	}
+
+	c_brush_polys++;
+	v = surf->polys->verts[0];
+
+	if (surf->texinfo->flags & SURF_FLOWING)
+	{
+		scroll = -64 * ((r_newrefdef.time / 40.0) - (int) (r_newrefdef.time / 40.0));
+
+		if (scroll == 0.0)
+		{
+			scroll = -64.0;
+		}
+
+		YQ2_VLA(GLfloat, tex, 4 * nv);
+		unsigned int index_tex = 0;
+
+		for (i = 0; i < nv; i++, v += VERTEXSIZE)
+		{
+			tex[index_tex++] = v[3] + scroll;
+			tex[index_tex++] = v[4];
+			tex[index_tex++] = v[5];
+			tex[index_tex++] = v[6];
+		}
+		v = surf->polys->verts[0];
+
+		// Polygon
+		glEnableClientState(GL_VERTEX_ARRAY);
+		glVertexPointer(3, GL_FLOAT, VERTEXSIZE * sizeof(GLfloat), v);
+
+		// Texture
+		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+		qglClientActiveTexture(GL_TEXTURE0);
+		glTexCoordPointer(2, GL_FLOAT, 4 * sizeof(GLfloat), tex);
+
+		// Lightmap
+		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+		qglClientActiveTexture(GL_TEXTURE1);
+		glTexCoordPointer(2, GL_FLOAT, 4 * sizeof(GLfloat), tex + 2);
+
+		// Draw the thing
+		glDrawArrays(GL_TRIANGLE_FAN, 0, nv);
+
+		YQ2_VLAFREE(tex);
+	}
+	else
+	{
+		// Polygon
+		glEnableClientState(GL_VERTEX_ARRAY);
+		glVertexPointer(3, GL_FLOAT, VERTEXSIZE * sizeof(GLfloat), v);
+
+		// Texture
+		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+		qglClientActiveTexture(GL_TEXTURE0);
+		glTexCoordPointer(2, GL_FLOAT, VERTEXSIZE * sizeof(GLfloat), v + 3);
+
+		// Lightmap
+		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+		qglClientActiveTexture(GL_TEXTURE1);
+		glTexCoordPointer(2, GL_FLOAT, VERTEXSIZE * sizeof(GLfloat), v + 5);
+
+		// Draw it
+		glDrawArrays(GL_TRIANGLE_FAN, 0, nv);
+	}
+
+	glDisableClientState(GL_VERTEX_ARRAY);
+	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+}
+
 static void
 R_DrawTextureChains(entity_t *currententity)
 {
@@ -598,32 +741,78 @@ R_DrawTextureChains(entity_t *currententity)
 
 	c_visible_textures = 0;
 
-	for (i = 0, image = gltextures; i < numgltextures; i++, image++)
+	if (!gl_config.multitexture)	// classic path
 	{
-		if (!image->registration_sequence)
+		for (i = 0, image = gltextures; i < numgltextures; i++, image++)
 		{
-			continue;
+			if (!image->registration_sequence)
+			{
+				continue;
+			}
+
+			s = image->texturechain;
+
+			if (!s)
+			{
+				continue;
+			}
+
+			c_visible_textures++;
+
+			for ( ; s; s = s->texturechain)
+			{
+				R_Bind(image->texnum);  // may reset because of dynamic lighting in R_RenderBrushPoly
+				R_RenderBrushPoly(currententity, s);
+			}
+
+			image->texturechain = NULL;
 		}
-
-		s = image->texturechain;
-
-		if (!s)
-		{
-			continue;
-		}
-
-		c_visible_textures++;
-
-		for ( ; s; s = s->texturechain)
-		{
-			R_Bind(image->texnum);  // may reset because of dynamic lighting in R_RenderBrushPoly
-			R_RenderBrushPoly(currententity, s);
-		}
-
-		image->texturechain = NULL;
 	}
+	else	// multitexture
+	{
+		R_EnableMultitexture(true);
 
-	R_TexEnv(GL_REPLACE);
+		for (i = 0, image = gltextures; i < numgltextures; i++, image++)
+		{
+			if (!image->registration_sequence || !image->texturechain)
+			{
+				continue;
+			}
+
+			R_MBind(GL_TEXTURE0, image->texnum);	// setting it only once
+			c_visible_textures++;
+
+			for (s = image->texturechain; s; s = s->texturechain)
+			{
+				if (!(s->flags & SURF_DRAWTURB))
+				{
+					R_RenderLightmappedPoly(currententity, s);
+				}
+			}
+		}
+
+		R_EnableMultitexture(false);
+
+		for (i = 0, image = gltextures; i < numgltextures; i++, image++)
+		{
+			if (!image->registration_sequence || !image->texturechain)
+			{
+				continue;
+			}
+
+			R_Bind(image->texnum);	// no danger of resetting in R_RenderBrushPoly
+
+			for (s = image->texturechain; s; s = s->texturechain)
+			{
+				if (s->flags & SURF_DRAWTURB)
+				{
+					R_RenderBrushPoly(currententity, s);
+				}
+			}
+
+			image->texturechain = NULL;
+		}
+	}
 }
 
 static void
@@ -679,8 +868,19 @@ R_DrawInlineBModel(entity_t *currententity, const model_t *currentmodel)
 			else
 			{
 				image = R_TextureAnimation(currententity, psurf->texinfo);
-				R_Bind(image->texnum);
-				R_RenderBrushPoly(currententity, psurf);
+
+				if (gl_config.multitexture && !(psurf->flags & SURF_DRAWTURB))
+				{
+					R_EnableMultitexture(true);
+					R_MBind(GL_TEXTURE0, image->texnum);
+					R_RenderLightmappedPoly(currententity, psurf);
+				}
+				else
+				{
+					R_EnableMultitexture(false);
+					R_Bind(image->texnum);
+					R_RenderBrushPoly(currententity, psurf);
+				}
 			}
 		}
 	}

--- a/src/client/refresh/gl1/gl1_surf.c
+++ b/src/client/refresh/gl1/gl1_surf.c
@@ -294,8 +294,8 @@ R_BlendLightmaps(const model_t *currentmodel)
 					// Apply overbright bits to the static lightmaps
 					if (gl1_overbrightbits->value)
 					{
-						R_TexEnv(GL_COMBINE_EXT);
-						glTexEnvi(GL_TEXTURE_ENV, GL_RGB_SCALE_EXT, gl1_overbrightbits->value);
+						R_TexEnv(GL_COMBINE);
+						glTexEnvi(GL_TEXTURE_ENV, GL_RGB_SCALE, gl1_overbrightbits->value);
 					}
 
 					R_DrawGLPolyChain(surf->polys, 0, 0);
@@ -353,8 +353,8 @@ R_BlendLightmaps(const model_t *currentmodel)
 						// Apply overbright bits to the dynamic lightmaps
 						if (gl1_overbrightbits->value)
 						{
-							R_TexEnv(GL_COMBINE_EXT);
-							glTexEnvi(GL_TEXTURE_ENV, GL_RGB_SCALE_EXT, gl1_overbrightbits->value);
+							R_TexEnv(GL_COMBINE);
+							glTexEnvi(GL_TEXTURE_ENV, GL_RGB_SCALE, gl1_overbrightbits->value);
 						}
 
 						R_DrawGLPolyChain(drawsurf->polys,
@@ -397,8 +397,8 @@ R_BlendLightmaps(const model_t *currentmodel)
 				// Apply overbright bits to the remainder lightmaps
 				if (gl1_overbrightbits->value)
 				{
-					R_TexEnv(GL_COMBINE_EXT);
-					glTexEnvi(GL_TEXTURE_ENV, GL_RGB_SCALE_EXT, gl1_overbrightbits->value);
+					R_TexEnv(GL_COMBINE);
+					glTexEnvi(GL_TEXTURE_ENV, GL_RGB_SCALE, gl1_overbrightbits->value);
 				}
 
 				R_DrawGLPolyChain(surf->polys,
@@ -439,8 +439,8 @@ R_RenderBrushPoly(entity_t *currententity, msurface_t *fa)
 		        They oversaturate otherwise. */
 		if (gl1_overbrightbits->value)
 		{
-			R_TexEnv(GL_COMBINE_EXT);
-			glTexEnvi(GL_TEXTURE_ENV, GL_RGB_SCALE_EXT, 1);
+			R_TexEnv(GL_COMBINE);
+			glTexEnvi(GL_TEXTURE_ENV, GL_RGB_SCALE, 1);
 		}
 		else
 		{

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -403,7 +403,7 @@ typedef struct
 
 	/* the lightmap texture data needs to be kept in
 	   main memory so texsubimage can update properly */
-	byte lightmap_buffer[4 * BLOCK_WIDTH * BLOCK_HEIGHT];
+	byte *lightmap_buffer[MAX_LIGHTMAPS];
 } gllightmapstate_t;
 
 extern glconfig_t gl_config;

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -162,6 +162,7 @@ extern cvar_t *gl1_overbrightbits;
 
 extern cvar_t *gl1_palettedtexture;
 extern cvar_t *gl1_pointparameters;
+extern cvar_t *gl1_multitexture;
 
 extern cvar_t *gl1_particle_min_size;
 extern cvar_t *gl1_particle_max_size;
@@ -230,6 +231,9 @@ void R_TranslatePlayerSkin(int playernum);
 void R_Bind(int texnum);
 
 void R_TexEnv(GLenum value);
+void R_SelectTexture(GLenum);
+void R_MBind(GLenum target, int texnum);
+void R_EnableMultitexture(qboolean enable);
 
 void R_LightPoint(entity_t *currententity, vec3_t p, vec3_t color);
 void R_PushDlights(void);
@@ -359,6 +363,8 @@ typedef struct
 	qboolean npottextures;
 	qboolean palettedtexture;
 	qboolean pointparameters;
+	qboolean multitexture;
+	qboolean mtexcombine;
 
 	// ----
 

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -39,24 +39,6 @@
  #define GL_COLOR_INDEX8_EXT GL_COLOR_INDEX
 #endif
 
-#ifndef GL_EXT_texture_filter_anisotropic
- #define GL_TEXTURE_MAX_ANISOTROPY_EXT 0x84FE
- #define GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT 0x84FF
-#endif
-
-#ifndef GL_VERSION_1_3
- #define GL_TEXTURE0 0x84C0
- #define GL_TEXTURE1 0x84C1
-#endif
-
-#ifndef GL_MULTISAMPLE
-#define GL_MULTISAMPLE 0x809D
-#endif
-
-#ifndef GL_MULTISAMPLE_FILTER_HINT_NV
-#define GL_MULTISAMPLE_FILTER_HINT_NV 0x8534
-#endif
-
 #define TEXNUM_LIGHTMAPS 1024
 #define TEXNUM_SCRAPS 1152
 #define TEXNUM_IMAGES 1153

--- a/src/client/refresh/gl1/header/model.h
+++ b/src/client/refresh/gl1/header/model.h
@@ -65,6 +65,7 @@ typedef struct msurface_s
 	/* lighting info */
 	int dlightframe;
 	int dlightbits;
+	qboolean dirty_lightmap;	// lightmap has dynamic lights from previous frame (mtex only)
 
 	int lightmaptexturenum;
 	byte styles[MAXLIGHTMAPS];

--- a/src/client/refresh/gl1/header/qgl.h
+++ b/src/client/refresh/gl1/header/qgl.h
@@ -52,6 +52,8 @@
 #endif
 
 #ifndef GL_VERSION_1_3
+#define GL_TEXTURE0                       0x84C0
+#define GL_TEXTURE1                       0x84C1
 #define GL_MULTISAMPLE                    0x809D
 #define GL_COMBINE                        0x8570
 #define GL_COMBINE_RGB                    0x8571
@@ -95,5 +97,7 @@ extern void ( APIENTRY *qglPointParameterfv ) ( GLenum param,
 		const GLfloat *value );
 extern void ( APIENTRY *qglColorTableEXT ) ( GLenum, GLenum, GLsizei, GLenum,
 		GLenum, const GLvoid * );
+extern void ( APIENTRY *qglActiveTexture ) ( GLenum texture );
+extern void ( APIENTRY *qglClientActiveTexture ) ( GLenum texture );
 
 #endif

--- a/src/client/refresh/gl1/header/qgl.h
+++ b/src/client/refresh/gl1/header/qgl.h
@@ -44,54 +44,37 @@
 #define APIENTRY
 #endif
 
-#define GL_SHARED_TEXTURE_PALETTE_EXT 0x81FB
+// Extracted from <glext.h>
+#ifndef GL_VERSION_1_4
+#define GL_POINT_SIZE_MIN                 0x8126
+#define GL_POINT_SIZE_MAX                 0x8127
+#define GL_POINT_DISTANCE_ATTENUATION     0x8129
+#endif
 
-#define GL_POINT_SIZE_MIN_EXT 0x8126
-#define GL_POINT_SIZE_MAX_EXT 0x8127
-#define GL_DISTANCE_ATTENUATION_EXT 0x8129
+#ifndef GL_VERSION_1_3
+#define GL_MULTISAMPLE                    0x809D
+#define GL_COMBINE                        0x8570
+#define GL_COMBINE_RGB                    0x8571
+#define GL_COMBINE_ALPHA                  0x8572
+#define GL_SOURCE0_RGB                    0x8580
+#define GL_SOURCE1_RGB                    0x8581
+#define GL_SOURCE0_ALPHA                  0x8588
+#define GL_SOURCE1_ALPHA                  0x8589
+#define GL_RGB_SCALE                      0x8573
+#define GL_PREVIOUS                       0x8578
+#endif
 
-#ifndef GL_EXT_texture_env_combine
-#define GL_COMBINE_EXT 0x8570
-#define GL_COMBINE_RGB_EXT 0x8571
-#define GL_COMBINE_ALPHA_EXT 0x8572
-#define GL_RGB_SCALE_EXT 0x8573
-#define GL_ADD_SIGNED_EXT 0x8574
-#define GL_INTERPOLATE_EXT 0x8575
-#define GL_CONSTANT_EXT 0x8576
-#define GL_PRIMARY_COLOR_EXT 0x8577
-#define GL_PREVIOUS_EXT 0x8578
-#define GL_SOURCE0_RGB_EXT 0x8580
-#define GL_SOURCE1_RGB_EXT 0x8581
-#define GL_SOURCE2_RGB_EXT 0x8582
-#define GL_SOURCE3_RGB_EXT 0x8583
-#define GL_SOURCE4_RGB_EXT 0x8584
-#define GL_SOURCE5_RGB_EXT 0x8585
-#define GL_SOURCE6_RGB_EXT 0x8586
-#define GL_SOURCE7_RGB_EXT 0x8587
-#define GL_SOURCE0_ALPHA_EXT 0x8588
-#define GL_SOURCE1_ALPHA_EXT 0x8589
-#define GL_SOURCE2_ALPHA_EXT 0x858A
-#define GL_SOURCE3_ALPHA_EXT 0x858B
-#define GL_SOURCE4_ALPHA_EXT 0x858C
-#define GL_SOURCE5_ALPHA_EXT 0x858D
-#define GL_SOURCE6_ALPHA_EXT 0x858E
-#define GL_SOURCE7_ALPHA_EXT 0x858F
-#define GL_OPERAND0_RGB_EXT 0x8590
-#define GL_OPERAND1_RGB_EXT 0x8591
-#define GL_OPERAND2_RGB_EXT 0x8592
-#define GL_OPERAND3_RGB_EXT 0x8593
-#define GL_OPERAND4_RGB_EXT 0x8594
-#define GL_OPERAND5_RGB_EXT 0x8595
-#define GL_OPERAND6_RGB_EXT 0x8596
-#define GL_OPERAND7_RGB_EXT 0x8597
-#define GL_OPERAND0_ALPHA_EXT 0x8598
-#define GL_OPERAND1_ALPHA_EXT 0x8599
-#define GL_OPERAND2_ALPHA_EXT 0x859A
-#define GL_OPERAND3_ALPHA_EXT 0x859B
-#define GL_OPERAND4_ALPHA_EXT 0x859C
-#define GL_OPERAND5_ALPHA_EXT 0x859D
-#define GL_OPERAND6_ALPHA_EXT 0x859E
-#define GL_OPERAND7_ALPHA_EXT 0x859F
+#ifndef GL_EXT_shared_texture_palette
+#define GL_SHARED_TEXTURE_PALETTE_EXT     0x81FB
+#endif
+
+#ifndef GL_EXT_texture_filter_anisotropic
+#define GL_TEXTURE_MAX_ANISOTROPY_EXT     0x84FE
+#define GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT 0x84FF
+#endif
+
+#ifndef GL_NV_multisample_filter_hint
+#define GL_MULTISAMPLE_FILTER_HINT_NV     0x8534
 #endif
 
 // =======================================================================
@@ -99,7 +82,7 @@
 /*
  * This is responsible for setting up our QGL extension pointers
  */
-qboolean QGL_Init ( void );
+void QGL_Init ( void );
 
 /*
  * Unloads the specified DLL then nulls out all the proc pointers.
@@ -107,8 +90,8 @@ qboolean QGL_Init ( void );
 void QGL_Shutdown ( void );
 
 /* GL extensions */
-extern void ( APIENTRY *qglPointParameterfARB ) ( GLenum param, GLfloat value );
-extern void ( APIENTRY *qglPointParameterfvARB ) ( GLenum param,
+extern void ( APIENTRY *qglPointParameterf ) ( GLenum param, GLfloat value );
+extern void ( APIENTRY *qglPointParameterfv ) ( GLenum param,
 		const GLfloat *value );
 extern void ( APIENTRY *qglColorTableEXT ) ( GLenum, GLenum, GLsizei, GLenum,
 		GLenum, const GLvoid * );

--- a/src/client/refresh/gl1/qgl.c
+++ b/src/client/refresh/gl1/qgl.c
@@ -38,8 +38,8 @@
 /*
  * GL extensions
  */
-void (APIENTRY *qglPointParameterfARB)(GLenum param, GLfloat value);
-void (APIENTRY *qglPointParameterfvARB)(GLenum param, const GLfloat *value);
+void (APIENTRY *qglPointParameterf)(GLenum param, GLfloat value);
+void (APIENTRY *qglPointParameterfv)(GLenum param, const GLfloat *value);
 void (APIENTRY *qglColorTableEXT)(GLenum, GLenum, GLsizei, GLenum, GLenum,
 		const GLvoid *);
 
@@ -47,9 +47,9 @@ void (APIENTRY *qglColorTableEXT)(GLenum, GLenum, GLsizei, GLenum, GLenum,
 
 void QGL_EXT_Reset ( void )
 {
-	qglPointParameterfARB     = NULL;
-	qglPointParameterfvARB    = NULL;
-	qglColorTableEXT          = NULL;
+	qglPointParameterf     = NULL;
+	qglPointParameterfv    = NULL;
+	qglColorTableEXT       = NULL;
 }
 
 /* ========================================================================= */
@@ -63,11 +63,10 @@ QGL_Shutdown ( void )
 
 /* ========================================================================= */
 
-qboolean
+void
 QGL_Init (void)
 {
 	// Reset GL extension pointers
 	QGL_EXT_Reset();
-	return true;
 }
 

--- a/src/client/refresh/gl1/qgl.c
+++ b/src/client/refresh/gl1/qgl.c
@@ -42,6 +42,8 @@ void (APIENTRY *qglPointParameterf)(GLenum param, GLfloat value);
 void (APIENTRY *qglPointParameterfv)(GLenum param, const GLfloat *value);
 void (APIENTRY *qglColorTableEXT)(GLenum, GLenum, GLsizei, GLenum, GLenum,
 		const GLvoid *);
+void (APIENTRY *qglActiveTexture) (GLenum texture);
+void (APIENTRY *qglClientActiveTexture) (GLenum texture);
 
 /* ========================================================================= */
 
@@ -50,6 +52,8 @@ void QGL_EXT_Reset ( void )
 	qglPointParameterf     = NULL;
 	qglPointParameterfv    = NULL;
 	qglColorTableEXT       = NULL;
+	qglActiveTexture       = NULL;
+	qglClientActiveTexture = NULL;
 }
 
 /* ========================================================================= */


### PR DESCRIPTION
While it is somewhat based in the one deleted almost 8 years ago by this project, this _mtex_ implementation is a very heavy revision on it, borrowing some properties from _Knightmare's KMQuake2_ source port, like keeping all lightmaps in memory for easier manipulation.

Features:

1. It is effectively apart from the standard rendering path. One of the reasons old multitexture was so slow is that it applied lightmaps again in a second pass (`R_BlendLightmaps()` function), which is redundant, lightmaps were already bound to the second TMU in the first (supposedly only) rendering pass. That was also one of the reasons [textures appeared so bright](https://github.com/yquake2/yquake2/issues/147), and rendering was so slow. This implementation is 100% visually consistent with the "no multitexture" rendering, doing both texture and lightmap in 1 pass.

2. Follows the standard texture chain, which avoids changing bound textures so much. "Old multitexture" rendered brushes without order, which bound to the same texture multiple times within a frame, again being redundant and reducing performance. The only heavy bind remaining here is the lightmap texture in the second TMU, which doesn't get re-bound that much compared to the color texture anyway.

3. In a step previous to rendering, dynamic lights are applied to the static lightmaps in memory, and then uploaded to the GPU, as a batch. Think `R_BlendLightmaps()` but in reverse. Avoids doing too many calls to `glTexSubImage2D()`, which are ridiculously slow.

4. Presents no lightmap generation errors, like the lava sectors in the `boss1` map with old mtex, which used to show fumbled textures.

5. `gl_showtris` works with this! It works even faster than classic rendering path.

There are a couple of issues:

1. Difference between max and min framerate is more pronounced, since the game goes almost 50% faster when nothing is happening, to just 5% faster when there's heavy lightmap generation. E.g. the exploding column in `base1` map, the very beginning of the game. Still, it must be mentioned that, unlike "old mtex", framerate is always above the standard "no mtex" rendering path, never below it.

2. `gl1_overbrightbits` works as intended for 1, 2 and 4, but jumping from 2 or 4 to 0 requires a `vid_restart`, or at least setting it to 1 first before going to 0.

I believe that, even with these issues, it's a huge help for people with old/small hardware.
Enabled by default, classic rendering path is nearly untouched if you want to go back.
I recommend testing this with the worst videocard/hardware you can find :)

Credits and thanks to _MH_ and _Knightmare_ for the dynamic lighting code (feature 3), which greatly helped the performance of this implementation.

Before finishing, I gotta mention a small but important fix included here: now the standard texture chain functions properly.

When adding a surface to the texture chain (in `R_RecursiveWorldNode()`), its current texture is identified by calling `R_TextureAnimation()`. Then, when browsing the chain in `R_DrawTextureChains()`, at the moment of drawing (`R_RenderBrushPoly()`), `R_TextureAnimation()` is called again to identify and bind the texture... which way too many times returns a different one, forcing GL1 to bind back and forth the same textures. You can apply this patch in the current master to see for yourself: [texture_chains_issue.patch](https://github.com/yquake2/yquake2/files/15080028/texture_chains_issue.patch)

Now the chain is respected, which helps rendering whether you are using multitexture or not.