### PR TITLE
Add header for strcasecmp()

### DIFF
--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <time.h>
 


### PR DESCRIPTION
## Why?

When compiling with `CFLAGS=-std=c2x` (C23), I would run into issue:

```
src/common/shared/shared.c: In function ‘Q_stricmp’:
src/common/shared/shared.c:1019:16: error: implicit declaration of function ‘strcasecmp’; did you mean ‘Q_strcasecmp’? [-Wimplicit-function-declaration]
 1019 |         return strcasecmp(s1, s2);
      |                ^~~~~~~~~~
      |                Q_strcasecmp
```
