### PR TITLE
AI, HuntTarget fix runtime warning.

### DIFF
--- a/src/game/g_ai.c
+++ b/src/game/g_ai.c
@@ -419,6 +419,10 @@ HuntTarget(edict_t *self)
 	{
 		VectorSubtract(self->enemy->s.origin, self->s.origin, vec);
 	}
+	else
+	{
+		VectorClear(vec);
+	}
 
 	self->ideal_yaw = vectoyaw(vec);
 


### PR DESCRIPTION
`Conditional jump or move depends on unitialised value(s)...HuntTarget (g_ai.c:423)...`