### PR TITLE
Mapfix for hangar1: Fixed target_speakers and trigger_push overspeed

### DIFF
--- a/stuff/mapfixes/baseq2/hangar1@09a0.ent
+++ b/stuff/mapfixes/baseq2/hangar1@09a0.ent
@@ -1,3 +1,14 @@
+// FIXED ENTITY STRING (by BjossiAlfreds and ConHuevosGuey)
+//
+// 1. Fixed missing spawnflag 1 on ambient target_speaker (b#1)
+//
+// 2. Fixed 2x stuck monster_infantry (b#2)
+//
+// 3. Flagged some non-DM entities with 2048 (b#3)
+//
+// 4. Fixed trigger_push overspeed (b#4)
+//
+// 5. Optimized trigger chains (b#5)
 {
 "nextmap" "hangar2"
 "message" "Outer Hangar"
@@ -17,6 +28,7 @@
 "target" "t86"
 "targetname" "t82"
 "classname" "trigger_once"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "classname" "target_speaker"
@@ -38,6 +50,7 @@
 }
 {
 "classname" "trigger_relay"
+"spawnflags" "3840" // b#5: added this
 "targetname" "t83"
 "target" "t84"
 "delay" "2"
@@ -45,8 +58,10 @@
 }
 {
 "classname" "target_crosslevel_target"
+"spawnflags" "2048" // b#3: added this
 "spawnflags" "32"
-"target" "t83"
+"target" "t84" // b#5: t83 -> t84
+"delay" "3" // b#5: moved here from trigger_relay (+1 for default delay of crosslevel targets)
 "origin" "1616 -384 1328"
 }
 {
@@ -238,14 +253,17 @@
 "noise" "world/bigpump.wav"
 "origin" "-728 -536 1136"
 "classname" "target_speaker"
+"spawnflags" "1" // b#1: added this
 }
 {
 "classname" "target_speaker"
+"spawnflags" "1" // b#1: added this
 "origin" "-880 -528 1136"
 "noise" "world/bigpump.wav"
 }
 {
 "classname" "target_speaker"
+"spawnflags" "1" // b#1: added this
 "origin" "-728 -432 1136"
 "noise" "world/bigpump.wav"
 }
@@ -253,6 +271,7 @@
 "noise" "world/bigpump.wav"
 "origin" "-616 -488 1024"
 "classname" "target_speaker"
