### PR TITLE
Grouped draw calls for improved performance with GL1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,6 +590,7 @@ set(GL1-Source
 	${REF_SRC_DIR}/gl1/gl1_surf.c
 	${REF_SRC_DIR}/gl1/gl1_warp.c
 	${REF_SRC_DIR}/gl1/gl1_sdl.c
+	${REF_SRC_DIR}/gl1/gl1_buffer.c
 	${REF_SRC_DIR}/files/models.c
 	${REF_SRC_DIR}/files/pcx.c
 	${REF_SRC_DIR}/files/stb.c

--- a/Makefile
+++ b/Makefile
@@ -959,6 +959,7 @@ REFGL1_OBJS_ := \
 	src/client/refresh/gl1/gl1_surf.o \
 	src/client/refresh/gl1/gl1_warp.o \
 	src/client/refresh/gl1/gl1_sdl.o \
+	src/client/refresh/gl1/gl1_buffer.o \
 	src/client/refresh/files/surf.o \
 	src/client/refresh/files/models.o \
 	src/client/refresh/files/pcx.o \

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -471,10 +471,6 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
 
 ## Graphics (OpenGL 1.4 only)
 
-* **gl1_biglightmaps**: Enables lightmaps and scrap to use a bigger
-  texture size, which means fewer texture switches, improving
-  performance. Default is `1` (enabled). Requires a `vid_restart`.
-
 * **gl1_intensity**: Sets the color intensity. Must be a floating point
   value, at least `1.0` - default is `2.0`. Applied when textures are
   loaded, so it needs a `vid_restart`.

--- a/src/client/refresh/gl1/gl1_buffer.c
+++ b/src/client/refresh/gl1/gl1_buffer.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 1997-2001 Id Software, Inc.
+ * Copyright (C) 2024      Jaime Moreira
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * =======================================================================
+ *
+ * Drawing buffer: sort of a "Q3A shader" handler, allows to join multiple
+ * draw calls into one, by grouping those which share the same
+ * characteristics (mostly the same texture).
+ *
+ * =======================================================================
+ */
+
+#include "header/local.h"
+
+#define MAX_VERTICES	16384
+#define MAX_INDICES 	(MAX_VERTICES * 4)
+
+typedef struct	//	832k aprox.
+{
+	buffered_draw_t	type;
+
+	GLfloat
+		vtx[MAX_VERTICES * 3],	// vertexes
+		tex[MAX_TEXTURE_UNITS][MAX_VERTICES * 2],	// texture coords
+		clr[MAX_VERTICES * 4];	// color components
+
+	GLushort
+		idx[MAX_INDICES],	// indices
+		vtx_ptr, idx_ptr;	// pointers for array positions
+
+	int	texture[MAX_TEXTURE_UNITS];
+	int	flags;	// entity flags
+	float	alpha;
+} glbuffer_t;
+
+glbuffer_t gl_buf;
+
+GLuint vt, tx, cl;	// indices for arrays in gl_buf
+
+extern void R_MYgluPerspective(GLdouble fovy, GLdouble aspect, GLdouble zNear, GLdouble zFar);
+
+void
+R_ApplyGLBuffer(void)
+{
+	// Properties of batched draws here
+	GLint vtx_size;
+	qboolean texture;
+
+	if (gl_buf.vtx_ptr == 0 || gl_buf.idx_ptr == 0)
+	{
+		return;
+	}
+
+	// defaults for drawing
+	vtx_size = 3;
+	texture = true;
+
+	// choosing features by type
+	switch (gl_buf.type)
+	{
+		case buf_2d:
+			vtx_size = 2;
+			break;
+		default:
+			break;
+	}
+
+	glEnableClientState( GL_VERTEX_ARRAY );
+	glVertexPointer (vtx_size, GL_FLOAT, 0, gl_buf.vtx);
+
+	if (texture)
+	{
+		R_Bind(gl_buf.texture[0]);
+
+		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+		glTexCoordPointer(2, GL_FLOAT, 0, gl_buf.tex[0]);
+	}
+
+	// All set, we can finally draw
+	glDrawElements(GL_TRIANGLES, gl_buf.idx_ptr, GL_UNSIGNED_SHORT, gl_buf.idx);
+	// ... and now, turn back everything as it was
+
+	if (texture)
+	{
+		glDisableClientState( GL_TEXTURE_COORD_ARRAY );
+	}
+
+	glDisableClientState( GL_VERTEX_ARRAY );
+
+	gl_buf.vtx_ptr = gl_buf.idx_ptr = 0;
+}
+
+void
+R_UpdateGLBuffer(buffered_draw_t type, int colortex, int lighttex, int flags, float alpha)
+{
+	if ( gl_buf.type != type || gl_buf.texture[0] != colortex )
+	{
+		R_ApplyGLBuffer();
+
+		gl_buf.type = type;
+		gl_buf.texture[0] = colortex;
+		gl_buf.texture[1] = lighttex;
+		gl_buf.flags = flags;
+		gl_buf.alpha = alpha;
+	}
+}
+
+void
+R_Buffer2DQuad(GLfloat ul_vx, GLfloat ul_vy, GLfloat dr_vx, GLfloat dr_vy,
+	GLfloat ul_tx, GLfloat ul_ty, GLfloat dr_tx, GLfloat dr_ty)
+{
+	static const GLushort idx_max = MAX_INDICES - 7;
+	static const GLushort vtx_max = MAX_VERTICES - 5;
+	unsigned int i;
+
+	if (gl_buf.idx_ptr > idx_max || gl_buf.vtx_ptr > vtx_max)
+	{
+		R_ApplyGLBuffer();
+	}
+
+	i = gl_buf.vtx_ptr * 2;      // vertex index
+
+	// "Quad" = 2-triangle GL_TRIANGLE_FAN
+	gl_buf.idx[gl_buf.idx_ptr++] = gl_buf.vtx_ptr;
+	gl_buf.idx[gl_buf.idx_ptr++] = gl_buf.vtx_ptr+1;
+	gl_buf.idx[gl_buf.idx_ptr++] = gl_buf.vtx_ptr+2;
+	gl_buf.idx[gl_buf.idx_ptr++] = gl_buf.vtx_ptr;
+	gl_buf.idx[gl_buf.idx_ptr++] = gl_buf.vtx_ptr+2;
+	gl_buf.idx[gl_buf.idx_ptr++] = gl_buf.vtx_ptr+3;
+
+	// up left corner coords
+	gl_buf.vtx[i]   = ul_vx;
+	gl_buf.vtx[i+1] = ul_vy;
+	// up right
+	gl_buf.vtx[i+2] = dr_vx;
+	gl_buf.vtx[i+3] = ul_vy;
+	// down right
+	gl_buf.vtx[i+4] = dr_vx;
+	gl_buf.vtx[i+5] = dr_vy;
+	// and finally, down left
+	gl_buf.vtx[i+6] = ul_vx;
+	gl_buf.vtx[i+7] = dr_vy;
+
+	gl_buf.tex[0][i]   = ul_tx;
+	gl_buf.tex[0][i+1] = ul_ty;
+	gl_buf.tex[0][i+2] = dr_tx;
+	gl_buf.tex[0][i+3] = ul_ty;
+	gl_buf.tex[0][i+4] = dr_tx;
+	gl_buf.tex[0][i+5] = dr_ty;
+	gl_buf.tex[0][i+6] = ul_tx;
+	gl_buf.tex[0][i+7] = dr_ty;
+
+	gl_buf.vtx_ptr += 4;
+}

--- a/src/client/refresh/gl1/gl1_buffer.c
+++ b/src/client/refresh/gl1/gl1_buffer.c
@@ -91,6 +91,7 @@ R_ApplyGLBuffer(void)
 			break;
 		case buf_flash:
 			color = true;
+		case buf_shadow:
 			texture = false;
 			break;
 		default:

--- a/src/client/refresh/gl1/gl1_buffer.c
+++ b/src/client/refresh/gl1/gl1_buffer.c
@@ -61,7 +61,7 @@ R_ApplyGLBuffer(void)
 {
 	// Properties of batched draws here
 	GLint vtx_size;
-	qboolean texture, mtex, alpha, texenv_set;
+	qboolean texture, mtex, alpha, color, texenv_set;
 
 	if (gl_buf.vtx_ptr == 0 || gl_buf.idx_ptr == 0)
 	{
@@ -71,7 +71,7 @@ R_ApplyGLBuffer(void)
 	// defaults for drawing (mostly buf_singletex features)
 	vtx_size = 3;
 	texture = true;
-	mtex = alpha = texenv_set = false;
+	mtex = alpha = color = texenv_set = false;
 
 	// choosing features by type
 	switch (gl_buf.type)
@@ -84,6 +84,10 @@ R_ApplyGLBuffer(void)
 			break;
 		case buf_alpha:
 			alpha = true;
+			break;
+		case buf_flash:
+			color = true;
+			texture = false;
 			break;
 		default:
 			break;
@@ -161,9 +165,20 @@ R_ApplyGLBuffer(void)
 		glTexCoordPointer(2, GL_FLOAT, 0, gl_buf.tex[0]);
 	}
 
+	if (color)
+	{
+		glEnableClientState(GL_COLOR_ARRAY);
+		glColorPointer(4, GL_FLOAT, 0, gl_buf.clr);
+	}
+
 	// All set, we can finally draw
 	glDrawElements(GL_TRIANGLES, gl_buf.idx_ptr, GL_UNSIGNED_SHORT, gl_buf.idx);
 	// ... and now, turn back everything as it was
+
+	if (color)
+	{
+		glDisableClientState(GL_COLOR_ARRAY);
+	}
 
 	if (texture)
 	{
@@ -317,4 +332,16 @@ R_BufferMultiTex(GLfloat cs, GLfloat ct, GLfloat ls, GLfloat lt)
 	gl_buf.tex[1][tx]   = ls;
 	gl_buf.tex[1][tx+1] = lt;
 	tx += 2;
+}
+
+/*
+ * Adds color components of vertex
+ */
+void
+R_BufferColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a)
+{
+	gl_buf.clr[cl++] = r;
+	gl_buf.clr[cl++] = g;
+	gl_buf.clr[cl++] = b;
+	gl_buf.clr[cl++] = a;
 }

--- a/src/client/refresh/gl1/gl1_draw.c
+++ b/src/client/refresh/gl1/gl1_draw.c
@@ -77,31 +77,10 @@ RDraw_CharScaled(int x, int y, int num, float scale)
 
 	scaledSize = 8*scale;
 
-	R_Bind(draw_chars->texnum);
+	R_UpdateGLBuffer(buf_2d, draw_chars->texnum, 0, 0, 1);
 
-	GLfloat vtx[] = {
-		x, y,
-		x + scaledSize, y,
-		x + scaledSize, y + scaledSize,
-		x, y + scaledSize
-	};
-
-	GLfloat tex[] = {
-		fcol, frow,
-		fcol + size, frow,
-		fcol + size, frow + size,
-		fcol, frow + size
-	};
-
-	glEnableClientState( GL_VERTEX_ARRAY );
-	glEnableClientState( GL_TEXTURE_COORD_ARRAY );
-
-	glVertexPointer( 2, GL_FLOAT, 0, vtx );
-	glTexCoordPointer( 2, GL_FLOAT, 0, tex );
-	glDrawArrays( GL_TRIANGLE_FAN, 0, 4 );
-
-	glDisableClientState( GL_VERTEX_ARRAY );
-	glDisableClientState( GL_TEXTURE_COORD_ARRAY );
+	R_Buffer2DQuad(x, y, x + scaledSize, y + scaledSize,
+		fcol, frow, fcol + size, frow + size);
 }
 
 image_t *
