### PR TITLE
Improvements for GL1/GLES1

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -508,7 +508,8 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   squares.
 
 * **gl1_stencilshadow**: If `gl_shadows` is set to `1`, this makes them
-  look a bit better (no flickering) by using the stencil buffer.
+  look a bit better (no flickering) by using the stencil buffer. Does
+  not work when `gl1_stereo` is `3`, `4` or `5`.
 
 * **gl1_lightmapcopies**: When enabled (`1`), keep 3 copies of the same
   lightmap rotating, shifting to another one when drawing a new frame.

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -517,9 +517,10 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   (dynamic lighting) causes slowdown. By default in GL1 is disabled,
   while in GLES1 is enabled. Needs `gl1_multitexture 1` & `vid_restart`.
 
-* **gl1_discardfb**: Only available in ES1. If set to `1` (default),
-  send a hint to discard framebuffers after finishing a frame. Useful
-  for GPUs that attempt to reuse them, something Quake 2 doesn't do.
+* **gl1_discardfb**: If `1`, clear color, depth and stencil buffers at
+  the start of a frame, and discard them at the end if possible. If
+  `2`, do only depth and stencil, no color. Increases performance in
+  mobile / embedded. Default in GL1 is `0`, while in GLES1 is `1`.
 
 
 ## Graphics (OpenGL 3.2 and OpenGL ES3 only)

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -1803,17 +1803,17 @@ RI_BeginFrame(float camera_separation)
 	gl_state.camera_separation = camera_separation;
 
 	// force a vid_restart if gl1_stereo has been modified.
