### PR TITLE
Small fix for SDL3 API change for SetClipboardText

### DIFF
--- a/src/client/input/sdl2.c
+++ b/src/client/input/sdl2.c
@@ -2441,8 +2441,11 @@ IN_GetClipboardText(char *out, size_t n)
 	SDL_free(s);
 }
 
+/* Copy string s to the clipboard.
+   Returns 0 on success, 1 otherwise.
+*/
 int
 IN_SetClipboardText(const char *s)
 {
-	return SDL_SetClipboardText(s);
+	return SDL_SetClipboardText(s) != 0;
 }

--- a/src/client/input/sdl3.c
+++ b/src/client/input/sdl3.c
@@ -2437,8 +2437,13 @@ IN_GetClipboardText(char *out, size_t n)
 	SDL_free(s);
 }
 
+/* Copy string s to the clipboard.
+   Returns 0 on success, 1 otherwise.
+*/
 int
 IN_SetClipboardText(const char *s)
 {
-	return SDL_SetClipboardText(s);
+	bool res = SDL_SetClipboardText(s);
+
+	return !res;
 }


### PR DESCRIPTION
Discovered that `SDL_SetClipboardText` API changed in SDL3 after the version I had been using, and it made the result of `IN_SetClipboardText` inconsistent between SDL2 and SDL3. Also added a comment to clearly define the return value of the wrapper.