@@ -190,6 +169,14 @@ RDraw_PicScaled(int x, int y, char *pic, float factor)
 		Scrap_Upload();
 	}
 
+	if (gl->texnum == TEXNUM_SCRAPS)
+	{
+		R_UpdateGLBuffer(buf_2d, TEXNUM_SCRAPS, 0, 0, 1);
+		R_Buffer2DQuad(x, y, x + gl->width * factor, y + gl->height * factor,
+			gl->sl, gl->tl, gl->sh, gl->th);
+		return;
+	}
+
 	R_Bind(gl->texnum);
 
 	GLfloat vtx[] = {
@@ -235,31 +222,10 @@ RDraw_TileClear(int x, int y, int w, int h, char *pic)
 		return;
 	}
 
-	R_Bind(image->texnum);
+	R_UpdateGLBuffer(buf_2d, image->texnum, 0, 0, 1);
 
-	GLfloat vtx[] = {
-		x, y,
-		x + w, y,
-		x + w, y + h,
-		x, y + h
-	};
-
-	GLfloat tex[] = {
-		x / 64.0, y / 64.0,
-		( x + w ) / 64.0, y / 64.0,
-		( x + w ) / 64.0, ( y + h ) / 64.0,
-		x / 64.0, ( y + h ) / 64.0
-	};
-
-	glEnableClientState( GL_VERTEX_ARRAY );
-	glEnableClientState( GL_TEXTURE_COORD_ARRAY );
-
-	glVertexPointer( 2, GL_FLOAT, 0, vtx );
-	glTexCoordPointer( 2, GL_FLOAT, 0, tex );
-	glDrawArrays( GL_TRIANGLE_FAN, 0, 4 );
-
-	glDisableClientState( GL_VERTEX_ARRAY );
-	glDisableClientState( GL_TEXTURE_COORD_ARRAY );
+	R_Buffer2DQuad(x, y, x + w, y + h, x / 64.0, y / 64.0,
+		( x + w ) / 64.0, ( y + h ) / 64.0);
 }
 
 /*
@@ -306,6 +272,7 @@ RDraw_Fill(int x, int y, int w, int h, int c)
 void
 RDraw_FadeScreen(void)
 {
+	R_ApplyGLBuffer();	// draw what needs to be hidden
 	glEnable(GL_BLEND);
 	glDisable(GL_TEXTURE_2D);
 	glColor4f(0, 0, 0, 0.8);

--- a/src/client/refresh/gl1/gl1_light.c
+++ b/src/client/refresh/gl1/gl1_light.c
@@ -35,53 +35,34 @@ static float s_blocklights[34 * 34 * 3];
 void
 R_RenderDlight(dlight_t *light)
 {
+	const float rad = light->intensity * 0.35;
 	int i, j;
-	float a;
-	float rad;
+	float vtx[3], a;
 
-	rad = light->intensity * 0.35;
-
-	GLfloat vtx[3*18];
-	GLfloat clr[4*18];
-
-	unsigned int index_vtx = 3;
-	unsigned int index_clr = 0;
-
-	glEnableClientState( GL_VERTEX_ARRAY );
-	glEnableClientState( GL_COLOR_ARRAY );
-
-	clr[index_clr++] = light->color [ 0 ] * 0.2;
-	clr[index_clr++] = light->color [ 1 ] * 0.2;
-	clr[index_clr++] = light->color [ 2 ] * 0.2;
-	clr[index_clr++] = 1;
+	R_SetBufferIndices(GL_TRIANGLE_FAN, 18);
 
 	for ( i = 0; i < 3; i++ )
 	{
 		vtx [ i ] = light->origin [ i ] - vpn [ i ] * rad;
 	}
 
+	R_BufferVertex( vtx[0], vtx[1], vtx[2] );
+	R_BufferColor( light->color[0] * 0.2, light->color[1] * 0.2,
+		light->color[2] * 0.2, 1 );
+
 	for ( i = 16; i >= 0; i-- )
 	{
-		clr[index_clr++] = 0;
-		clr[index_clr++] = 0;
-		clr[index_clr++] = 0;
-		clr[index_clr++] = 1;
-
 		a = i / 16.0 * M_PI * 2;
 
 		for ( j = 0; j < 3; j++ )
 		{
-			vtx[index_vtx++] = light->origin [ j ] + vright [ j ] * cos( a ) * rad
+			vtx[ j ] = light->origin [ j ] + vright [ j ] * cos( a ) * rad
 				+ vup [ j ] * sin( a ) * rad;
 		}
+
+		R_BufferVertex( vtx[0], vtx[1], vtx[2] );
+		R_BufferColor( 0, 0, 0, 1 );
 	}
-
-	glVertexPointer( 3, GL_FLOAT, 0, vtx );
-	glColorPointer( 4, GL_FLOAT, 0, clr );
-	glDrawArrays( GL_TRIANGLE_FAN, 0, 18 );
-
-	glDisableClientState( GL_VERTEX_ARRAY );
-	glDisableClientState( GL_COLOR_ARRAY );
 }
 
 void
@@ -94,6 +75,7 @@ R_RenderDlights(void)
 	{
 		return;
 	}
+	R_UpdateGLBuffer(buf_flash, 0, 0, 0, 1);
 
 	/* because the count hasn't advanced yet for this frame */
 	r_dlightframecount = r_framecount + 1;
