### PR TITLE
Clipboard and in-line editing for menu input fields

### DIFF
--- a/src/client/cl_keyboard.c
+++ b/src/client/cl_keyboard.c
@@ -1420,7 +1420,8 @@ Key_Event(int key, qboolean down, qboolean special)
 	/* FIXME: Better way to do CTRL+<key> actions in the console?
 	   special should be set to true in this case.
 	*/
-	if (keydown[K_CTRL] && IsInConsole() &&
+	if (keydown[K_CTRL] &&
+		(IsInConsole() || cls.key_dest == key_menu) &&
 		key >= 'a' && key <= 'z')
 	{
 		special = true;

--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -103,7 +103,6 @@ typedef struct
 	int cursor;
 	int length;
 	int visible_length;
-	int visible_offset;
 } menufield_s;
 
 typedef struct

--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -138,6 +138,7 @@ typedef struct
 
 void M_PushMenu(menuframework_s* menu);
 
+void Field_ResetCursor(menuframework_s *m);
 qboolean Field_Key(menufield_s *field, int key);
 
 void Menu_AddItem(menuframework_s *menu, void *item);

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -325,12 +325,19 @@ Default_MenuKey(menuframework_s *m, int key)
     switch (menu_key)
     {
     case K_ESCAPE:
+        if (m)
+        {
+            Field_ResetCursor(m);
+        }
+
         M_PopMenu();
         return menu_out_sound;
 
     case K_UPARROW:
         if (m)
         {
+            Field_ResetCursor(m);
+
             m->cursor--;
             Menu_AdjustCursor(m, -1);
             sound = menu_move_sound;
@@ -340,6 +347,8 @@ Default_MenuKey(menuframework_s *m, int key)
     case K_DOWNARROW:
         if (m)
         {
+            Field_ResetCursor(m);
+
             m->cursor++;
             Menu_AdjustCursor(m, 1);
             sound = menu_move_sound;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -311,17 +311,14 @@ Default_MenuKey(menuframework_s *m, int key)
 
     if (m)
     {
-        menucommon_s *item;
+        menucommon_s *item = Menu_ItemAtCursor(m);
 
-        if ((item = Menu_ItemAtCursor(m)) != 0)
+        if (item && item->type == MTYPE_FIELD)
         {
-            if (item->type == MTYPE_FIELD)
-            {
-                if (Field_Key((menufield_s *)item, key))
-                {
-                    return NULL;
-                }
-            }
+               if (Field_Key((menufield_s *)item, key))
+               {
+                   return NULL;
+               }
         }
     }
 
@@ -5237,6 +5234,7 @@ AddressBook_MenuInit(void)
 
     for (i = 0; i < NUM_ADDRESSBOOK_ENTRIES; i++)
     {
+		menufield_s *f;
         const cvar_t *adr;
         char buffer[20];
 
@@ -5244,19 +5242,22 @@ AddressBook_MenuInit(void)
 
         adr = Cvar_Get(buffer, "", CVAR_ARCHIVE);
 
-        s_addressbook_fields[i].generic.type = MTYPE_FIELD;
-        s_addressbook_fields[i].generic.name = 0;
-        s_addressbook_fields[i].generic.callback = 0;
-        s_addressbook_fields[i].generic.x = 0;
-        s_addressbook_fields[i].generic.y = i * 18 + 0;
-        s_addressbook_fields[i].generic.localdata[0] = i;
-        s_addressbook_fields[i].cursor = 0;
-        s_addressbook_fields[i].length = 60;
-        s_addressbook_fields[i].visible_length = 30;
+		f = &s_addressbook_fields[i];
 
-        strcpy(s_addressbook_fields[i].buffer, adr->string);
+        f->generic.type = MTYPE_FIELD;
+        f->generic.name = 0;
+        f->generic.callback = 0;
+        f->generic.x = 0;
+        f->generic.y = i * 18 + 0;
+        f->generic.localdata[0] = i;
 
-        Menu_AddItem(&s_addressbook_menu, &s_addressbook_fields[i]);
+        f->length = 60;
+        f->visible_length = 30;
+
+        Q_strlcpy(f->buffer, adr->string, f->length);
+        f->cursor = strlen(f->buffer);
+
+        Menu_AddItem(&s_addressbook_menu, f);
     }
 }
 

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -215,6 +215,19 @@ Field_Draw(menufield_s *f)
 	}
 }
 
+void
+Field_ResetCursor(menuframework_s *m)
+{
+	menucommon_s *item = Menu_ItemAtCursor(m);
+
+	if (item && item->type == MTYPE_FIELD)
+	{
+		menufield_s *f = (menufield_s *)item;
+
+		f->cursor = strlen(f->buffer);
+	}
+}
+
 extern int keydown[];
 
 qboolean

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -291,6 +291,7 @@ Field_Key(menufield_s *f, int key)
 			}
 			break;
 
+		case K_KP_RIGHTARROW:
 		case K_RIGHTARROW:
 			if (f->buffer[f->cursor] != '\0')
 			{
@@ -303,6 +304,17 @@ Field_Key(menufield_s *f, int key)
 			{
 				Q_strdel(f->buffer, f->cursor - 1, 1);
 				f->cursor--;
+			}
+			break;
+
+		case K_END:
+			if (f->buffer[f->cursor] == '\0')
+			{
+				f->cursor = 0;
+			}
+			else
+			{
+				f->cursor = strlen(f->buffer);
 			}
 			break;
 

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -335,6 +335,7 @@ void Q_strdel(char *s, size_t i, size_t n);
 /* Insert src into dest starting at index i, total, n is the total size of the buffer */
 /* Returns length of src on success, 0 if there is not enough space in dest for src */
 size_t Q_strins(char *dest, const char *src, size_t i, size_t n);
+qboolean Q_strisnum(const char *s);
 
 /* ============================================= */
 

--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -1190,6 +1190,20 @@ Q_strins(char *dest, const char *src, size_t i, size_t n)
 	return slen;
 }
 
+qboolean
+Q_strisnum(const char *s)
+{
+	for (; *s != '\0'; s++)
+	{
+		if (!isdigit(*s))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
 /*
  * An unicode compatible fopen() Wrapper for Windows.
  */


### PR DESCRIPTION
This PR adds clipboard support and line editing extensions to menu fields (like the server address book).

CTRL actions:
* CTRL+V - Pastes clipboard into the current input field
* CTRL+C - Copies the input field content to the clipboard
* CTRL+X - Same as CTRL+C but clears the input field afterwards
* CTRL+L - Clears the current input field

Line navigation:
* Left/right arrows move the cursor left/right through the line, allowing for in-line editing
* Delete key deletes the character highlighted by the cursor
* Page End key jumps the cursor between the start and end of the current input string

And I added a new shared function, `Q_strisnum`, to test if a string is only made up of digits (for pasting input into number-only fields).

I also spotted an unsafe use of `strcpy`. When the value of the adr cvars are copied into the address book, there is no bounds checking, so cvar values longer than 79 bytes will corrupt static memory.

I don't know yet if this PR is fully ready. In my testing everything seems to work, both intended behavior and safeguards.

EDIT: Added code to reset the cursor pos to the end of the input when it loses focus (esc, up/down arrows).