### PR TITLE
Attempts to speed up level load times

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -13,6 +13,7 @@ have been renamed. The prefixes are:
 * `ogg_`: Ogg/Vorbis music playback.
 * `r_`: Common to all renderers.
 * `s_`: Sound system.
+* `sv_`: Server 
 * `sw_`: Software renderer.
 * `vid_`: Video backend.
 
@@ -56,6 +57,40 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   sleep and tells the operating system to send a wakeup signal when it's
   time for the next frame. The latter is more CPU friendly but can be
   rather inaccurate, especially on Windows. Use with care.
+
+* **sv_optimize_sp_loadtime**<br />
+  **sv_optimize_mp_loadtime**: These cvars enable/disable optimizations
+  that speed up level load times (or more accurately, client connection).
+
+  sp stands for singleplayer and mp for multiplayer, respectively.
+  The sp version is enabled by default (value 7) while multiplayer is 0.
+
+  The cvar value is a bitmask for 3 optimization features:
+  * **1: Message utilization**<br />
+    When the server sends the client configstrings and other data
+    during the connection process, the message buffer is only used
+    around 50-60%. When this flag is enabled, the message is used
+    much better, dramatically reducing the amount of messages needed
+    to deliver all the data to the client.
+
+  * **2: Server send rate**<br />
+    By default, the server sends messages to clients once every
+    0.1 seconds, roughly. This slows down sending data to clients,
+    especially in singleplayer. This is normal for active clients,
+    but for connecting/inactive clients, this delay is unnecessary.
+    When this flag is set, the server will send messages to
+    inactive clients ~8x more frequently.
+
+  * **4: Reconnection**<br />
+    When the server changes maps, like on level transitions,
+    the server first sends a "changing" command to all clients,
+    and then a "reconnect" command. The delay between these commands
+    can be quite long, ~1 second. This flag will avoid this delay when
+    set, by sending the two commands within the same message.
+
+  Simply add these flag values together to get the cvar value you want.
+  For example, sendrate + reconnect = 2 + 4 = 6.
+  Set to 7 for all optimizations, or 0 to disable them entirely.
 
 * **cl_maxfps**: The approximate framerate for client/server ("packet")
   frames if *cl_async* is `1`. If set to `-1` (the default), the engine

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -222,9 +222,7 @@ CL_Record_f(void)
 			}
 
 			MSG_WriteByte(&buf, svc_configstring);
-
-			MSG_WriteShort(&buf, i);
-			MSG_WriteString(&buf, cl.configstrings[i]);
+			MSG_WriteConfigString(&buf, i, cl.configstrings[i]);
 		}
 	}
 

--- a/src/client/cl_network.c
+++ b/src/client/cl_network.c
@@ -444,6 +444,13 @@ CL_Changing_f(void)
 
 	SCR_BeginLoadingPlaque();
 	cls.state = ca_connected; /* not active anymore, but not disconnected */
+
+	/* reset this to 0 just in case it didn't get a chance to settle normally
+		this became a problem with the faster client connection changes
+		but is a good idea to do this regardless
+	*/
+	anykeydown = 0;
+
 	Com_Printf("\nChanging map...\n");
 
 #ifdef USE_CURL

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -106,6 +106,10 @@ void SZ_Print(sizebuf_t *buf, char *data);  /* strcats onto the sizebuf */
 struct usercmd_s;
 struct entity_state_s;
 
+size_t MSG_String_Size(const char *s);
+size_t MSG_DeltaEntity_Size(const entity_state_t *from, const entity_state_t *to,
+	qboolean force, qboolean newentity);
+
 void MSG_WriteChar(sizebuf_t *sb, int c);
 void MSG_WriteByte(sizebuf_t *sb, int c);
 void MSG_WriteShort(sizebuf_t *sb, int c);
@@ -118,6 +122,8 @@ void MSG_WriteAngle(sizebuf_t *sb, float f);
 void MSG_WriteAngle16(sizebuf_t *sb, float f);
 void MSG_WriteDeltaUsercmd(sizebuf_t *sb, struct usercmd_s *from,
 		struct usercmd_s *cmd);