@@ -110,6 +92,7 @@ R_RenderDlights(void)
 	{
 		R_RenderDlight(l);
 	}
+	R_ApplyGLBuffer();
 
 	glColor4f(1, 1, 1, 1);
 	glDisable(GL_BLEND);

--- a/src/client/refresh/gl1/gl1_mesh.c
+++ b/src/client/refresh/gl1/gl1_mesh.c
@@ -86,19 +86,13 @@ R_LerpVerts(entity_t *currententity, int nverts, dtrivertx_t *v, dtrivertx_t *ov
 static void
 R_DrawAliasFrameLerp(entity_t *currententity, dmdl_t *paliashdr, float backlerp)
 {
-    unsigned short total;
-    GLenum type;
-	float l;
 	daliasframe_t *frame, *oldframe;
 	dtrivertx_t *v, *ov, *verts;
 	int *order;
-	int count;
-	float frontlerp;
-	float alpha;
+	int count, i, index_xyz;
+	float tex[2], frontlerp, l, alpha;
 	vec3_t move, delta, vectors[3];
 	vec3_t frontv, backv;
-	int i;
-	int index_xyz;
 	float *lerp;
 
 	frame = (daliasframe_t *)((byte *)paliashdr + paliashdr->ofs_frames
@@ -118,13 +112,6 @@ R_DrawAliasFrameLerp(entity_t *currententity, dmdl_t *paliashdr, float backlerp)
 	else
 	{
 		alpha = 1.0;
-	}
-
-	if (currententity->flags &
-		(RF_SHELL_RED | RF_SHELL_GREEN | RF_SHELL_BLUE | RF_SHELL_DOUBLE |
-		 RF_SHELL_HALF_DAM))
-	{
-		glDisable(GL_TEXTURE_2D);
 	}
 
 	frontlerp = 1.0 - backlerp;
@@ -154,127 +141,66 @@ R_DrawAliasFrameLerp(entity_t *currententity, dmdl_t *paliashdr, float backlerp)
 
 	R_LerpVerts(currententity, paliashdr->num_xyz, v, ov, verts, lerp, move, frontv, backv);
 
-#ifdef _MSC_VER // workaround for lack of VLAs (=> our workaround uses alloca() which is bad in loops)
-	int maxCount = 0;
-	const int* tmpOrder = order;
 	while (1)
 	{
-		int c = *tmpOrder++;
-		if (!c)
-			break;
-		if ( c < 0 )
-			c = -c;
-		if ( c > maxCount )
-			maxCount = c;
+		/* get the vertex count and primitive type */
+		count = *order++;
 
-		tmpOrder += 3 * c;
-	}
-
-	YQ2_VLA( GLfloat, vtx, 3 * maxCount );
-	YQ2_VLA( GLfloat, tex, 2 * maxCount );
-	YQ2_VLA( GLfloat, clr, 4 * maxCount );
-#endif
-
-		while (1)
+		if (!count)
 		{
-			/* get the vertex count and primitive type */
-			count = *order++;
-
-			if (!count)
-			{
-				break; /* done */
-			}
-
-			if (count < 0)
-			{
-				count = -count;
-
-                type = GL_TRIANGLE_FAN;
-			}
-			else
-			{
-                type = GL_TRIANGLE_STRIP;
-			}
-
-			total = count;
-
-#ifndef _MSC_VER // we have real VLAs, so it's safe to use one in this loop
-			YQ2_VLA(GLfloat, vtx, 3*total);
-			YQ2_VLA(GLfloat, tex, 2*total);
-			YQ2_VLA(GLfloat, clr, 4*total);
-#endif
-			unsigned int index_vtx = 0;
-			unsigned int index_tex = 0;
-			unsigned int index_clr = 0;
-
-			if (currententity->flags &
-				(RF_SHELL_RED | RF_SHELL_GREEN | RF_SHELL_BLUE))
-			{
-				do
-				{
-					index_xyz = order[2];
-					order += 3;
-
-					clr[index_clr++] = shadelight[0];
-					clr[index_clr++] = shadelight[1];
-					clr[index_clr++] = shadelight[2];
-					clr[index_clr++] = alpha;
-
-					vtx[index_vtx++] = s_lerped[index_xyz][0];
-					vtx[index_vtx++] = s_lerped[index_xyz][1];
-					vtx[index_vtx++] = s_lerped[index_xyz][2];
-				}
-				while (--count);
-			}
-			else
-			{
-				do
-				{
-					/* texture coordinates come from the draw list */
-					tex[index_tex++] = ((float *) order)[0];
-					tex[index_tex++] = ((float *) order)[1];
-
-					index_xyz = order[2];
-					order += 3;
-
-					/* normals and vertexes come from the frame list */
-					l = shadedots[verts[index_xyz].lightnormalindex];
-
-					clr[index_clr++] = l * shadelight[0];
-					clr[index_clr++] = l * shadelight[1];
-					clr[index_clr++] = l * shadelight[2];
-					clr[index_clr++] = alpha;
-
-					vtx[index_vtx++] = s_lerped[index_xyz][0];
-					vtx[index_vtx++] = s_lerped[index_xyz][1];
-					vtx[index_vtx++] = s_lerped[index_xyz][2];
-				}
-				while (--count);
-			}
-
-			glEnableClientState(GL_VERTEX_ARRAY);
-			glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-			glEnableClientState(GL_COLOR_ARRAY);
-
-			glVertexPointer(3, GL_FLOAT, 0, vtx);
-			glTexCoordPointer(2, GL_FLOAT, 0, tex);
-			glColorPointer(4, GL_FLOAT, 0, clr);
-			glDrawArrays(type, 0, total);
-
-			glDisableClientState(GL_VERTEX_ARRAY);
-			glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-			glDisableClientState(GL_COLOR_ARRAY);
+			break; /* done */
 		}
 
-		YQ2_VLAFREE( vtx );
-		YQ2_VLAFREE( tex );
-		YQ2_VLAFREE( clr )
+		if (count < 0)
+		{
+			count = -count;
+			R_SetBufferIndices(GL_TRIANGLE_FAN, count);
+		}
+		else
+		{
+			R_SetBufferIndices(GL_TRIANGLE_STRIP, count);
+		}
 
-	if (currententity->flags &
-		(RF_SHELL_RED | RF_SHELL_GREEN | RF_SHELL_BLUE |
-		 RF_SHELL_DOUBLE | RF_SHELL_HALF_DAM))
-	{
-		glEnable(GL_TEXTURE_2D);
+		if (currententity->flags &
+			(RF_SHELL_RED | RF_SHELL_GREEN | RF_SHELL_BLUE))
+		{
+			do
+			{
+				index_xyz = order[2];
+				order += 3;
+
+				R_BufferVertex(s_lerped[index_xyz][0],
+					s_lerped[index_xyz][1], s_lerped[index_xyz][2]);
+
+				R_BufferColor(shadelight[0], shadelight[1],
+					shadelight[2], alpha);
+			}
+			while (--count);
+		}
+		else
+		{
+			do
+			{
+				/* texture coordinates come from the draw list */
+				tex[0] = ((float *)order)[0];
+				tex[1] = ((float *)order)[1];
+
+				index_xyz = order[2];
+				order += 3;
+
+				/* normals and vertexes come from the frame list */
+				l = shadedots[verts[index_xyz].lightnormalindex];
+
+				R_BufferVertex(s_lerped[index_xyz][0],
+					s_lerped[index_xyz][1], s_lerped[index_xyz][2]);
+
+				R_BufferSingleTex(tex[0], tex[1]);
+
+				R_BufferColor(l * shadelight[0], l * shadelight[1],
+					l * shadelight[2], alpha);
+			}
+			while (--count);
+		}
 	}
 }
 
@@ -557,7 +483,6 @@ R_DrawAliasModel(entity_t *currententity, const model_t *currentmodel)
 		}
 	}
 
