### PR TITLE
added .gitignore for Visual Studio-related and build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.mk
 *.user
 *.d
+/.vs
+/out/build/x64-Debug


### PR DESCRIPTION
To make it easier to perform Git Push within Microsoft Visual Studios, a .gitignore has been added to the following:

- /.vs
- /out/build/x64-Debug