### PR TITLE
Fixed monsters acting confused while following combat points

### DIFF
--- a/src/game/g_misc.c
+++ b/src/game/g_misc.c
@@ -574,6 +574,7 @@ point_combat_touch(edict_t *self, edict_t *other, cplane_t *plane /* unused */,
 		csurface_t *surf /* unused */)
 {
 	edict_t *activator;
+	vec3_t v;
 
 	if (!self || !other)
 	{
@@ -590,12 +591,18 @@ point_combat_touch(edict_t *self, edict_t *other, cplane_t *plane /* unused */,
 		other->target = self->target;
 		other->goalentity = other->movetarget = G_PickTarget(other->target);
 
-		if (!other->goalentity)
+		if (other->goalentity)
+		{
+			VectorSubtract(other->goalentity->s.origin, other->s.origin, v);
+			other->ideal_yaw = vectoyaw(v);
+		}
+		else
 		{
 			gi.dprintf("%s at %s target %s does not exist\n",
 					self->classname,
 					vtos(self->s.origin),
 					self->target);
+
 			other->movetarget = self;
 		}
 


### PR DESCRIPTION
This PR addresses https://github.com/yquake2/yquake2/issues/1223.

Simply setting `ideal_yaw` correctly in `FoundTarget` and `point_combat_touch` fixes the issue.