-	R_EnableMultitexture(false);
 	paliashdr = (dmdl_t *)currentmodel->extradata;
 
 	/* get lighting information */
@@ -685,7 +610,6 @@ R_DrawAliasModel(entity_t *currententity, const model_t *currentmodel)
     }
 
 
-
 	/* ir goggles color override */
 	if (r_newrefdef.rdflags & RDF_IRGOGGLES && currententity->flags &
 		RF_IR_VISIBLE)
@@ -706,45 +630,6 @@ R_DrawAliasModel(entity_t *currententity, const model_t *currentmodel)
 
 	/* locate the proper data */
 	c_alias_polys += paliashdr->num_tris;
-
-	/* draw all the triangles */
-	if (currententity->flags & RF_DEPTHHACK)
-	{
-		/* hack the depth range to prevent view model from poking into walls */
-		glDepthRange(gldepthmin, gldepthmin + 0.3 * (gldepthmax - gldepthmin));
-	}
-
-	if (currententity->flags & RF_WEAPONMODEL)
-	{
-		extern void R_MYgluPerspective(GLdouble fovy, GLdouble aspect, GLdouble zNear, GLdouble zFar);
-
-		glMatrixMode(GL_PROJECTION);
-		glPushMatrix();
-		glLoadIdentity();
-
-		if (gl_lefthand->value == 1.0F)
-		{
-			glScalef(-1, 1, 1);
-		}
-
-		float dist = (r_farsee->value == 0) ? 4096.0f : 8192.0f;
-
-		if (r_gunfov->value < 0)
-		{
-			R_MYgluPerspective(r_newrefdef.fov_y, (float)r_newrefdef.width / r_newrefdef.height, 4, dist);
-		}
-		else
-		{
-			R_MYgluPerspective(r_gunfov->value, (float)r_newrefdef.width / r_newrefdef.height, 4, dist);
-		}
-
-		glMatrixMode(GL_MODELVIEW);
-
-		if (gl_lefthand->value == 1.0F)
-		{
-			glCullFace(GL_BACK);
-		}
-	}
 
 	glPushMatrix();
 	currententity->angles[PITCH] = -currententity->angles[PITCH];