-	if ( gl_state.stereo_mode != gl1_stereo->value ) {
+	if ( gl_state.stereo_mode != gl1_stereo->value )
+	{
 		// If we've gone from one mode to another with the same special buffer requirements there's no need to restart.
-		if ( GL_GetSpecialBufferModeForStereoMode( gl_state.stereo_mode ) == GL_GetSpecialBufferModeForStereoMode( gl1_stereo->value )  ) {
+		if ( GL_GetSpecialBufferModeForStereoMode( gl_state.stereo_mode ) == GL_GetSpecialBufferModeForStereoMode( gl1_stereo->value ) )
+		{
 			gl_state.stereo_mode = gl1_stereo->value;
 		}
 		else
 		{
 			R_Printf(PRINT_ALL, "stereo supermode changed, restarting video!\n");
-			cvar_t	*ref;
-			ref = ri.Cvar_Get("vid_fullscreen", "0", CVAR_ARCHIVE);
-			ref->modified = true;
+			ri.Cmd_ExecuteText(EXEC_APPEND, "vid_restart\n");
 		}
 	}
 

--- a/src/client/refresh/gl1/gl1_mesh.c
+++ b/src/client/refresh/gl1/gl1_mesh.c
@@ -207,6 +207,11 @@ R_DrawAliasFrameLerp(entity_t *currententity, dmdl_t *paliashdr, float backlerp)
 static void
 R_DrawAliasShadow(entity_t *currententity, dmdl_t *paliashdr, int posenum)
 {
+	// Don't do stencil test on unsupported stereo modes
+	const qboolean stencilt = ( gl_state.stencil && gl1_stencilshadow->value &&
+		( gl_state.stereo_mode < STEREO_MODE_ROW_INTERLEAVED
+		|| gl_state.stereo_mode > STEREO_MODE_PIXEL_INTERLEAVED ) );
+
 	int *order;
 	vec3_t point;
 	float height = 0, lheight;
@@ -219,7 +224,7 @@ R_DrawAliasShadow(entity_t *currententity, dmdl_t *paliashdr, int posenum)
 	R_UpdateGLBuffer(buf_shadow, 0, 0, 0, 1);
 
 	/* stencilbuffer shadows */
-	if (gl_state.stencil && gl1_stencilshadow->value)
+	if (stencilt)
 	{
 		glEnable(GL_STENCIL_TEST);
 		glStencilFunc(GL_EQUAL, 1, 2);
@@ -265,7 +270,7 @@ R_DrawAliasShadow(entity_t *currententity, dmdl_t *paliashdr, int posenum)
 	R_ApplyGLBuffer();
 
 	/* stencilbuffer shadows */
-	if (gl_state.stencil && gl1_stencilshadow->value)
+	if (stencilt)
 	{
 		glDisable(GL_STENCIL_TEST);
 	}

--- a/src/client/refresh/gl1/gl1_misc.c
+++ b/src/client/refresh/gl1/gl1_misc.c
@@ -169,7 +169,6 @@ R_Strings(void)
 void
 R_SetDefaultState(void)
 {
-	glClearColor(1, 0, 0.5, 0.5);
 	glDisable(GL_MULTISAMPLE);
 	glCullFace(GL_FRONT);
 	glEnable(GL_TEXTURE_2D);

--- a/src/client/refresh/gl1/gl1_sdl.c
+++ b/src/client/refresh/gl1/gl1_sdl.c
@@ -38,6 +38,8 @@ static SDL_GLContext context = NULL;
 qboolean IsHighDPIaware = false;
 static qboolean vsyncActive = false;
 
+extern cvar_t *gl1_discardfb;
+
 // ----
 
 /*
@@ -47,13 +49,26 @@ void
 RI_EndFrame(void)
 {
 	R_ApplyGLBuffer();	// to draw buffered 2D text
+
 #ifdef YQ2_GL1_GLES
-	if (gl_config.discardfb)
+	static const GLenum attachments[3] = {GL_COLOR_EXT, GL_DEPTH_EXT, GL_STENCIL_EXT};
+
+	if (qglDiscardFramebufferEXT)
 	{
-		static const GLenum attachments[] = { GL_DEPTH_EXT, GL_STENCIL_EXT };
-		qglDiscardFramebufferEXT(GL_FRAMEBUFFER_OES, 2, attachments);
+		switch ((int)gl1_discardfb->value)
+		{
+			case 1:
+				qglDiscardFramebufferEXT(GL_FRAMEBUFFER_OES, 3, &attachments[0]);
+				break;
+			case 2:
+				qglDiscardFramebufferEXT(GL_FRAMEBUFFER_OES, 2, &attachments[1]);
+				break;
+			default:
+				break;
+		}
 	}
 #endif
+
 	SDL_GL_SwapWindow(window);
 }
 

--- a/src/client/refresh/gl1/gl1_surf.c
+++ b/src/client/refresh/gl1/gl1_surf.c
@@ -114,7 +114,7 @@ R_DrawTriangleOutlines(void)
 
                     for (k=0; k<3; k++)
                     {
-                       vtx[0+k] = p->verts [ 0 ][ k ];
+                        vtx[0+k] = p->verts [ 0 ][ k ];
                         vtx[3+k] = p->verts [ j - 1 ][ k ];
                         vtx[6+k] = p->verts [ j ][ k ];
                         vtx[9+k] = p->verts [ 0 ][ k ];
@@ -388,7 +388,7 @@ R_BlendLightmaps(const model_t *currentmodel)
 }
 
 static void
-R_RenderBrushPoly(entity_t *currententity, msurface_t *fa)
+R_RenderBrushPoly(msurface_t *fa)
 {
 	int maps;
 	qboolean is_dynamic = false;
@@ -526,10 +526,10 @@ R_DrawAlphaSurfaces(void)
 }
 
 static void
-R_RenderLightmappedPoly(entity_t *currententity, msurface_t *surf)
+R_RenderLightmappedPoly(msurface_t *surf)
 {
+	const int nv = surf->polys->numverts;
 	int i;
-	int nv = surf->polys->numverts;
 	float scroll;
 	float *v;
 
@@ -747,7 +747,7 @@ dynamic_surf:
 }
 
 static void
-R_DrawTextureChains(entity_t *currententity)
+R_DrawTextureChains(void)
 {
 	int i;
 	msurface_t *s;
@@ -776,7 +776,7 @@ R_DrawTextureChains(entity_t *currententity)
 			for ( ; s; s = s->texturechain)
 			{
 				R_UpdateGLBuffer(buf_singletex, image->texnum, 0, s->flags, 1);
-				R_RenderBrushPoly(currententity, s);
+				R_RenderBrushPoly(s);
 			}
 
 			image->texturechain = NULL;
@@ -799,7 +799,7 @@ R_DrawTextureChains(entity_t *currententity)
 				if (!(s->flags & SURF_DRAWTURB))
 				{
 					R_UpdateGLBuffer(buf_mtex, image->texnum, s->lightmaptexturenum, 0, 1);
-					R_RenderLightmappedPoly(currententity, s);
+					R_RenderLightmappedPoly(s);
 				}
 			}
 		}
@@ -819,7 +819,7 @@ R_DrawTextureChains(entity_t *currententity)
 				if (s->flags & SURF_DRAWTURB)
 				{
 					R_UpdateGLBuffer(buf_singletex, image->texnum, 0, s->flags, 1);
-					R_RenderBrushPoly(currententity, s);
+					R_RenderBrushPoly(s);
 				}
 			}
 
@@ -887,12 +887,12 @@ R_DrawInlineBModel(entity_t *currententity, const model_t *currentmodel)
 				{
 					// Dynamic lighting already generated in R_GetBrushesLighting()
 					R_UpdateGLBuffer(buf_mtex, image->texnum, psurf->lightmaptexturenum, 0, 1);
-					R_RenderLightmappedPoly(currententity, psurf);
+					R_RenderLightmappedPoly(psurf);
 				}
 				else
 				{
 					R_UpdateGLBuffer(buf_singletex, image->texnum, 0, psurf->flags, 1);
-					R_RenderBrushPoly(currententity, psurf);
+					R_RenderBrushPoly(psurf);
 				}
 			}
 		}
@@ -1246,7 +1246,7 @@ R_DrawWorld(void)
 	R_RecursiveWorldNode(&ent, r_worldmodel->nodes);
 	R_GetBrushesLighting();
 	R_RegenAllLightmaps();
-	R_DrawTextureChains(&ent);
+	R_DrawTextureChains();
 	R_BlendLightmaps(r_worldmodel);
 	R_DrawSkyBox();
 	R_DrawTriangleOutlines();

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -148,8 +148,6 @@ typedef struct	//	832k aprox.
 
 #include "model.h"
 
-void R_SetDefaultState(void);
-
 extern glbuffer_t gl_buf;
 extern float gldepthmin, gldepthmax;
 
@@ -427,7 +425,6 @@ typedef struct
 	qboolean pointparameters;
 	qboolean multitexture;
 	qboolean lightmapcopies;	// many copies of same lightmap, for embedded
-	qboolean discardfb;
 
 	// ----
 


### PR DESCRIPTION
### 1. Fixed stencil shadow in stereo modes

When shadows with stencil enabled (`r_shadows` & `gl1_stencilshadow`) were used with `gl1_stereo` between `3` and `5`, the renderer was doing a "_wallhack_", showing entities behind walls. Fix is just disabling stencil for shadow in these stereo modes, since they use the stencil buffer for their own operation.

### 2. Stereo 3D modes (gl1_stereo) allowed in GLES1

Availability of each mode still depend on the hardware, e.g. RPi3 doesn't do modes `3` to `5`, not even in _RaspiOS Bookworm_ using GL1. At least it's no longer locked by software, and now RPi3 does `2`, `6` and `7` in both GL1 and GLES1.
This marks the end of the usage of classic `glBegin()`/`glEnd()` pairing in this renderer.

### 3. gl1_discardfb functionality expanded

Now it can be used in GL1. Taking a hint from [ARM Mali performance tips](https://developer.arm.com/community/arm-community-blogs/b/mobile-graphics-and-gaming-blog/posts/mali-performance-2-how-to-correctly-handle-framebuffers), we call `glClear()` at the start of each frame, and at the end, we call `glDiscardFramebufferEXT()` with the same parameters. The last step is only available with GLES1, but it seems the first is the most important one, since in the RPi3  it helps in _Bookworm_ and _Arch_ using GL1.
When `gl1_discardfb` is `1`, we clear stencil and depth, and when `2`, we additionally clear color, which at least in a RPi3 is even more helpful with performance, getting almost a 10% improvement over the current master branch.
Note that the "_clear color_" is black, unless `r_clear` is set.