### PR TITLE
Fix C23 bool type being 1 byte long, while the enum bool is 4 bytes.

### DIFF
--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -37,21 +37,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
+#include <stdbool.h>
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202000L // C23 or newer
-typedef bool qboolean;
-#else
-#ifdef true
- #undef true
-#endif
-
-#ifdef false
- #undef false
-#endif
-
-typedef enum {false, true}  qboolean;
-#endif
-
+typedef int qboolean;
 typedef unsigned char byte;
 
 #ifndef NULL


### PR DESCRIPTION
C23 introduced `true` and `false` as language keywords, breaking YQ2s use of them. The first attempt to get C23 was to use the buildin `bool` type when building in C23 mode and the classic enum based `qboolean` in any other mode. This didn't take into acount, that `bool` is 1 byte long, while the enum based `qboolean` is 4 bytes long. This breaks savegames and may have impact for mods.

Fix this by always using `int` as `qboolean` and the buildin `true` and `false` types, either in their C99 or C23 variant. This way `qboolean` is always 4 bytes long and the newly introduced `true` and `false` keywords don't clash.

Suggested by @DanielGibson.

Closes #1206.