@@ -778,18 +663,6 @@ R_DrawAliasModel(entity_t *currententity, const model_t *currentmodel)
 		skin = r_notexture; /* fallback... */
 	}
 
-	R_Bind(skin->texnum);
-
-	/* draw it */
-	glShadeModel(GL_SMOOTH);
-
-	R_TexEnv(GL_MODULATE);
-
-	if (currententity->flags & RF_TRANSLUCENT)
-	{
-		glEnable(GL_BLEND);
-	}
-
 	if ((currententity->frame >= paliashdr->num_frames) ||
 		(currententity->frame < 0))
 	{
@@ -813,7 +686,9 @@ R_DrawAliasModel(entity_t *currententity, const model_t *currentmodel)
 		currententity->backlerp = 0;
 	}
 
+	R_UpdateGLBuffer(buf_alias, skin->texnum, 0, currententity->flags, 1);
 	R_DrawAliasFrameLerp(currententity, paliashdr, currententity->backlerp);
+	R_ApplyGLBuffer();
 
 	R_TexEnv(GL_REPLACE);
 	glShadeModel(GL_FLAT);
@@ -834,25 +709,6 @@ R_DrawAliasModel(entity_t *currententity, const model_t *currentmodel)
 		glEnable(GL_TEXTURE_2D);
 		glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 		glEnable(GL_CULL_FACE);
