### PR TITLE
Fix memory leaks

### DIFF
--- a/src/client/cl_effects.c
+++ b/src/client/cl_effects.c
@@ -54,7 +54,8 @@ CL_AddMuzzleFlash(void)
 
 	if ((i < 1) || (i >= MAX_EDICTS))
 	{
-		Com_Error(ERR_DROP, "CL_AddMuzzleFlash: bad entity");
+		Com_Error(ERR_DROP, "%s: bad entity %d >= %d\n",
+			__func__, i, MAX_EDICTS);
 	}
 
 	weapon = MSG_ReadByte(&net_message);
@@ -334,14 +335,15 @@ CL_AddMuzzleFlash2(void)
 
 	if ((ent < 1) || (ent >= MAX_EDICTS))
 	{
-		Com_Error(ERR_DROP, "CL_AddMuzzleFlash2: bad entity");
+		Com_Error(ERR_DROP, "%s: bad entity %d >= %d\n",
+			__func__, ent, MAX_EDICTS);
 	}
 
 	flash_number = MSG_ReadByte(&net_message);
 
 	if (flash_number > 210)
 	{
-		Com_DPrintf("CL_AddMuzzleFlash2: bad offset");
+		Com_DPrintf("%s: bad offset\n", __func__);
 		return;
 	}
 

--- a/src/client/cl_entities.c
+++ b/src/client/cl_entities.c
@@ -864,7 +864,8 @@ CL_GetEntitySoundOrigin(int ent, vec3_t org)
 
 	if ((ent < 0) || (ent >= MAX_EDICTS))
 	{
-		Com_Error(ERR_DROP, "CL_GetEntitySoundOrigin: bad ent");
+		Com_Error(ERR_DROP, "%s: bad entity %d >= %d\n",
+			__func__, ent, MAX_EDICTS);
 	}
 
 	old = &cl_entities[ent];
@@ -881,7 +882,8 @@ CL_GetEntitySoundVelocity(int ent, vec3_t vel)
 
 	if ((ent < 0) || (ent >= MAX_EDICTS))
 	{
-		Com_Error(ERR_DROP, "CL_GetEntitySoundVelocity: bad ent");
+		Com_Error(ERR_DROP, "%s: bad entity %d >= %d\n",
+			__func__, ent, MAX_EDICTS);
 	}
 
 	old = &cl_entities[ent];

--- a/src/client/cl_image.c
+++ b/src/client/cl_image.c
@@ -265,9 +265,15 @@ PCX_Decode(const char *name, const byte *raw, int len, byte **pic, byte **palett
 				return;
 			}
 
