### PR TITLE
fix HTTP download crash (on empty file)

### DIFF
--- a/src/client/curl/download.c
+++ b/src/client/curl/download.c
@@ -264,6 +264,9 @@ static void CL_StartHTTPDownload (dlqueue_t *entry, dlhandle_t *dl)
 	}
 
 	// Make sure that the download handle is in empty state.
+	if (dl->tempBuffer) {
+		free(dl->tempBuffer);
+	}
 	dl->tempBuffer = NULL;
 	dl->fileSize = 0;
 	dl->position = 0;
@@ -474,6 +477,10 @@ static void CL_ParseFileList(dlhandle_t *dl)
 {
 	if (!cl_http_filelists->value)
 	{
+		return;
+	}
+
+	if (!dl->tempBuffer) {
 		return;
 	}
 


### PR DESCRIPTION

when empty filelist downloaded from HTTP server,
CL_ParseFileList() uses unallocated buffer for strchr()

segfault happens:

0  __strchr_avx2 () at ../sysdeps/x86_64/multiarch/strchr-avx2.S:65
1  0x00007ffff743de2c in __interceptor_strchr (s=0x0, c=<optimized out>)
    at ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:705
2  0x000055555566d7f8 in CL_ParseFileList (dl=0x55555587a178 <cls+20984>)
    at src/client/curl/download.c:484
3  0x000055555566e26c in CL_FinishHTTPDownload ()
    at src/client/curl/download.c:670