+"spawnflags" "1" // b#1: added this
 }
 {
 "classname" "target_speaker"
@@ -316,6 +335,7 @@
 "model" "*5"
 "target" "t76"
 "classname" "trigger_once"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "origin" "-728 -712 1432"
@@ -335,7 +355,7 @@
 {
 "origin" "-424 -1000 904"
 "target" "t5"
-"spawnflags" "1792"
+"spawnflags" "3840" // b#5: 1792 -> 3840
 "classname" "trigger_always"
 }
 {
@@ -457,7 +477,7 @@
 {
 "origin" "-224 -568 1512"
 "target" "t70"
-"spawnflags" "1792"
+"spawnflags" "3840" // b#5: 1792 -> 3840
 "classname" "trigger_always"
 }
 {
@@ -566,12 +586,14 @@
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t73"
 "target" "t74"
 "origin" "-1176 -712 1104"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "target" "t73"
 "targetname" "t74"
 "origin" "-960 -712 1104"
@@ -587,7 +609,7 @@
 {
 "model" "*6"
 "classname" "trigger_counter"
-"spawnflags" "1"
+"spawnflags" "2049" // b#3: 1 -> 2049
 "target" "t71"
 "targetname" "t72"
 }
@@ -614,23 +636,27 @@
 }
 {
 "classname" "target_explosion"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t70"
 "delay" ".3"
 "origin" "-256 -616 1464"
 }
 {
 "classname" "target_explosion"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t70"
 "origin" "-272 -624 1504"
 }
 {
 "classname" "target_explosion"
+"spawnflags" "2048" // added this
 "targetname" "t70"
 "delay" ".5"
 "origin" "-216 -624 1504"
 }
 {
 "classname" "target_explosion"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t70"
 "delay" ".1"
 "origin" "-200 -632 1432"
@@ -640,7 +666,7 @@
 "classname" "trigger_counter"
 "count" "5"
 "targetname" "t69"
-"spawnflags" "1"
+"spawnflags" "2049" // b#3: 1 -> 2049
 "target" "t70"
 }
 {
@@ -760,12 +786,14 @@
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t67"
 "target" "t68"
 "origin" "160 448 1368"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t68"
 "target" "t67"
 "origin" "456 440 1368"
@@ -778,96 +806,112 @@
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t64"
 "target" "t65"
 "origin" "1384 -360 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t63"
 "target" "t64"
 "origin" "1328 -424 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t62"
 "target" "t63"
 "origin" "1288 -504 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t61"
 "target" "t62"
 "origin" "1296 -576 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t60"
 "target" "t61"
 "origin" "1312 -656 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t59"
 "target" "t60"
 "origin" "1368 -720 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t58"
 "target" "t59"
 "origin" "1456 -744 1144"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048"
 "targetname" "t57"
 "target" "t58"
 "origin" "1544 -752 1144"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t56"
 "target" "t57"
 "origin" "1624 -712 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t55"
 "target" "t56"
 "origin" "1688 -656 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t54"
 "target" "t55"
 "origin" "1720 -560 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t53"
 "target" "t54"
 "origin" "1712 -472 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t52"
 "target" "t53"
 "origin" "1664 -400 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t51"
 "target" "t52"
 "origin" "1600 -352 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "target" "t51"
 "targetname" "t66"
 "origin" "1504 -328 1128"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t65"
 "target" "t66"
 "origin" "1448 -336 1128"
@@ -887,6 +931,7 @@
 {
 "model" "*10"
 "classname" "trigger_once"
+"spawnflags" "2048" // b#3: added this
 "target" "t50"
 }
 {
@@ -939,12 +984,14 @@
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "target" "t48"
 "targetname" "t49"
 "origin" "-704 -576 1416"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t48"
 "target" "t49"
 "origin" "-704 -872 1416"
@@ -1176,6 +1223,7 @@
 }
 {
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t26"
 "killtarget" "message"
 "origin" "536 472 1488"
@@ -1184,6 +1232,7 @@
 {
 "model" "*14"
 "classname" "trigger_multiple"
+"spawnflags" "2048" // b#3: added this
 "message" "Tank commander's head needed at scanner."
 "wait" "5"
 "targetname" "message"
@@ -1204,6 +1253,7 @@
 {
 "model" "*15"
 "classname" "trigger_once"
+"spawnflags" "2048" // b#3: added this
 "target" "t44"
 }
 {
@@ -1417,13 +1467,13 @@
 "spawnflags" "1"
 "angle" "180"
 "classname" "monster_infantry"
-"origin" "992 8 1384" //stuck monster at the steps "1008 8 1384"
+"origin" "992 8 1384" // b#2: 1008 -> 992
 }
 {
 "classname" "monster_infantry"
 "angle" "180"
 "spawnflags" "1"
-"origin" "992 -136 1384" //stuck monster at the steps "1008 -136 1384"
+"origin" "992 -136 1384" // b#2: 1008 -> 992
 }
 {
 "classname" "item_health_large"
@@ -1488,24 +1538,28 @@
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t39"
 "target" "t40"
 "origin" "928 -920 992"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "target" "t39"
 "targetname" "t40"
 "origin" "752 -976 912"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t37"
 "target" "t38"
 "origin" "688 -1136 912"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "target" "t37"
 "targetname" "t38"
 "origin" "712 -928 912"
@@ -1522,60 +1576,70 @@
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t35"
 "target" "t36"
 "origin" "-376 -336 1032"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "target" "t35"
 "targetname" "t36"
 "origin" "-600 -472 1032"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t33"
 "target" "t34"
 "origin" "-376 -752 1032"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "target" "t33"
 "targetname" "t34"
 "origin" "-376 -520 1032"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t31"
 "target" "t32"
 "origin" "-584 -512 1064"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "target" "t31"
 "targetname" "t32"
 "origin" "-600 -744 1064"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t29"
 "target" "t30"
 "origin" "-464 -800 1032"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "target" "t29"
 "targetname" "t30"
 "origin" "-520 -1128 1032"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t27"
 "target" "t28"
 "origin" "-440 -1256 1032"
 }
 {
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 "target" "t27"
 "targetname" "t28"
 "origin" "-680 -1120 1032"
@@ -1989,17 +2053,18 @@
 "origin" "520 488 1440"
 "targetname" "t26"
 "noise" "world/force1.wav"
-"spawnflags" "1"
+"spawnflags" "2049" // b#3: 1 -> 2049
 "classname" "target_speaker"
 }
 {
 "model" "*19"
 "classname" "func_wall"
-"spawnflags" "6"
+"spawnflags" "2054" // b#3: 6 -> 2054
 "targetname" "t26"
 }
 {
 "classname" "trigger_key"
+"spawnflags" "2048" // b#3: added this
 "item" "key_commander_head"
 "targetname" "t25"
 "target" "t26"
@@ -2014,6 +2079,7 @@
 }
 {
 "classname" "target_speaker"
+"spawnflags" "2048" // b#3: added this
 "noise" "world/scan1.wav"
 "targetname" "t23"
 "origin" "320 552 1424"
@@ -2029,12 +2095,14 @@
 "target" "t23"
 "targetname" "t22"
 "classname" "trigger_multiple"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
 "origin" "384 520 1488"
 "delay" "1.2"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 "target" "t25"
 }
 {
@@ -2043,6 +2111,7 @@
 "delay" "0.9"
 "target" "t20"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2050,6 +2119,7 @@
 "delay" "1"
 "target" "t20"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2057,6 +2127,7 @@
 "delay" "0.7"
 "target" "t19"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2064,6 +2135,7 @@
 "delay" "0.8"
 "target" "t19"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2071,6 +2143,7 @@
 "delay" "0.5"
 "target" "t18"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2078,6 +2151,7 @@
 "delay" "0.6"
 "target" "t18"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2085,6 +2159,7 @@
 "delay" "0.3"
 "target" "t17"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2092,6 +2167,7 @@
 "delay" "0.4"
 "target" "t17"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2099,6 +2175,7 @@
 "delay" "0.1"
 "target" "t16"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2106,6 +2183,7 @@
 "delay" "0.2"
 "target" "t16"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2113,6 +2191,7 @@
 "delay" "1.2"
 "target" "t21"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t23"
@@ -2120,6 +2199,7 @@
 "delay" "1.1"
 "target" "t21"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "origin" "224 608 1496"
@@ -2155,72 +2235,78 @@
 "origin" "304 580 1584"
 "targetname" "t11"
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "origin" "304 580 1560"
 "targetname" "t12"
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "origin" "304 580 1536"
 "targetname" "t13"
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "origin" "304 580 1512"
 "targetname" "t14"
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "origin" "304 580 1488"
 "targetname" "t15"
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "origin" "304 580 1608"
 "targetname" "t10"
 "classname" "path_corner"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "targetname" "t17"
 "origin" "344 580 1584"
 "target" "t11"
 "classname" "target_laser"
-"spawnflags" "16"
+"spawnflags" "2064" // b#3: 16 -> 2064
 }
 {
 "targetname" "t18"
 "origin" "344 580 1560"
 "target" "t12"
 "classname" "target_laser"
-"spawnflags" "16"
+"spawnflags" "2064" // b#3: 16 -> 2064
 }
 {
 "targetname" "t19"
 "origin" "344 580 1536"
 "target" "t13"
 "classname" "target_laser"
-"spawnflags" "16"
+"spawnflags" "2064" // b#3: 16 -> 2064
 }
 {
 "targetname" "t20"
 "origin" "344 580 1512"
 "target" "t14"
 "classname" "target_laser"
-"spawnflags" "16"
+"spawnflags" "2064" // b#3: 16 -> 2064
 }
 {
 "targetname" "t21"
 "origin" "344 580 1488"
 "target" "t15"
 "classname" "target_laser"
-"spawnflags" "16"
+"spawnflags" "2064" // b#3: 16 -> 2064
 }
 {
 "targetname" "t16"
 "origin" "344 580 1608"
 "target" "t10"
-"spawnflags" "16"
+"spawnflags" "2064" // b#3: 16 -> 2064
 "classname" "target_laser"
 }
 {
@@ -2442,14 +2528,14 @@
 }
 {
 "noise" "world/fan1.wav"
-"spawnflags" "1"
+"spawnflags" "2049" // b#3: 1 -> 2049
 "classname" "target_speaker"
 "origin" "-392 -976 944"
 "targetname" "t5"
 }
 {
 "classname" "target_speaker"
-"spawnflags" "1"
+"spawnflags" "2049" // b#3: 1 -> 2049
 "noise" "world/fan1.wav"
 "targetname" "t5"
 "origin" "-352 -976 944"
@@ -2564,6 +2650,7 @@
 "model" "*25"
 "classname" "trigger_push"
 "angle" "270"
+"speed" "180" // b#4: added this
 }
 {
 "model" "*26"
@@ -2618,12 +2705,14 @@
 {
 "dmg" "1"
 "classname" "target_explosion"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t5"
 "origin" "-388 -1004 920"
 }
 {
 "dmg" "1"
 "classname" "target_explosion"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t5"
 "delay" ".2"
 "origin" "-396 -1112 920"
@@ -2631,6 +2720,7 @@
 {
 "dmg" "1"
 "classname" "target_explosion"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t5"
 "delay" ".4"
 "origin" "-396 -1056 920"
@@ -2638,11 +2728,13 @@
 {
 "dmg" "1"
 "classname" "target_explosion"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t5"
 "origin" "-412 -1084 904"
 }
 {
 "classname" "target_explosion"
+"spawnflags" "2048" // b#3: added this
 "dmg" "1"
 "targetname" "t5"
 "delay" ".6"
@@ -2650,15 +2742,16 @@
 }
 {
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 "targetname" "t5"
-"target" "t6"
+//"target" "t6" // not needed
 "origin" "-432 -960 904"
 "killtarget" "t6"
 }
 {
 "model" "*28"
 "classname" "trigger_hurt"
-"spawnflags" "6"
+"spawnflags" "2054" // b#3: 6 -> 2054
 "dmg" "1000"
 "targetname" "t5"
 }
@@ -2668,6 +2761,7 @@
 "angle" "180"
 "speed" "50"
 "targetname" "t6"
+"spawnflags" "2048" // b#3: added this
 }
 {
 "model" "*30"
@@ -2968,12 +3062,14 @@
 "targetname" "rings1"
 "delay" "1.2"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 "target" "ring7"
 }
 {
 "origin" "1408 -312 1440"
 "targetname" "rings1"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 "target" "ring1"
 }
 {
@@ -2981,6 +3077,7 @@
 "targetname" "rings1"
 "delay" "0.2"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 "target" "ring2"
 }
 {
@@ -2988,6 +3085,7 @@
 "targetname" "rings1"
 "delay" "0.4"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 "target" "ring3"
 }
 {
@@ -2995,6 +3093,7 @@
 "targetname" "rings1"
 "delay" "0.6"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 "target" "ring4"
 }
 {
@@ -3002,6 +3101,7 @@
 "targetname" "rings1"
 "delay" "0.8"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 "target" "ring5"
 }
 {
@@ -3009,6 +3109,7 @@
 "targetname" "rings1"
 "delay" "1"
 "classname" "trigger_relay"
+"spawnflags" "2048" // b#3: added this
 "target" "ring6"
 }
 {
@@ -3109,4 +3210,3 @@
 "_minlight" "2"
 "spawnflags" "2048"
 }
-


### PR DESCRIPTION
This PR adds more mapfixes to the hangar1.ent file.

* Added missing spawnflag 1 to a few ambient `target_speaker`. These are water pumping sounds playing by the big water pipe by the water
* Fixed `trigger_push` overspeed. The default (1000) will overflow the 6-byte interger vector used by clients. 1000 * 10 * 8 = 14464 (65536 overflow bit thrown away). So I gave it a speed of 180 (14464 / 80 = 180.8), which is the actual speed it has in-game
* Added spawnflag 2048 to a bunch of non-DM entities

On a side note, I wanted to make the commander's head button permanently pressed after using the key, but there is no way to do this without code extensions as far as I know. Unless maybe using a `func_wall` to replace the button entity when using the key. I left it unchanged.