### PR TITLE
Fixed doors not being usable with NULL activator

### DIFF
--- a/src/game/g_func.c
+++ b/src/game/g_func.c
@@ -1429,12 +1429,12 @@ door_go_up(edict_t *self, edict_t *activator)
 void
 door_use(edict_t *self, edict_t *other /* unused */, edict_t *activator)
 {
-	if (!self || !activator)
+	edict_t *ent;
+
+	if (!self)
 	{
 		return;
 	}
-
-	edict_t *ent;
 
 	if (self->flags & FL_TEAMSLAVE)
 	{
@@ -2472,13 +2472,22 @@ void
 trigger_elevator_use(edict_t *self, edict_t *other, edict_t *activator /* unused */)
 {
 	edict_t *target;
+	edict_t *train;
 
 	if (!self || !other)
 	{
 		return;
 	}
 
-	if (self->movetarget->nextthink)
+	train = self->movetarget;
+
+	if (!train || !train->inuse ||
+		!train->classname || strcmp(train->classname, "func_train") != 0)
+	{
+		return;
+	}
+
+	if (train->nextthink)
 	{
 		return;
 	}
@@ -2497,8 +2506,8 @@ trigger_elevator_use(edict_t *self, edict_t *other, edict_t *activator /* unused
 		return;
 	}
 
-	self->movetarget->target_ent = target;
-	train_resume(self->movetarget);
+	train->target_ent = target;
+	train_resume(train);
 }
 
 void


### PR DESCRIPTION
This PR addresses issue reported in https://github.com/yquake2/yquake2/issues/1185.

When the button is pressed, it targets a `trigger_elevator` which works as a controller entity for `func_train` which is the elevator platform. Each button has a `pathtarget` that tells the `trigger_elevator` which `path_corner` to go to. Each `path_corner` has a pathtarget that targets the door of the respective floor. The failure here is that there is a NULL check for `activator` at the top of `door_use`. Since the elevator platform is managed by a controller entity, it has no activator set, which causes the NULL check to return early, preventing the door from opening.

This is another side-effect of all the NULL checks at the top of functions. `door_use` was needlessly checking for a NULL activator. This fix may fix related issues in other custom maps, and possibly subtle map bugs in official maps (though I have no examples of this).

I also spotted possible trouble if the `func_train` controlled by a `trigger_elevator` gets killtargeted or disappears for another reason, so I added safety checks for this.