### PR TITLE
Fix potential memory corruption issue where cl_numparticles is 0 and CL_ClearParticles is called

### DIFF
--- a/src/client/cl_particles.c
+++ b/src/client/cl_particles.c
@@ -33,6 +33,9 @@ int cl_numparticles = MAX_PARTICLES;
 void
 CL_ClearParticles(void)
 {
+	if (cl_numparticles == 0)
+		return;
+		
 	int i;
 
 	free_particles = &particles[0];


### PR DESCRIPTION
If CL_ClearParticles is called with zero particles, cl_particles[0-1] = -1 will have its "next" field set to NULL, potentially corrupting 4 bytes of memory at (cl_particles)-[80..76]. This may be user-manipulable but I'm not sure how bad this is in practice. 