-	}
-
-	if (currententity->flags & RF_WEAPONMODEL)
-	{
-		glMatrixMode(GL_PROJECTION);
-		glPopMatrix();
-		glMatrixMode(GL_MODELVIEW);
-		if (gl_lefthand->value == 1.0F)
-			glCullFace(GL_FRONT);
-	}
-
-	if (currententity->flags & RF_TRANSLUCENT)
-	{
-		glDisable(GL_BLEND);
-	}
-
-	if (currententity->flags & RF_DEPTHHACK)
-	{
-		glDepthRange(gldepthmin, gldepthmax);
 	}
 
 	if (gl_shadows->value &&

--- a/src/client/refresh/gl1/gl1_sdl.c
+++ b/src/client/refresh/gl1/gl1_sdl.c
@@ -46,6 +46,7 @@ static qboolean vsyncActive = false;
 void
 RI_EndFrame(void)
 {
+	R_ApplyGLBuffer();	// to draw buffered 2D text
 	SDL_GL_SwapWindow(window);
 }
 

--- a/src/client/refresh/gl1/gl1_warp.c
+++ b/src/client/refresh/gl1/gl1_warp.c
@@ -282,7 +282,7 @@ R_EmitWaterPolys(msurface_t *fa)
 {
 	glpoly_t *p, *bp;
 	float *v;
-	int i;
+	int i, nv;
 	float s, t, os, ot;
 	float scroll;
 	float rdt = r_newrefdef.time;
@@ -296,53 +296,24 @@ R_EmitWaterPolys(msurface_t *fa)
 		scroll = 0;
 	}
 
-	// workaround for lack of VLAs (=> our workaround uses alloca() which is bad in loops)
-#ifdef _MSC_VER
-	int maxNumVerts = 0;
-	for ( glpoly_t* tmp = fa->polys; tmp; tmp = tmp->next )
-	{
-		if (tmp->numverts > maxNumVerts)
-			maxNumVerts = tmp->numverts;
-	}
-
-	YQ2_VLA( GLfloat, tex, 2 * maxNumVerts );
-#endif
-
 	for (bp = fa->polys; bp; bp = bp->next)
 	{
 		p = bp;
-#ifndef _MSC_VER // we have real VLAs, so it's safe to use one in this loop
-        YQ2_VLA(GLfloat, tex, 2*p->numverts);
-#endif
-        unsigned int index_tex = 0;
+		nv = p->numverts;
+		R_SetBufferIndices(GL_TRIANGLE_FAN, nv);
 
-		for ( i = 0, v = p->verts [ 0 ]; i < p->numverts; i++, v += VERTEXSIZE )
+		for ( i = 0, v = p->verts [ 0 ]; i < nv; i++, v += VERTEXSIZE )
 		{
 			os = v [ 3 ];
 			ot = v [ 4 ];
 
-			s = os + r_turbsin [ (int) ( ( ot * 0.125 + r_newrefdef.time ) * TURBSCALE ) & 255 ];
-			s += scroll;
-			tex[index_tex++] = s * ( 1.0 / 64 );
-
+			s = os + r_turbsin [ (int) ( ( ot * 0.125 + rdt ) * TURBSCALE ) & 255 ] + scroll;
 			t = ot + r_turbsin [ (int) ( ( os * 0.125 + rdt ) * TURBSCALE ) & 255 ];
-			tex[index_tex++] = t * ( 1.0 / 64 );
+
+			R_BufferVertex( v[0], v[1], v[2] );
+			R_BufferSingleTex( s * ( 1.0 / 64 ), t * ( 1.0 / 64 ) );
 		}
-
-		v = p->verts [ 0 ];
-
-        glEnableClientState( GL_VERTEX_ARRAY );
-        glEnableClientState( GL_TEXTURE_COORD_ARRAY );
-
-        glVertexPointer( 3, GL_FLOAT, VERTEXSIZE*sizeof(GLfloat), v );
-        glTexCoordPointer( 2, GL_FLOAT, 0, tex );
-        glDrawArrays( GL_TRIANGLE_FAN, 0, p->numverts );
-
-        glDisableClientState( GL_VERTEX_ARRAY );
-        glDisableClientState( GL_TEXTURE_COORD_ARRAY );
 	}
-
-	YQ2_VLAFREE( tex );
 }
 
 void

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -39,17 +39,18 @@
  #define GL_COLOR_INDEX8_EXT GL_COLOR_INDEX
 #endif
 