+int DeltaEntityBits(const struct entity_state_s *from,
+		const struct entity_state_s *to, qboolean newentity);
 void MSG_WriteDeltaEntity(struct entity_state_s *from,
 		struct entity_state_s *to, sizebuf_t *msg,
 		qboolean force, qboolean newentity);

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -106,7 +106,7 @@ void SZ_Print(sizebuf_t *buf, char *data);  /* strcats onto the sizebuf */
 struct usercmd_s;
 struct entity_state_s;
 
-size_t MSG_String_Size(const char *s);
+size_t MSG_ConfigString_Size(const char *s);
 size_t MSG_DeltaEntity_Size(const entity_state_t *from, const entity_state_t *to,
 	qboolean force, qboolean newentity);
 
@@ -120,6 +120,7 @@ void MSG_WriteCoord(sizebuf_t *sb, float f);
 void MSG_WritePos(sizebuf_t *sb, vec3_t pos);
 void MSG_WriteAngle(sizebuf_t *sb, float f);
 void MSG_WriteAngle16(sizebuf_t *sb, float f);
+void MSG_WriteConfigString(sizebuf_t *sb, short index, const char *s);
 void MSG_WriteDeltaUsercmd(sizebuf_t *sb, struct usercmd_s *from,
 		struct usercmd_s *cmd);
 int DeltaEntityBits(const struct entity_state_s *from,

--- a/src/common/movemsg.c
+++ b/src/common/movemsg.c
@@ -192,7 +192,7 @@ vec3_t bytedirs[NUMVERTEXNORMALS] = {
 };
 
 size_t
-MSG_String_Size(const char *s)
+MSG_ConfigString_Size(const char *s)
 {
 	return strlen(s) + 4; /* string length + null char + message type + index */
 }
@@ -448,6 +448,13 @@ void
 MSG_WriteAngle16(sizebuf_t *sb, float f)
 {
 	MSG_WriteShort(sb, ANGLE2SHORT(f));
+}
+
+void
+MSG_WriteConfigString(sizebuf_t *buf, short index, const char *s)
+{
+	MSG_WriteShort(buf, index);
+	MSG_WriteString(buf, s);
 }
 
 void

--- a/src/server/header/server.h
+++ b/src/server/header/server.h
@@ -176,7 +176,13 @@ typedef struct
 	FILE *demofile;
 	sizebuf_t demo_multicast;
 	byte demo_multicast_buf[MAX_MSGLEN];
+
+	int gamemode;
 } server_static_t;
+
+#define GAMEMODE_SP 1
+#define GAMEMODE_COOP 2
+#define GAMEMODE_DM 3
 
 extern netadr_t net_from;
 extern sizebuf_t net_message;
@@ -185,6 +191,9 @@ extern netadr_t master_adr[MAX_MASTERS];    /* address of the master server */
 
 extern server_static_t svs;                 /* persistant server info */
 extern server_t sv;                         /* local server */
+
+extern cvar_t *sv_optimize_sp_loadtime;
+extern cvar_t *sv_optimize_mp_loadtime;
 
 extern cvar_t *sv_paused;
 extern cvar_t *maxclients;
@@ -283,6 +292,14 @@ int SV_PointContents(vec3_t p);
 
 trace_t SV_Trace(vec3_t start, vec3_t mins, vec3_t maxs,
 		vec3_t end, edict_t *passedict, int contentmask);
+
+/* loadtime optimizations */
+
+#define OPTIMIZE_MSGUTIL 1
+#define OPTIMIZE_SENDRATE 2
+#define OPTIMIZE_RECONNECT 4
+
+int SV_Optimizations(void);
 
 #endif
 

--- a/src/server/header/server.h
+++ b/src/server/header/server.h
@@ -228,6 +228,7 @@ void SV_FlushRedirect(int sv_redirected, char *outputbuf);
 
 void SV_DemoCompleted(void);
 void SV_SendClientMessages(void);
