### PR TITLE
Fixed spawntemp data leaking into mid-level spawned entities

### DIFF
--- a/src/game/g_spawn.c
+++ b/src/game/g_spawn.c
@@ -700,6 +700,9 @@ SpawnEntities(const char *mapname, char *entities, const char *spawnpoint)
 		ED_CallSpawn(ent);
 	}
 
+	/* in case the last entity in the entstring has spawntemp fields */
+	memset(&st, 0, sizeof(st));
+
 	gi.dprintf("%i entities inhibited.\n", inhibit);
 
 	G_FindTeams();


### PR DESCRIPTION
This PR addresses https://github.com/yquake2/yquake2/issues/1139.

This happens because `st` is reset 'before' parsing each entity in the string, so after the very last entity has been parsed, `st` won't be reset and its data remains for the rest of the level, accessible to entities spawed by for example a target_spawner, or the makron.

The fix was to simply add a `memset` after the spawn loop in `SpawnEntities`.

This issue can also apply to child entities, like for example door triggers. But those don't use any spawntemp fields as far as I know, but still worth noting for future reference.