### PR TITLE
gl3 issues fixes.

### DIFF
--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -379,10 +379,14 @@ SetMode_impl(int *pwidth, int *pheight, int mode, int fullscreen)
 
 	R_Printf(PRINT_ALL, " %dx%d (vid_fullscreen %i)\n", *pwidth, *pheight, fullscreen);
 
-
 	if (!ri.GLimp_InitGraphics(fullscreen, pwidth, pheight))
 	{
 		return rserr_invalid_mode;
+	}
+
+	if (mode == -2 || fullscreen)
+	{
+		GL3_BindVBO(0);
 	}
 
 	/* This is totaly obscure: For some strange reasons the renderer


### PR DESCRIPTION
segfault on video mode changes from no fullscreen to native/fullscreen or vice-versa. memory leak on SDL init as we dlload the gl3 lib dynamically for mode changes.