### PR TITLE
fix HTTP download crash (on 404)

### DIFF
--- a/src/client/curl/download.c
+++ b/src/client/curl/download.c
@@ -81,7 +81,7 @@ static size_t CL_HTTP_Recv(void *ptr, size_t size, size_t nmemb, void *stream)
 
 	if (!dl->fileSize)
 	{
-		double length = 0;
+		curl_off_t length = 0;
 
 		qcurl_easy_getinfo(dl->curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &length);
 


### PR DESCRIPTION

Change parameter type to match CURL lib

(prevents crash on HTTP download)


example

test server:
q2.bot.nu:27912

server config:
set sv_downloadserver "https://quake2.pages.dev/"
map DEBEQUA2


Client connects, and three files added to queue:

HTTP download: /.filelist - Queued
HTTP download: /maps/DEBEQUA2.filelist - Queued
HTTP download: maps/DEBEQUA2.bsp - Queued


 from URL:
https://quake2.pages.dev/.filelist		- no file
https://quake2.pages.dev/maps/DEBEQUA2.filelist	- no file
https://quake2.pages.dev/maps/DEBEQUA2.bsp	- exists

when 404 response received for '.filelist' file,
CL_HTTP_Recv() is called and uses wrong file length in malloc()


one of tests:

==43024==ERROR: AddressSanitizer: requested allocation size 0x8000000000000000 (0x8000000000001000 after adjustments for alignment, red zones etc.) exceeds maximum supported size of 0x10000000000 (thread T0)
    0 0x7ffff74b4887 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    1 0x55555566b023 in CL_HTTP_Recv src/client/curl/download.c:98
    2 0x7fffcbcc257a  (/lib/x86_64-linux-gnu/libcurl.so.4+0x5157a)