### PR TITLE
Infinite loop in R_GetBrushesLighting() function, hangs the game

### DIFF
--- a/src/client/refresh/gl1/gl1_surf.c
+++ b/src/client/refresh/gl1/gl1_surf.c
@@ -1143,9 +1143,9 @@ R_GetBrushesLighting(void)
 		for (k = 0; k < currentmodel->nummodelsurfaces; k++, surf++)
 		{
 			if (surf->texinfo->flags & (SURF_TRANS33 | SURF_TRANS66 | SURF_WARP)
-				|| surf->flags & SURF_DRAWTURB)
+				|| surf->flags & SURF_DRAWTURB || surf->lmchain_frame == r_framecount)
 			{
-				continue;
+				continue;	// either not affected by light, or already in the chain
 			}
 
 			// find which side of the node we are on
@@ -1155,6 +1155,7 @@ R_GetBrushesLighting(void)
 			if (((surf->flags & SURF_PLANEBACK) && (dot < -BACKFACE_EPSILON)) ||
 				(!(surf->flags & SURF_PLANEBACK) && (dot > BACKFACE_EPSILON)))
 			{
+				surf->lmchain_frame = r_framecount;	// don't add this twice to the chain
 				surf->lightmapchain = gl_lms.lightmap_surfaces[surf->lightmaptexturenum];
 				gl_lms.lightmap_surfaces[surf->lightmaptexturenum] = surf;
 			}

--- a/src/client/refresh/gl1/header/model.h
+++ b/src/client/refresh/gl1/header/model.h
@@ -59,6 +59,7 @@ typedef struct msurface_s
 	glpoly_t *polys;                /* multiple if warped */
 	struct  msurface_s *texturechain;
 	struct  msurface_s *lightmapchain;
+	int lmchain_frame;	// avoids adding this surface twice to the lightmap chain
 
 	mtexinfo_t *texinfo;
 


### PR DESCRIPTION
First of all, my apologies for this, because I added this to the game, and it currently affects v8.40.

I thought of opening an issue for this, but since I'm responsible, I'd rather offer the solution.

As usual, for all the things I tested for PR #1124, it failed in the simplest: in `base3` map, when you reach the outdoor courtyard with the blue key door, the game hangs. The reason is the new `R_GetBrushesLighting()` function I added to the PR.

This function adds surfaces of brushes from the entity list to the lightmap chain, so the lightmap changes for brushes are done together with the world's lightmap changes, instead of doing them separately, improving the game's performance by a pretty decent margin. The problem: some of the surfaces in this list of brushes appear _more than once_, adding them twice to the lightmap chain, provoking the chain to go circular. Yup, the game hangs because it enters an infinite loop. I haven't encountered this until now, in `base3` map. I tested #1124 with Q2 demo version and `base3` works just fine there. I assume these "repeated" surfaces brushes are the exploding boxes the Enforcer activates with the alarm button.

The present PR does a simple task: if the loop that adds surfaces to the lightmap chain finds that the surface has been added in this frame, then ignores it and continue. Otherwise, registers the current frame in the surface and adds it to the chain.

Again, I'm sorry, and I hope this doesn't generate too much problems for you.