### PR TITLE
soft: fix texture lock

### DIFF
--- a/src/client/refresh/soft/sw_main.c
+++ b/src/client/refresh/soft/sw_main.c
@@ -2194,7 +2194,11 @@ RE_CleanFrame(void)
 	memset(swap_buffers, 0,
 		vid_buffer_height * vid_buffer_width * sizeof(pixel_t) * 2);
 
+#ifdef USE_SDL3
 	if (!SDL_LockTexture(texture, NULL, (void**)&pixels, &pitch))
+#else
+	if (SDL_LockTexture(texture, NULL, (void**)&pixels, &pitch))
+#endif
 	{
 		Com_Printf("Can't lock texture: %s\n", SDL_GetError());
 		return;
@@ -2214,7 +2218,11 @@ RE_FlushFrame(int vmin, int vmax)
 	int pitch;
 	Uint32 *pixels;
 
+#ifdef USE_SDL3
 	if (!SDL_LockTexture(texture, NULL, (void**)&pixels, &pitch))
+#else
+	if (SDL_LockTexture(texture, NULL, (void**)&pixels, &pitch))
+#endif
 	{
 		Com_Printf("Can't lock texture: %s\n", SDL_GetError());
 		return;


### PR DESCRIPTION
Regression has been  introduced in 39d2c7dbb45d53678e82baa1e727d2647d5ee755 as sdl3 has changed logic of SDL_LockTexture function call.