### PR TITLE
update of tag allocator.

### DIFF
--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -803,8 +803,8 @@ extern int time_before_ref;
 extern int time_after_ref;
 
 void Z_Free(void *ptr);
-void *Z_Malloc(int size);           /* returns 0 filled memory */
-void *Z_TagMalloc(int size, int tag);
+void *Z_Malloc(unsigned int size);           /* returns 0 filled memory */
+void *Z_TagMalloc(unsigned int size, int tag);
 void Z_FreeTags(int tag);
 
 void Qcommon_Init(int argc, char **argv);

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -63,13 +63,16 @@ typedef unsigned char byte;
   #if defined(__GNUC__)
 	#define YQ2_ATTR_MALLOC         __attribute__ ((__malloc__))
 	#define YQ2_ATTR_INLINE         __attribute__((always_inline)) inline
+	#define YQ2_UNLIKELY(C)         __builtin_expect(!!(C), false)
   #elif defined(_MSC_VER)
 	#define YQ2_ATTR_MALLOC         __declspec(restrict)
 	#define YQ2_ATTR_INLINE         __forceinline
+	#define YQ2_UNLIKELY(C)         (C)
   #else
 	// no equivalent per see
 	#define YQ2_ATTR_MALLOC
 	#define YQ2_ATTR_INLINE         inline
+	#define YQ2_UNLIKELY(C)         (C)
   #endif
 #elif defined(__GNUC__) // GCC and clang should support this attribute
 	#define YQ2_ALIGNAS_SIZE(SIZE)  __attribute__(( __aligned__(SIZE) ))
@@ -80,6 +83,7 @@ typedef unsigned char byte;
 	#define YQ2_ATTR_INLINE         __attribute__((always_inline)) inline
 	// GCC supports this extension since 4.6
 	#define YQ2_STATIC_ASSERT(C, M) _Static_assert((C), M)
+	#define YQ2_UNLIKELY(C)         __builtin_expect(!!(C), false)
 #elif defined(_MSC_VER)
 	// Note: We prefer VS2019 16.8 or newer in C11 mode (/std:c11),
 	//       then the __STDC_VERSION__ >= 201112L case above is used
@@ -99,6 +103,7 @@ typedef unsigned char byte;
 	#define YQ2_ATTR_MALLOC         __declspec(restrict)
 	#define YQ2_ATTR_INLINE         __forceinline
 	#define YQ2_STATIC_ASSERT(C, M) assert((C) && M)
+	#define YQ2_UNLIKELY(C)         (C)
 #else
 	#warning "Please add a case for your compiler here to align correctly"
 	#define YQ2_ALIGNAS_SIZE(SIZE)
@@ -107,6 +112,7 @@ typedef unsigned char byte;
 	#define YQ2_ATTR_MALLOC
 	#define YQ2_ATTR_INLINE         inline
 	#define YQ2_STATIC_ASSERT(C, M) assert((C) && M)
+	#define YQ2_UNLIKELY(C)         (C)
 #endif
 
 #if defined(__GNUC__)

--- a/src/common/header/zone.h
+++ b/src/common/header/zone.h
@@ -32,7 +32,7 @@ typedef struct zhead_s
 	struct zhead_s	*prev, *next;
 	short	magic;
 	short	tag; /* for group free */
-	int		size;
+	unsigned int size;
 } zhead_t;
 
 void Z_Stats_f (void);

--- a/src/game/g_misc.c
+++ b/src/game/g_misc.c
@@ -2389,7 +2389,7 @@ typedef struct zhead_s
    struct zhead_s *prev, *next;
    short magic;
    short tag;
-   int size;
+   unsigned int size;
 } zhead_t;
 
 void

--- a/src/game/header/game.h
+++ b/src/game/header/game.h
@@ -162,7 +162,7 @@ typedef struct
 	void (*WriteAngle)(float f);
 
 	/* managed memory allocation */
-	void *(*TagMalloc)(int size, int tag);
+	void *(*TagMalloc)(unsigned int size, int tag);
 	void (*TagFree)(void *block);
 	void (*FreeTags)(int tag);
 


### PR DESCRIPTION
without changing the size of the zone head type.
introducing YA2_UNLIKELY to optimise rarely called edge cases.