-#define TEXNUM_LIGHTMAPS 1024
-#define TEXNUM_SCRAPS 1152
-#define TEXNUM_IMAGES 1153
-#define MAX_GLTEXTURES 1024
+#define MAX_LIGHTMAPS 128
 #define MAX_SCRAPS 1
+#define TEXNUM_LIGHTMAPS 1024
+#define TEXNUM_SCRAPS (TEXNUM_LIGHTMAPS + MAX_LIGHTMAPS)
+#define TEXNUM_IMAGES (TEXNUM_SCRAPS + MAX_SCRAPS)
+#define MAX_GLTEXTURES 1024
 #define BLOCK_WIDTH 128		// default values; now defined in glstate_t
 #define BLOCK_HEIGHT 128
 #define REF_VERSION "Yamagi Quake II OpenGL Refresher"
 #define BACKFACE_EPSILON 0.01
 #define LIGHTMAP_BYTES 4
-#define MAX_LIGHTMAPS 128
+#define MAX_TEXTURE_UNITS 2
 #define GL_LIGHTMAP_FORMAT GL_RGBA
 
 /* up / down */
@@ -106,18 +107,16 @@ typedef enum
 	rserr_unknown
 } rserr_t;
 
+typedef enum
+{
+	buf_2d
+} buffered_draw_t;
+
 #include "model.h"
 
 void R_SetDefaultState(void);
 
 extern float gldepthmin, gldepthmax;
-
-typedef struct
-{
-	float x, y, z;
-	float s, t;
-	float r, g, b;
-} glvert_t;
 
 extern image_t gltextures[MAX_GLTEXTURES];
 extern int numgltextures;
@@ -287,6 +286,11 @@ void R_TextureAlphaMode(char *string);
 void R_TextureSolidMode(char *string);
 int Scrap_AllocBlock(int w, int h, int *x, int *y);
 
+void R_ApplyGLBuffer(void);
+void R_UpdateGLBuffer(buffered_draw_t type, int colortex, int lighttex, int flags, float alpha);
+void R_Buffer2DQuad(GLfloat ul_vx, GLfloat ul_vy, GLfloat dr_vx, GLfloat dr_vy,
+	GLfloat ul_tx, GLfloat ul_ty, GLfloat dr_tx, GLfloat dr_ty);
+
 #ifdef DEBUG
 void glCheckError_(const char *file, const char *function, int line);
 // Ideally, the following list should contain all OpenGL calls.
@@ -380,7 +384,7 @@ typedef struct
 
 	int lightmap_textures;
 
-	int currenttextures[2];
+	int currenttextures[MAX_TEXTURE_UNITS];
 	int currenttmu;
 	GLenum currenttarget;
 

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -111,6 +111,7 @@ typedef enum
 {
 	buf_2d,
 	buf_singletex,
+	buf_mtex,
 	buf_alpha
 } buffered_draw_t;
 
@@ -295,6 +296,7 @@ void R_Buffer2DQuad(GLfloat ul_vx, GLfloat ul_vy, GLfloat dr_vx, GLfloat dr_vy,
 void R_SetBufferIndices(GLenum type, GLuint vertices_num);
 void R_BufferVertex(GLfloat x, GLfloat y, GLfloat z);
 void R_BufferSingleTex(GLfloat s, GLfloat t);
+void R_BufferMultiTex(GLfloat cs, GLfloat ct, GLfloat ls, GLfloat lt);
 
 #ifdef DEBUG
 void glCheckError_(const char *file, const char *function, int line);

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -109,7 +109,9 @@ typedef enum
 
 typedef enum
 {
-	buf_2d
+	buf_2d,
+	buf_singletex,
+	buf_alpha
 } buffered_draw_t;
 
 #include "model.h"
@@ -290,6 +292,9 @@ void R_ApplyGLBuffer(void);
 void R_UpdateGLBuffer(buffered_draw_t type, int colortex, int lighttex, int flags, float alpha);
 void R_Buffer2DQuad(GLfloat ul_vx, GLfloat ul_vy, GLfloat dr_vx, GLfloat dr_vy,
 	GLfloat ul_tx, GLfloat ul_ty, GLfloat dr_tx, GLfloat dr_ty);
+void R_SetBufferIndices(GLenum type, GLuint vertices_num);
+void R_BufferVertex(GLfloat x, GLfloat y, GLfloat z);
+void R_BufferSingleTex(GLfloat s, GLfloat t);
 
 #ifdef DEBUG
 void glCheckError_(const char *file, const char *function, int line);

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -113,6 +113,7 @@ typedef enum
 	buf_singletex,
 	buf_mtex,
 	buf_alpha,
+	buf_alias,
 	buf_flash
 } buffered_draw_t;
 

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -108,9 +108,6 @@ typedef enum
 
 #include "model.h"
 