-			if ((len > 768) && (((byte *)pcx)[len - 769] == 0x0C))
+			if (len > 768)
 			{
 				memcpy(*palette, (byte *)pcx + len - 768, 768);
+
+				if ((((byte *)pcx)[len - 769] != 0x0C))
+				{
+					Com_DPrintf("%s: %s has no palette marker\n",
+						__func__, name);
+				}
 			}
 			else
 			{

--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -380,12 +380,13 @@ CL_ParsePacketEntities(frame_t *oldframe, frame_t *newframe)
 
 		if (newnum >= MAX_EDICTS)
 		{
-			Com_Error(ERR_DROP, "CL_ParsePacketEntities: bad number:%i", newnum);
+			Com_Error(ERR_DROP, "%s: bad entity %d >= %d\n",
+				__func__, newnum, MAX_EDICTS);
 		}
 
 		if (net_message.readcount > net_message.cursize)
 		{
-			Com_Error(ERR_DROP, "CL_ParsePacketEntities: end of message");
+			Com_Error(ERR_DROP, "%s: end of message", __func__);
 		}
 
 		if (!newnum)
@@ -1192,7 +1193,8 @@ CL_ParseStartSoundPacket(void)
 
 		if (ent > MAX_EDICTS)
 		{
-			Com_Error(ERR_DROP, "CL_ParseStartSoundPacket: ent = %i", ent);
+			Com_Error(ERR_DROP, "%s: bad entity %d >= %d\n",
+				__func__, ent, MAX_EDICTS);
 		}
 
 		channel &= 7;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5695,10 +5695,18 @@ HasSkinsInDir(const char *dirname, int *num)
 
 			for (j = 0; j < num_png; j ++)
 			{
-				if (list_png[j] && !strchr(list_png[j] + dirname_size, '/'))
+				if (list_png[j])
 				{
-					*curr = list_png[j];
-					curr++;
+					if (!strchr(list_png[j] + dirname_size, '/'))
+					{
+						*curr = list_png[j];
+						curr++;
+					}
+					else
+					{
+						/* unused in final response */
+						free(list_png[j]);
+					}
 				}
 			}
 
@@ -5711,10 +5719,18 @@ HasSkinsInDir(const char *dirname, int *num)
 
 			for (j = 0; j < num_pcx; j ++)
 			{
-				if (list_pcx[j] && !strchr(list_pcx[j] + dirname_size, '/'))
+				if (list_pcx[j])
 				{
-					*curr = list_pcx[j];
-					curr++;
+					if (!strchr(list_pcx[j] + dirname_size, '/'))
+					{
+						*curr = list_pcx[j];
+						curr++;
+					}
+					else
+					{
+						/* unused in final response */
+						free(list_pcx[j]);
+					}
 				}
 			}
 

--- a/src/client/refresh/files/pcx.c
+++ b/src/client/refresh/files/pcx.c
@@ -340,9 +340,15 @@ PCX_Decode(const char *name, const byte *raw, int len, byte **pic, byte **palett
 				return;
 			}
 
-			if ((len > 768) && (((byte *)pcx)[len - 769] == 0x0C))
+			if (len > 768)
 			{
 				memcpy(*palette, (byte *)pcx + len - 768, 768);
+
+				if ((((byte *)pcx)[len - 769] != 0x0C))
+				{
+					R_Printf(PRINT_DEVELOPER, "%s: %s has no palette marker\n",
+						__func__, name);
+				}
 			}
 			else
 			{

--- a/src/client/refresh/gl1/gl1_lightmap.c
+++ b/src/client/refresh/gl1/gl1_lightmap.c
@@ -109,8 +109,7 @@ LM_UploadBlock(qboolean dynamic)
 	}
 	else
 	{
-		gl_lms.internal_format = GL_LIGHTMAP_FORMAT;
-		glTexImage2D(GL_TEXTURE_2D, 0, gl_lms.internal_format,
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_LIGHTMAP_FORMAT,
 				gl_state.block_width, gl_state.block_height,
 				0, GL_LIGHTMAP_FORMAT, GL_UNSIGNED_BYTE,
 				gl_lms.lightmap_buffer[buffer]);
@@ -123,7 +122,7 @@ LM_UploadBlock(qboolean dynamic)
 				R_Bind(gl_state.lightmap_textures + (gl_state.max_lightmaps * i) + texture);
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-				glTexImage2D(GL_TEXTURE_2D, 0, gl_lms.internal_format,
+				glTexImage2D(GL_TEXTURE_2D, 0, GL_LIGHTMAP_FORMAT,
 					gl_state.block_width, gl_state.block_height,
 					0, GL_LIGHTMAP_FORMAT, GL_UNSIGNED_BYTE,
 					gl_lms.lightmap_buffer[buffer]);
@@ -326,7 +325,6 @@ LM_BeginBuildingLightmaps(model_t *m)
 	}
 
 	gl_lms.current_lightmap_texture = 1;
-	gl_lms.internal_format = GL_LIGHTMAP_FORMAT;
 
 	if (gl_config.multitexture)
 	{
@@ -341,7 +339,7 @@ LM_BeginBuildingLightmaps(model_t *m)
 	R_Bind(gl_state.lightmap_textures + 0);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexImage2D(GL_TEXTURE_2D, 0, gl_lms.internal_format,
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_LIGHTMAP_FORMAT,
 			gl_state.block_width, gl_state.block_height,
 			0, GL_LIGHTMAP_FORMAT, GL_UNSIGNED_BYTE,
 			gl_lms.lightmap_buffer[0]);

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -463,7 +463,6 @@ typedef struct
 
 typedef struct
 {
-	int internal_format;
 	int current_lightmap_texture;
 
 	msurface_t *lightmap_surfaces[MAX_LIGHTMAPS];

--- a/src/client/refresh/gl3/gl3_lightmap.c
+++ b/src/client/refresh/gl3/gl3_lightmap.c
@@ -56,8 +56,7 @@ GL3_LM_UploadBlock(void)
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
-		gl3_lms.internal_format = GL_LIGHTMAP_FORMAT;
-		glTexImage2D(GL_TEXTURE_2D, 0, gl3_lms.internal_format,
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_LIGHTMAP_FORMAT,
 		             BLOCK_WIDTH, BLOCK_HEIGHT, 0, GL_LIGHTMAP_FORMAT,
 		             GL_UNSIGNED_BYTE, gl3_lms.lightmap_buffers[map]);
 	}
@@ -255,7 +254,6 @@ GL3_LM_BeginBuildingLightmaps(gl3model_t *m)
 	gl3_newrefdef.lightstyles = lightstyles;
 
 	gl3_lms.current_lightmap_texture = 0;
-	gl3_lms.internal_format = GL_LIGHTMAP_FORMAT;
 
 	// Note: the dynamic lightmap used to be initialized here, we don't use that anymore.
 }

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -317,7 +317,6 @@ enum {MAX_GL3TEXTURES = 1024};
 
 typedef struct
 {
-	int internal_format;
 	int current_lightmap_texture; // index into gl3state.lightmap_textureIDs[]
 
 	//msurface_t *lightmap_surfaces[MAX_LIGHTMAPS]; - no more lightmap chains, lightmaps are rendered multitextured

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -731,6 +731,12 @@ FS_LoadFile(const char *path, void **buffer)
 
 	if (size <= 0)
 	{
+		if (size == 0)
+		{
+			/* empty file, close before exit*/
+			FS_FCloseFile(f);
+		}
+
 		if (buffer)
 		{
 			*buffer = NULL;

--- a/src/common/movemsg.c
+++ b/src/common/movemsg.c
@@ -444,7 +444,8 @@ MSG_WriteDeltaEntity(entity_state_t *from,
 
 	if (to->number >= MAX_EDICTS)
 	{
-		Com_Error(ERR_FATAL, "Entity number >= MAX_EDICTS");
+		Com_Error(ERR_DROP, "%s: bad entity %d >= %d\n",
+			__func__, to->number, MAX_EDICTS);
 	}
 
 	/* send an update */

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -122,6 +122,11 @@ SV_CreateBaseline(void)
 
 		/* take current state as baseline */
 		VectorCopy(svent->s.origin, svent->s.old_origin);
+		if (entnum >= MAX_EDICTS)
+		{
+			Com_Error(ERR_DROP, "%s: bad entity %d >= %d\n",
+				__func__, entnum, MAX_EDICTS);
+		}
 		sv.baselines[entnum] = svent->s;
 	}
 }


### PR DESCRIPTION
* Fix memory leak with merge skin files names in menu in #1130 
* Fix file header leak for empty file
* Small cleanup for light map format in gl* renders.
* Fix crash received message with entity id bigger than static buffer of entities.