+void SV_SendPrepClientMessages(void);
 
 void SV_Multicast(vec3_t origin, multicast_t to);
 void SV_StartSound(vec3_t origin, edict_t *entity, int channel,

--- a/src/server/sv_cmd.c
+++ b/src/server/sv_cmd.c
@@ -612,8 +612,7 @@ SV_ServerRecord_f(void)
 		if (sv.configstrings[i][0])
 		{
 			MSG_WriteByte(&buf, svc_configstring);
-			MSG_WriteShort(&buf, i);
-			MSG_WriteString(&buf, sv.configstrings[i]);
+			MSG_WriteConfigString(&buf, i, sv.configstrings[i]);
 
 			if (buf.cursize + 67 >= buf.maxsize)
 			{

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -212,8 +212,7 @@ PF_Configstring(int index, char *val)
 		/* send the update to everyone */
 		SZ_Clear(&sv.multicast);
 		MSG_WriteChar(&sv.multicast, svc_configstring);
-		MSG_WriteShort(&sv.multicast, index);
-		MSG_WriteString(&sv.multicast, val);
+		MSG_WriteConfigString(&sv.multicast, index, val);
 
 		SV_Multicast(vec3_origin, MULTICAST_ALL_R);
 	}

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -67,8 +67,7 @@ SV_FindIndex(char *name, int start, int max, qboolean create)
 	{
 		/* send the update to everyone */
 		MSG_WriteChar(&sv.multicast, svc_configstring);
-		MSG_WriteShort(&sv.multicast, start + i);
-		MSG_WriteString(&sv.multicast, name);
+		MSG_WriteConfigString(&sv.multicast, start + i, name);
 		SV_Multicast(vec3_origin, MULTICAST_ALL_R);
 	}
 

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -493,6 +493,7 @@ SV_Map(qboolean attractloop, char *levelstring, qboolean loadgame, qboolean isau
 	char *ch;
 	size_t l;
 	char spawnpoint[MAX_QPATH];
+	char *ext;
 
 	sv.loadgame = loadgame;
 	sv.attractloop = attractloop;
@@ -548,7 +549,9 @@ SV_Map(qboolean attractloop, char *levelstring, qboolean loadgame, qboolean isau
 		--l;
 	}
 
-	if ((l > 4) && !strcmp(level + l - 4, ".cin"))
+	ext = (l <= 4) ? NULL : level + l - 4;
+
+	if (ext && !strcmp(ext, ".cin"))
 	{
 #ifndef DEDICATED_ONLY
 		SCR_BeginLoadingPlaque(); /* for local system */
@@ -556,7 +559,7 @@ SV_Map(qboolean attractloop, char *levelstring, qboolean loadgame, qboolean isau
 		SV_BroadcastCommand("changing\n");
 		SV_SpawnServer(level, spawnpoint, ss_cinematic, attractloop, loadgame, isautosave);
 	}
-	else if ((l > 4) && !strcmp(level + l - 4, ".dm2"))
+	else if (ext && !strcmp(ext, ".dm2"))
 	{
 #ifndef DEDICATED_ONLY
 		SCR_BeginLoadingPlaque(); /* for local system */
@@ -564,10 +567,10 @@ SV_Map(qboolean attractloop, char *levelstring, qboolean loadgame, qboolean isau
 		SV_BroadcastCommand("changing\n");
 		SV_SpawnServer(level, spawnpoint, ss_demo, attractloop, loadgame, isautosave);
 	}
-	else if ((l > 4) && (!strcmp(level + l - 4, ".pcx") ||
-						!strcmp(level + l - 4, ".tga") ||
-						!strcmp(level + l - 4, ".jpg") ||
-						!strcmp(level + l - 4, ".png")))
+	else if (ext && (!strcmp(ext, ".pcx") ||
+					!strcmp(ext, ".tga") ||
+					!strcmp(ext, ".jpg") ||
+					!strcmp(ext, ".png")))
 	{
 #ifndef DEDICATED_ONLY
 		SCR_BeginLoadingPlaque(); /* for local system */
@@ -581,8 +584,7 @@ SV_Map(qboolean attractloop, char *levelstring, qboolean loadgame, qboolean isau
 		SCR_BeginLoadingPlaque(); /* for local system */
 #endif
 		SV_BroadcastCommand("changing\n");
-		SV_SendPrepClientMessages();
-		SV_SendClientMessages();
+
 		SV_SpawnServer(level, spawnpoint, ss_game, attractloop, loadgame, isautosave);
 		Cbuf_CopyToDefer();
 	}

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -582,6 +582,7 @@ SV_Map(qboolean attractloop, char *levelstring, qboolean loadgame, qboolean isau
 		SCR_BeginLoadingPlaque(); /* for local system */
 #endif
 		SV_BroadcastCommand("changing\n");
+		SV_SendPrepClientMessages();
 		SV_SendClientMessages();
 		SV_SpawnServer(level, spawnpoint, ss_game, attractloop, loadgame, isautosave);
 		Cbuf_CopyToDefer();

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -397,6 +397,11 @@ SV_Frame(int usec)
 	/* get packets from clients */
 	SV_ReadPackets();
 
+	/* send messages more often to new clients getting ready for spawning in
+	   speeds up the process of sending configstrings, entty deltas, etc.
+	*/
+	SV_SendPrepClientMessages();
+
 	/* move autonomous things around if enough time has passed */
 	if (!sv_timedemo->value && (svs.realtime < sv.time))
 	{

--- a/src/server/sv_user.c
+++ b/src/server/sv_user.c
@@ -138,6 +138,11 @@ SV_Configstrings_f(void)
 
 	start = (int)strtol(Cmd_Argv(2), (char **)NULL, 10);
 
+	if (start < 0)
+	{
+		start = 0;
+	}
+
 	/* write a packet full of data */
 	while (start < MAX_CONFIGSTRINGS)
 	{
@@ -198,6 +203,12 @@ SV_Baselines_f(void)
 	}
 
 	start = (int)strtol(Cmd_Argv(2), (char **)NULL, 10);
+
+	if (start < 0)
+	{
+		start = 0;
+	}
+
 	memset(&nullstate, 0, sizeof(nullstate));
 
 	/* write a packet full of data */

--- a/src/server/sv_user.c
+++ b/src/server/sv_user.c
@@ -119,6 +119,7 @@ SV_Configstrings_f(void)
 {
 	int start;
 	char *cs;
+	int max_msgutil;
 
 	Com_DPrintf("Configstrings() from %s\n", sv_client->name);
 
@@ -143,6 +144,10 @@ SV_Configstrings_f(void)
 		start = 0;
 	}
 
+	/* 560 is roughly the legacy safety margin */
+	max_msgutil = (SV_Optimizations() & OPTIMIZE_MSGUTIL) ?
+		SAFE_MARGIN : 560;
+
 	/* write a packet full of data */
 	while (start < MAX_CONFIGSTRINGS)
 	{
@@ -151,7 +156,7 @@ SV_Configstrings_f(void)
 		if (*cs != '\0')
 		{
 			if ((sv_client->netchan.message.cursize + MSG_ConfigString_Size(cs))
-				> (MAX_MSGLEN - (CMD_MARGIN + SAFE_MARGIN)))
+				> (MAX_MSGLEN - (CMD_MARGIN + max_msgutil)))
 			{
 				break;
 			}
@@ -182,6 +187,7 @@ void
 SV_Baselines_f(void)
 {
 	int start;
+	int max_msgutil;
 	entity_state_t nullstate;
 	entity_state_t *base;
 
@@ -210,6 +216,10 @@ SV_Baselines_f(void)
 
 	memset(&nullstate, 0, sizeof(nullstate));
 
+	/* 560 is roughly the legacy safety margin */
+	max_msgutil = (SV_Optimizations() & OPTIMIZE_MSGUTIL) ?
+		SAFE_MARGIN : 560;
+
 	/* write a packet full of data */
 	while (start < MAX_EDICTS)
 	{
@@ -218,7 +228,7 @@ SV_Baselines_f(void)
 		if (base->modelindex || base->sound || base->effects)
 		{
 			if ((sv_client->netchan.message.cursize + MSG_DeltaEntity_Size(&nullstate, base, true, true))
-				> (MAX_MSGLEN - (CMD_MARGIN + SAFE_MARGIN)))
+				> (MAX_MSGLEN - (CMD_MARGIN + max_msgutil)))
 			{
 				break;
 			}

--- a/src/server/sv_user.c
+++ b/src/server/sv_user.c
@@ -150,15 +150,14 @@ SV_Configstrings_f(void)
 
 		if (*cs != '\0')
 		{
-			if ((sv_client->netchan.message.cursize + MSG_String_Size(cs))
+			if ((sv_client->netchan.message.cursize + MSG_ConfigString_Size(cs))
 				> (MAX_MSGLEN - (CMD_MARGIN + SAFE_MARGIN)))
 			{
 				break;
 			}
 
 			MSG_WriteByte(&sv_client->netchan.message, svc_configstring);
-			MSG_WriteShort(&sv_client->netchan.message, start);
-			MSG_WriteString(&sv_client->netchan.message, cs);
+			MSG_WriteConfigString(&sv_client->netchan.message, start, cs);
 		}
 
 		start++;


### PR DESCRIPTION
This PR is my attempts to address points discussed in https://github.com/yquake2/yquake2/issues/1201 to speed up level load times, or rather, client connection times more technically speaking.

1. Model names and clients printed to console

The loops that loop through the model configstrings print out the string value to console, including empty lines that represent inline models. Each loop iteration calls `SCR_UpdateScreen` which is vey expensive.

I simply removed printing from the loops and instead just print "models" or "clients".

This change is part of the PR although @0lvin has made a commit that addresses the same issue. We can use that solution instead if preferred.

2. Message utilization

After the server receives the "new" message from a client, it will go through a process of sending configstrings and entity deltas in bulk messages. In the original code the message is only filled until `MAX_MSGLEN / 2` is exceeded, or 700 bytes. This will leave over 600 bytes unused.

I changed the code by creating `MSG_ConfigString_Size` and `MSG_DeltaEntity_Size` for predicting how much space the data will take, and introduced 2 defines: `CMD_MARGIN` which reserves 40 bytes for the command appended at the end of the message, and `SAFE_MARGIN` which reserves space for overhead (like packet header data) and misc additions. I'm currently using a value of 24 which seems to work well.

A `SAFE_MARGIN` value of around 500-600 would be fairly close to the original behavior.

I'm not aware of the server adding any other data to these configstrings/baselines messages while getting ready to spawn in. If unexpected overflows happen we can increase the value of `SAFE_MARGIN`.

3. Server slow to send client messages

The server ticks at 10 FPS. This is correct for active clients, but I feel this is fairly slow for clients who are still getting ready.

Most of the slowdown is with the configstrings/baselines messages. After receiving a "new" message, the server sends the first bulk of configstrings to the client along with a stuffed command to request the next bulk. The client then parses it and sends the stuffed command back to the server. For large maps this can take dozens of back-and-forths, which is several seconds of delay.

My first "toy attempt" to solve this is by splitting `SV_SendClientMessages` into 2 functions, the other being `SV_SendPrepClientMessages`. The latter function is called every server frame and only sends messages to clients who are not yet spawned in, while the original function still takes care of sending messages every 10 server frames (~0.1 second).

4. Reconnection delay

Reconnection happens on level transitions or when a map loads after a video (like the intro or end-of-unit videos). This one still eludes me. At the end of `SV_Map` the server first broadcasts a "changing" command, sends it, and then broadcasts a "reconnect". For reasons I still can't figure out, it takes the reconnect command up to a second to be processed client-side. Is the server slow to send it or the client slow to read it? Not sure at this time.

In any case, I simply removed the call to `SV_SendClientMessages` after broadcasting the "changing" command and that removed the delay. The client is fast and responsive to reconnect. 

NOTE: Removing the call to `SV_SendClientMessages` was made possible by the change I described in 3. I guess the reason for it in the original code was to make sure the clients receive "changing" quickly, instead of having to wait for the next full server frame.

I was thinking this delay may be intentional but I don't really see a reason for it, after `SV_SpawnServer` the server should be ready to accept clients as far as I can tell.

5. Misc stuff

I spotted that the index parameter to the "baselines" and "configstrings" server commands is not checked, so buggy/malicious clients could send negative values leading to reading out of bounds.

I also made a wrapper `MSG_WriteConfigString` function, not necessary but figured it is better than sending the components individually in every use case.

---

With all of these optimizations I am getting very large reductions in time spent on the loading screen. That includes starting a new game through the menu, map command, and in-game level transitions


These changes are experimental so this is a draft/test PR. In particular I don't feel confident in my solutions to 3 and 4.

I have only tested this locally, where server and client are both running on the same system/in the same process. I feel it is important to test this in a real online setting, where server and client are on different networks.