-void GL_BeginRendering(int *x, int *y, int *width, int *height);
-void GL_EndRendering(void);
-
 void R_SetDefaultState(void);
 
 extern float gldepthmin, gldepthmax;

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -112,7 +112,8 @@ typedef enum
 	buf_2d,
 	buf_singletex,
 	buf_mtex,
-	buf_alpha
+	buf_alpha,
+	buf_flash
 } buffered_draw_t;
 
 #include "model.h"
@@ -297,6 +298,7 @@ void R_SetBufferIndices(GLenum type, GLuint vertices_num);
 void R_BufferVertex(GLfloat x, GLfloat y, GLfloat z);
 void R_BufferSingleTex(GLfloat s, GLfloat t);
 void R_BufferMultiTex(GLfloat cs, GLfloat ct, GLfloat ls, GLfloat lt);
+void R_BufferColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a);
 
 #ifdef DEBUG
 void glCheckError_(const char *file, const char *function, int line);

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -165,7 +165,6 @@ extern cvar_t *gl1_overbrightbits;
 extern cvar_t *gl1_palettedtexture;
 extern cvar_t *gl1_pointparameters;
 extern cvar_t *gl1_multitexture;
-extern cvar_t *gl1_biglightmaps;
 
 extern cvar_t *gl1_particle_min_size;
 extern cvar_t *gl1_particle_max_size;

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -114,7 +114,8 @@ typedef enum
 	buf_mtex,
 	buf_alpha,
 	buf_alias,
-	buf_flash
+	buf_flash,
+	buf_shadow
 } buffered_draw_t;
 
 #include "model.h"

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -229,7 +229,7 @@ extern int c_visible_textures;
 extern float r_world_matrix[16];
 
 void R_TranslatePlayerSkin(int playernum);
-void R_Bind(int texnum);
+qboolean R_Bind(int texnum);
 
 void R_TexEnv(GLenum value);
 void R_SelectTexture(GLenum);
@@ -296,6 +296,7 @@ void glCheckError_(const char *file, const char *function, int line);
 // Either way, errors are caught, since error flags are persisted until the next glGetError() call.
 // So they show, even if the location of the error is inaccurate.
 #define glDrawArrays(...) glDrawArrays(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
+#define glDrawElements(...) glDrawElements(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
 #define glTexImage2D(...) glTexImage2D(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
 #define glTexSubImage2D(...) glTexSubImage2D(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)
 #define glTexEnvf(...) glTexEnvf(__VA_ARGS__); glCheckError_(__FILE__, __func__, __LINE__)


### PR DESCRIPTION
_Quake III Arena_ was a revolution because of its use of "_shaders_", which doesn't refer about the "_programmable pipeline_" (the modern sense), but to the scripted features of a surface, which in backend meant the replacing of many small `glDrawArrays()` calls with a single big `glDrawElements()` call, which many OpenGL documents will agree is the preferred way to pursue an increase of performance.

The short version of the thinking behind this is: if there are a lot of `glDrawArrays()` with GL_TRIANGLE_FANs (or any other primitive) with the same texture, instead create indices that regenerate these FANs (or primitives) manually, and at the end do a `glDrawElements()` call, which use these indices to draw instead of the original vertices. May sound more expensive, but indices + vertices don't use much more space than the vertices alone, and as OpenGL uses a "client-server" architecture internally, 1 communication established between CPU and GPU is a lot less than the 6, or more, it uses to draw the same primitives in a normal scene.

Some Q2 ports like _Knightmare_ and [Thenesis Quake 2](https://github.com/thenesis-org/lp-public) use a similar technique for drawing, and here I'm presenting my version, which IMHO is more respectful of the original Q2 functions' organization, while being more readable, or at least simpler to follow in code. All this work reduces the OpenGL calls to around ~1500 per frame which, while still over the ~1000 Quake 3 uses, is better than the current ~8000 Yamagi / vanilla Q2 has. These numbers were obtained thanks to [apitrace](https://github.com/apitrace/apitrace).

By disabling vsync, and using `timedemo 1` with different demos (especially Xatrix's `xdemo1.dm2`), up to a ~45% speed improvement can be observed against the current master. As usual, the worse the hardware, the better the test :)

One major difference with other implementations is the reduction of calls to `glTexSubImage2D()`, which in this PR gets reduced to one call per lightmap, per frame. This is thanks to the pre-calculation of dynamic lights for `mod_brush` models before they are drawn, in the `R_GetBrushesLighting()` function.

Note: calls to `glTexSubImage2D()` are normally sluggish. But for big sized textures, those calls are even slower, and not many times dynamic lights cover more than two of the classic 128x128 area, so the advantage of grouping many surfaces under one lightmap was lost. Having big lightmaps used to be fast, but after this batching of draw calls, it became a nuisance, so I partially removed it and restored the classic 128x128 area. Original `gl1_biglightmaps` logic remains underneath, but it's preferable not to make it visible to the user. Let's see if there's a need to restore it in the future.

While I don't have the hardware to test it, I believe this PR can help a lot with issue #949, since this work's approach to rendering gets it a little bit closer to Q3A/RTCW.

@DanielGibson: if you still have it, can you test this PR with your Raspberry Pi 4? I believe the work done here, applied to the GLES3 renderer, can help a lot with its performance. Just a thought.

Credits and thanks to @Paril for his explanation of Q2's dynamic lighting in Discord.