### PR TITLE
Fix missing limits header in SDL2 module

### DIFF
--- a/src/client/input/sdl2.c
+++ b/src/client/input/sdl2.c
@@ -35,6 +35,7 @@
  */
 
 #include <SDL2/SDL.h>
+#include <limits.h>
 
 #include "header/input.h"
 #include "../header/keyboard.h"

--- a/src/client/input/sdl3.c
+++ b/src/client/input/sdl3.c
@@ -35,6 +35,7 @@
  */
 
 #include <SDL3/SDL.h>
+#include <limits.h>
 
 #include "SDL3/SDL_gamepad.h"
 #include "SDL3/SDL_properties.h"


### PR DESCRIPTION
Hi there,
I was not able to build unless adding the limits.h include. Was it missing? If there is a better solution or I did something wrong, please disregard this tiny PR.
Greetings,
MF

PS. My build config:

Build configuration
YQ2_ARCH = x86_64 COMPILER = gcc
WITH_CURL = no
WITH_OPENAL = yes
WITH_RPATH = yes
WITH_SDL3 = no
WITH_SYSTEMWIDE = no
WITH_SYSTEMDIR = 