### PR TITLE
Mapfixes for mine1 mine2 jail2

### DIFF
--- a/stuff/mapfixes/baseq2/jail2@ee5d.ent
+++ b/stuff/mapfixes/baseq2/jail2@ee5d.ent
@@ -1,0 +1,5356 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Fixed incorrect targetname for 3x info_player_coop (b#1)
+//
+// 2. Added missing targetname to info_player_start (b#2)
+//
+// 3. Added spawnflag 1 to target_speaker entities (b#3)
+//
+// 4. Fixed silent elevator at level start (b#4)
+//
+// 5. Added missing spawnflag 256-2048 to some entities (b#5)
+//
+// 6. Removed unused fields/entities (b#6)
+{
+"message" "Detention Center"
+"classname" "worldspawn"
+"sky" "unit3_"
+"sounds" "4"
+"nextmap" "jail3"
+}
+{
+"classname" "monster_medic"
+"target" "t176"
+"angle" "270"
+"origin" "-336 728 32"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"target" "t176"
+"targetname" "t178"
+"origin" "88 324 4"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"targetname" "t177"
+"target" "t178"
+"origin" "-340 308 4"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"targetname" "t176"
+"target" "t177"
+"origin" "-332 536 4"
+}
+{
+"origin" "-2688 -16 80"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2968 88 80"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2944 392 80"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2920 592 80"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2560 576 80"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2280 520 80"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1144 520 80"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb1.wav"
+"origin" "-1928 320 80"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb1.wav"
+"origin" "-1760 320 80"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb1.wav"
+"origin" "-1592 312 80"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb1.wav"
+"origin" "-1408 320 80"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "-2376 24 80"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "-960 872 64"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "832 392 64"
+}
+{
+"origin" "-1144 168 80"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2128 320 80"
+"noise" "world/amb1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-840 512 80"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-824 376 80"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-552 368 80"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-88 504 248"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "-880 160 80"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "320 296 192"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb19.wav"
+"origin" "-16 888 176"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb19.wav"
+"origin" "0 728 64"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb19.wav"
+"origin" "1288 424 64"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "-40 16 296"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "648 32 64"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "904 -128 64"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "1080 -136 64"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "1280 -120 64"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "1528 40 64"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "1288 24 64"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"origin" "832 800 64"
+}
+{
+"origin" "1616 664 -120"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1864 656 -24"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1864 928 -24"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1600 936 80"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1600 736 176"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1272 872 176"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1488 680 176"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1416 416 176"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "8 712 352"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1408 632 64"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1360 800 64"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1216 656 64"
+"noise" "world/amb19.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1088 664 64"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "184 16 296"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "840 672 64"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-984 760 64"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "704 384 64"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "96 488 248"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "312 504 192"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-328 464 192"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-280 168 192"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-160 -640 192"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"angle" "0"
+"classname" "info_player_coop"
+"targetname" "jail3b" // b#1: jail1 -> jail3b
+"origin" "-3200 296 -16"
+}
+{
+"angle" "0"
+"classname" "info_player_coop"
+"targetname" "jail3b" // b#1: jail1 -> jail3b
+"origin" "-3200 384 -16"
+}
+{
+"classname" "info_player_coop"
+"angle" "0"
+"targetname" "jail3b" // b#1: jail1 -> jail3b
+"origin" "-3192 232 -16"
+}
+{
+"angle" "270"
+"classname" "info_player_coop"
+"targetname" "jail1"
+"origin" "-8 -1680 88"
+}
+{
+"angle" "270"
+"classname" "info_player_coop"
+"targetname" "jail1"
+"origin" "-56 -1680 88"
+}
+{
+"classname" "info_player_coop"
+"angle" "270"
+"targetname" "jail1"
+"origin" "40 -1680 88"
+}
+{
+"model" "*1"
+"spawnflags" "2048"
+"target" "t60"
+"_minlight" ".2"
+"angle" "270"
+"classname" "func_button"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-864 -672 -200"
+}
+{
+"model" "*2"
+"_minlight" ".2"
+"target" "t150"
+"angle" "0"
+"classname" "func_button"
+}
+{
+"origin" "-3184 392 56"
+"spawnflags" "2064" // b#5: 16 -> 2064
+"target" "t175"
+"delay" "2" // b#6: moved here from relay
+"classname" "target_crosslevel_target"
+}
+{
+"origin" "-3184 360 56"
+"targetname" "t175"
+"target" "t173"
+"delay" "2"
+"classname" "trigger_relay"
+"spawnflags" "3840" // b#6: added this
+}
+{
+"classname" "target_help"
+"targetname" "t174"
+"message" "Use blue keycard to\ngain access to the\ndetention center."
+"origin" "-880 -624 -168"
+}
+{
+"classname" "target_help"
+"targetname" "t161"
+"message" "Locate blue keycard."
+"origin" "-48 -1568 168"
+}
+{
+"classname" "target_help"
+"targetname" "t175" // b#6: t173 -> t175
+"message" "Find the yellow laser\ncontrol computer."
+"origin" "-3184 312 68"
+}
+{
+"classname" "item_armor_jacket"
+"spawnflags" "2048"
+"origin" "-16 -544 -336"
+}
+{
+"classname" "item_power_shield"
+"origin" "-2768 584 -208"
+}
+{
+"model" "*3"
+"spawnflags" "2048"
+"angle" "180"
+"classname" "func_button"
+"target" "t61"
+"_minlight" ".2"
+}
+{
+"model" "*4"
+"spawnflags" "2048"
+"classname" "func_button"
+"angle" "0"
+"target" "t29"
+"_minlight" ".2"
+}
+{
+"classname" "item_adrenaline"
+"origin" "-2792 624 -208"
+}
+{
+"spawnflags" "1024"
+"classname" "ammo_bullets"
+"origin" "-2584 -224 16"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1024"
+"origin" "-2664 -176 16"
+}
+{
+"origin" "168 -1760 80"
+"spawnflags" "1792"
+"classname" "weapon_shotgun"
+}
+{
+"origin" "-224 -1792 88"
+"spawnflags" "1792"
+"targetname" "t172"
+"angle" "0"
+"classname" "misc_teleporter_dest"
+}
+{
+"origin" "-12 -548 -328"
+"spawnflags" "1792"
+"target" "t172"
+"classname" "misc_teleporter"
+}
+{
+"origin" "-2976 -32 16"
+"spawnflags" "1792"
+"classname" "ammo_slugs"
+}
+{
+"origin" "160 576 216"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "0 -1792 80"
+"spawnflags" "1792"
+"classname" "item_armor_combat"
+}
+{
+"origin" "288 744 8"
+"spawnflags" "1792"
+"classname" "ammo_slugs"
+}
+{
+"origin" "1120 248 16"
+"spawnflags" "1792"
+"classname" "ammo_rockets"
+}
+{
+"origin" "-2664 -232 16"
+"spawnflags" "1792"
+"classname" "weapon_shotgun"
+}
+{
+"spawnflags" "2048"
+"origin" "-1528 712 16"
+"classname" "ammo_rockets"
+}
+{
+"spawnflags" "2048"
+"origin" "-1528 672 16"
+"classname" "ammo_rockets"
+}
+{
+"origin" "-1728 592 160"
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+}
+{
+"origin" "-2428 292 -16"
+"spawnflags" "1792"
+"classname" "weapon_rocketlauncher"
+}
+{
+"classname" "info_player_intermission"
+"angles" "-11 310 0"
+"origin" "-1410 -350 -228"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "315"
+"origin" "-1792 832 168"
+}
+{
+"classname" "info_player_deathmatch"
+"origin" "-3200 160 -24"
+"angle" "45"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "272 -1824 88"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "144 -640 8"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "270"
+"origin" "96 592 216"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "0"
+"origin" "672 672 24"
+}
+{
+"spawnflags" "1024"
+"classname" "ammo_cells"
+"origin" "800 288 16"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1024"
+"origin" "800 240 16"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "225"
+"origin" "1792 832 -168"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "180"
+"origin" "1624 48 24"
+}
+{
+"model" "*5"
+"spawnflags" "1792"
+"classname" "trigger_once"
+"target" "t141"
+}
+{
+"model" "*6"
+"classname" "trigger_once"
+"target" "t141"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+"origin" "-1648 208 16"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+"origin" "-1688 208 16"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-1608 208 16"
+}
+{
+"classname" "weapon_machinegun"
+"spawnflags" "1792"
+"origin" "-1952 32 16"
+}
+{
+"origin" "160 -24 248"
+"spawnflags" "1792"
+"classname" "weapon_hyperblaster"
+}
+{
+"origin" "240 -24 248"
+"spawnflags" "1792"
+"classname" "ammo_cells"
+}
+{
+"origin" "280 -24 248"
+"spawnflags" "1792"
+"classname" "ammo_cells"
+}
+{
+"origin" "1444 416 112"
+"spawnflags" "4"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "1408 416 128"
+"spawnflags" "0"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "224 -472 0"
+"spawnflags" "1792"
+"classname" "weapon_shotgun"
+}
+{
+"origin" "-928 -424 -232"
+"angle" "270"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-816 -512 -240"
+"spawnflags" "1792"
+"angle" "180"
+"classname" "weapon_railgun"
+}
+{
+"origin" "-1304 -648 -168"
+"target" "t128"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"model" "*7"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-56 -160 144"
+"target" "t144"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"model" "*8"
+"height" "100"
+"speed" "100"
+"angle" "180"
+"classname" "trigger_monsterjump"
+}
+{
+"origin" "-128 192 176"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-128 512 160"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "128 512 160"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "128 192 176"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "1600 16 104"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1104 320 88"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-3056 576 96"
+"classname" "target_speaker"
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-3072 0 96"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-1488 680 200"
+"noise" "world/comp_hum2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1832 800 200"
+"noise" "world/comp_hum1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-992 936 96"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1536 872 224"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1728 872 224"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-856 832 96"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1728 136 72"
+"targetname" "t24"
+"classname" "target_speaker"
+"spawnflags" "2049"
+"noise" "world/force1.wav"
+}
+{
+"origin" "-1984 136 72"
+"targetname" "t25"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"noise" "world/force1.wav"
+}
+{
+"origin" "-1984 504 72"
+"targetname" "t20"
+"classname" "target_speaker"
+"spawnflags" "2049"
+"noise" "world/force1.wav"
+}
+{
+"origin" "-1728 504 72"
+"targetname" "t21"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"noise" "world/force1.wav"
+}
+{
+"origin" "-1472 504 72"
+"targetname" "t22"
+"classname" "target_speaker"
+"spawnflags" "2049"
+"noise" "world/force1.wav"
+}
+{
+"origin" "-1472 136 72"
+"targetname" "t23"
+"noise" "world/force1.wav"
+"spawnflags" "2049"
+"classname" "target_speaker"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-864 112 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-1120 112 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-1056 112 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-1200 224 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-1112 352 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-1112 416 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-1192 416 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-1192 480 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-1184 552 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-1120 552 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-1072 464 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-912 464 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-880 416 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-880 288 16"
+"classname" "light"
+"light" "60"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-800 112 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-784 160 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-784 224 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-784 288 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-992 272 16"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-944 272 16"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-944 320 16"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-880 352 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-880 224 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-808 560 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-784 536 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-784 480 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-736 432 16"
+"_color" "0.717647 1.000000 0.717647"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-1104 -656 -352"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "-984 -536 -352"
+}
+{
+"origin" "-248 -472 -352"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-416 -336 -352"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-360 -480 -352"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-352 -680 -352"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-488 -584 -352"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-608 -448 -352"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-712 -560 -352"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-832 -472 -352"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-128 -344 -352"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-840 -616 -184"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "-840 -456 -184"
+"classname" "target_speaker"
+"spawnflags" "1" // b#3: 2 -> 1
+"noise" "world/comp_hum1.wav"
+}
+{
+"origin" "-888 -824 -112"
+"noise" "world/comp_hum3.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "-864 -400 -160"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "-320 -1120 96"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-464 -600 -112"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-464 -584 -48"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "56 -672 -8"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "-1160 -592 128"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "-1136 -808 128"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "-1376 -816 128"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "-1304 -680 128"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "-1288 -416 128"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "-1400 -552 128"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "-264 -496 192"
+}
+{
+"origin" "-392 -360 192"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1144 -456 128"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-8 -496 192"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb19.wav"
+"origin" "1448 672 -120"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "-160 -352 192"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "120 -360 192"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"origin" "-416 -656 192"
+}
+{
+"origin" "176 -640 192"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "136 -992 96"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "320 -1120 96"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "136 -1856 112"
+"classname" "target_speaker"
+"noise" "world/comp_hum1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "0 -1856 112"
+"spawnflags" "1"
+"classname" "target_speaker"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "-192 -1848 112"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1056 -880 -160"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "-320 -1536 144"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "320 -1536 144"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "168 -1744 144"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "-168 -1744 144"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "-136 -992 96"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "616 8 24"
+"target" "t171"
+"targetname" "t170"
+"spawnflags" "257"
+"classname" "monster_infantry"
+"angle" "90"
+}
+{
+"origin" "616 56 24"
+"targetname" "t171"
+"spawnflags" "257"
+"angle" "270"
+"classname" "monster_infantry"
+}
+{
+"model" "*9"
+"target" "t170"
+"classname" "trigger_once"
+"spawnflags" "2304" // b#5: added this
+}
+{
+"origin" "1360 936 128"
+"classname" "item_health_small"
+}
+{
+"origin" "1320 936 128"
+"classname" "item_health_small"
+}
+{
+"origin" "1400 936 128"
+"classname" "item_health_small"
+}
+{
+"origin" "1184 936 128"
+"classname" "item_armor_jacket"
+}
+{
+"targetname" "t169"
+"angle" "180"
+"classname" "monster_infantry"
+"spawnflags" "258"
+"origin" "2024 792 -80"
+}
+{
+"targetname" "t169"
+"classname" "monster_infantry"
+"angle" "180"
+"spawnflags" "2"
+"origin" "2024 688 -80"
+}
+{
+"model" "*10"
+"spawnflags" "2048"
+"classname" "func_door"
+"angle" "-2"
+"wait" "-1"
+"lip" "4"
+"speed" "150"
+"targetname" "t169"
+"_minlight" ".1"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "2016 736 -16"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "2016 792 -16"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "2016 680 -16"
+}
+{
+"spawnflags" "1"
+"classname" "monster_infantry"
+"targetname" "t167"
+"target" "t168"
+"item" "ammo_bullets"
+"origin" "976 -128 24"
+}
+{
+"spawnflags" "1"
+"classname" "monster_infantry"
+"targetname" "t166"
+"target" "t167"
+"origin" "1072 -128 24"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_infantry"
+"spawnflags" "1"
+"targetname" "t168"
+"origin" "760 -128 24"
+}
+{
+"model" "*11"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+"target" "t165"
+}
+{
+"angle" "0"
+"classname" "monster_infantry"
+"targetname" "t165"
+"spawnflags" "1"
+"target" "t166"
+"origin" "1152 -104 24"
+}
+{
+"classname" "monster_infantry"
+"angle" "0"
+"targetname" "t165"
+"spawnflags" "1"
+"item" "ammo_bullets"
+"origin" "1152 -152 24"
+}
+{
+"origin" "424 288 112"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "item_armor_jacket"
+"origin" "-288 736 8"
+}
+{
+"origin" "-792 -512 -208"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1408 872 96"
+"message" "You have found a secret area."
+"targetname" "t164"
+"classname" "target_secret"
+}
+{
+"model" "*12"
+"target" "t164"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"classname" "item_health_large"
+"origin" "248 -408 0"
+}
+{
+"classname" "item_health_large"
+"origin" "-168 80 248"
+}
+{
+"classname" "item_health_large"
+"origin" "-168 40 248"
+}
+{
+"origin" "628 32 272"
+"classname" "item_armor_jacket"
+}
+{
+"origin" "408 376 80"
+"targetname" "t139"
+"classname" "target_goal"
+}
+{
+"origin" "56 -184 32"
+"targetname" "t138"
+"classname" "target_goal"
+}
+{
+"origin" "-2416 404 32"
+"message" "You have found a secret area."
+"targetname" "t162"
+"classname" "target_secret"
+}
+{
+"model" "*13"
+"target" "t162"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"spawnflags" "2048"
+"origin" "-2392 292 -12"
+"classname" "item_adrenaline"
+}
+{
+"origin" "-1728 -88 72"
+"item" "ammo_grenades"
+"angle" "90"
+"spawnflags" "8"
+"classname" "misc_insane"
+}
+{
+"classname" "item_bandolier"
+"origin" "200 -432 0"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "1"
+"origin" "216 -400 -16"
+}
+{
+"message" "Locate red key card in the\nsecurity complex."
+"origin" "104 -152 72"
+"classname" "target_help"
+"targetname" "t138"
+}
+{
+"model" "*14"
+"target" "t161"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "1512 672 128"
+"classname" "item_health"
+}
+{
+"classname" "item_health"
+"origin" "-1424 56 16"
+}
+{
+"classname" "item_health"
+"origin" "-2016 608 16"
+}
+{
+"origin" "-1220 878 224"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-1186 878 224"
+"classname" "ammo_bullets"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-1254 878 224"
+}
+{
+"classname" "item_health_large"
+"origin" "-2312 216 16"
+}
+{
+"classname" "item_health_large"
+"origin" "-2312 176 16"
+}
+{
+"classname" "item_health_small"
+"origin" "-1100 942 8"
+}
+{
+"classname" "item_health_small"
+"origin" "-1066 942 8"
+}
+{
+"classname" "item_health_large"
+"origin" "-600 472 0"
+}
+{
+"origin" "-2400 184 28"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "ammo_shells"
+"origin" "-2584 652 16"
+}
+{
+"classname" "ammo_shells"
+"origin" "-2548 652 16"
+}
+{
+"classname" "ammo_shells"
+"origin" "-2900 812 16"
+}
+{
+"classname" "ammo_shells"
+"origin" "-2900 776 16"
+}
+{
+"classname" "item_health"
+"origin" "-3056 620 52"
+}
+{
+"classname" "item_health"
+"origin" "-3056 580 52"
+}
+{
+"classname" "ammo_cells"
+"origin" "-2792 276 -108"
+}
+{
+"classname" "ammo_cells"
+"origin" "-2792 240 -108"
+}
+{
+"classname" "ammo_cells"
+"origin" "-2792 312 -108"
+}
+{
+"classname" "item_health_large"
+"origin" "-2704 160 16"
+}
+{
+"classname" "ammo_shells"
+"origin" "284 88 248"
+}
+{
+"classname" "ammo_shells"
+"origin" "248 88 248"
+}
+{
+"classname" "ammo_shells"
+"origin" "320 88 248"
+}
+{
+"classname" "item_armor_shard"
+"origin" "744 48 16"
+}
+{
+"classname" "item_armor_shard"
+"origin" "744 88 16"
+}
+{
+"classname" "item_armor_shard"
+"origin" "704 88 16"
+}
+{
+"classname" "item_health"
+"origin" "1184 96 16"
+}
+{
+"classname" "item_health"
+"origin" "1184 32 16"
+}
+{
+"model" "*15"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+"target" "t160"
+}
+{
+"spawnflags" "2"
+"angle" "180"
+"classname" "monster_flyer"
+"targetname" "t160"
+"origin" "592 56 296"
+}
+{
+"spawnflags" "2"
+"classname" "monster_flyer"
+"angle" "180"
+"targetname" "t160"
+"origin" "592 16 296"
+}
+{
+"origin" "616 32 168"
+"light" "80"
+"classname" "light"
+}
+{
+"model" "*16"
+"classname" "func_explosive"
+"mass" "800"
+"dmg" "1"
+"targetname" "t160"
+}
+{
+"style" "1"
+"classname" "func_areaportal"
+"targetname" "t159"
+}
+{
+"model" "*17"
+"classname" "func_door"
+"angle" "-1"
+"_minlight" ".2"
+"target" "t159"
+}
+{
+"classname" "monster_infantry"
+"angle" "180"
+"spawnflags" "257"
+"origin" "1896 944 -80"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_infantry"
+"angle" "90"
+"target" "t157"
+"spawnflags" "1"
+"origin" "1728 688 -168"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"targetname" "t157"
+"target" "t158"
+//"angle" "180" // b#6: never used
+"origin" "1728 848 -184"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"targetname" "t158"
+"target" "t157"
+"origin" "1728 640 -184"
+}
+{
+"classname" "item_health_small"
+"origin" "1956 764 -88"
+}
+{
+"classname" "item_health_small"
+"origin" "1956 800 -88"
+}
+{
+"classname" "item_health_small"
+"origin" "1956 836 -88"
+}
+{
+"classname" "item_health_small"
+"origin" "1956 872 -88"
+}
+{
+"classname" "item_health_small"
+"origin" "1956 728 -88"
+}
+{
+"classname" "ammo_grenades"
+"origin" "1672 832 -176"
+}
+{
+"classname" "ammo_grenades"
+"origin" "1672 872 -176"
+}
+{
+"classname" "ammo_grenades"
+"origin" "1672 792 -176"
+}
+{
+"classname" "weapon_grenadelauncher"
+"origin" "1304 696 -176"
+"target" "t169"
+}
+{
+"item" "ammo_grenades"
+"classname" "misc_insane"
+"angle" "225"
+"origin" "1368 728 -168"
+}
+{
+"classname" "ammo_shells"
+"origin" "856 856 16"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2"
+"origin" "832 824 0"
+}
+{
+"classname" "item_armor_jacket"
+"origin" "808 856 16"
+}
+{
+"classname" "item_health_large"
+"origin" "608 288 0"
+}
+{
+"classname" "item_health_large"
+"origin" "544 280 0"
+}
+{
+"classname" "ammo_bullets"
+"origin" "544 488 0"
+}
+{
+"classname" "ammo_bullets"
+"origin" "592 488 0"
+}
+{
+"style" "2"
+"classname" "func_areaportal"
+"targetname" "t139"
+}
+{
+"origin" "-1320 872 232"
+"delay" ".2"
+"targetname" "t75"
+"target" "t76"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1480 864 88"
+"classname" "item_armor_combat"
+}
+{
+"origin" "-1432 728 160"
+"classname" "ammo_shells"
+}
+{
+"origin" "-1760 32 0"
+"classname" "misc_deadsoldier"
+"spawnflags" "1"
+}
+{
+"origin" "-1720 -16 0"
+"spawnflags" "8"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "-1472 600 32"
+"angle" "270"
+"spawnflags" "16"
+"classname" "misc_insane"
+}
+{
+"origin" "-1168 176 16"
+"classname" "ammo_bullets"
+}
+{
+"origin" "368 744 8"
+"classname" "item_health_small"
+}
+{
+"origin" "368 704 8"
+"classname" "item_health_small"
+}
+{
+"origin" "-384 736 8"
+"classname" "item_health_large"
+}
+{
+"spawnflags" "2050"
+"origin" "-1296 -432 -168"
+"targetname" "t128"
+"noise" "world/klaxon1.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2050"
+"origin" "-868 -488 -168"
+"targetname" "t128"
+"noise" "world/klaxon1.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2050"
+"origin" "-1296 -784 -168"
+"targetname" "t128"
+"classname" "target_speaker"
+"noise" "world/klaxon1.wav"
+}
+{
+"item" "ammo_shells"
+"origin" "-1952 680 24"
+"target" "t155"
+"classname" "misc_insane"
+}
+{
+"origin" "-1960 632 8"
+"target" "t156"
+"targetname" "t155"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "-1952 712 8"
+"target" "t155"
+"targetname" "t154"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "-2032 712 8"
+"target" "t154"
+"targetname" "t153"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "-2032 640 8"
+"targetname" "t156"
+"target" "t153"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "-1512 8 8"
+"target" "t152"
+"targetname" "t151"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "-1424 -64 8"
+"target" "t151"
+"targetname" "t152"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"item" "ammo_bullets"
+"origin" "-1512 -48 24"
+"target" "t151"
+"angle" "90"
+"spawnflags" "4"
+"classname" "misc_insane"
+}
+{
+"origin" "-948 808 -84"
+"spawnflags" "4"
+"classname" "misc_insane"
+}
+{
+"origin" "-968 936 -68"
+"angle" "270"
+"spawnflags" "8"
+"classname" "misc_insane"
+}
+{
+"origin" "-938 388 12"
+"targetname" "t150"
+"classname" "target_laser"
+"spawnflags" "3"
+"angle" "180"
+"dmg" "50"
+}
+{
+"origin" "-938 388 52"
+"targetname" "t150"
+"dmg" "50"
+"angle" "180"
+"spawnflags" "3"
+"classname" "target_laser"
+}
+{
+"classname" "target_crosslevel_trigger"
+"spawnflags" "2049" // b#5: 1 -> 2049
+"targetname" "t148"
+"origin" "-28 0 320"
+}
+{
+"classname" "target_help"
+"targetname" "t148"
+"message" "Return to the\nsecurity complex."
+"origin" "-100 60 320"
+}
+{
+"classname" "target_goal"
+"targetname" "t148"
+"origin" "-108 -40 320"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "3840" // b#6: added this
+"target" "t149"
+"targetname" "t148"
+"origin" "-108 -16 320"
+}
+{
+"noise" "world/comp_hum1.wav"
+"classname" "target_speaker"
+"spawnflags" "2048" // b#5: added this
+"attenuation" "-1"
+"targetname" "t148"
+"origin" "-76 -36 288"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "-84 -95 252"
+}
+{
+"classname" "light"
+"light" "48"
+"origin" "-60 -95 252"
+}
+{
+"classname" "item_health"
+"origin" "-48 752 304"
+}
+{
+"origin" "-160 568 216"
+"classname" "ammo_bullets"
+}
+{
+"spawnflags" "3584"
+"origin" "-120 608 216"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-152 0 16"
+"classname" "item_health_large"
+}
+{
+"origin" "64 24 16"
+"classname" "ammo_shells"
+}
+{
+"origin" "32 24 16"
+"classname" "ammo_shells"
+}
+{
+"origin" "-640 -472 -120"
+"classname" "item_health"
+}
+{
+"origin" "-600 -472 -120"
+"classname" "item_health"
+}
+{
+"origin" "-1240 -672 64"
+"targetname" "t146"
+"classname" "point_combat"
+"spawnflags" "256"
+}
+{
+"origin" "-1240 -808 64"
+"targetname" "t147"
+"classname" "point_combat"
+}
+{
+"origin" "-1240 -544 64"
+"targetname" "t145"
+"classname" "point_combat"
+}
+{
+"origin" "-284 -1812 88"
+"classname" "ammo_shells"
+}
+{
+"origin" "-284 -1848 88"
+"classname" "ammo_shells"
+}
+{
+"origin" "-284 -1776 88"
+"classname" "ammo_shells"
+}
+{
+"origin" "4 -1196 4"
+"classname" "ammo_bullets"
+}
+{
+"origin" "40 -1196 4"
+"classname" "ammo_bullets"
+}
+{
+"origin" "76 -1196 4"
+"classname" "ammo_bullets"
+}
+{
+"model" "*18"
+"spawnflags" "2048"
+"wait" "-1"
+"target" "brandon"
+"classname" "trigger_multiple"
+}
+{
+"model" "*19"
+"spawnflags" "2048"
+"target" "t128"
+"targetname" "brandon"
+"wait" "-1"
+"angle" "0"
+"classname" "func_button"
+}
+{
+"spawnflags" "2048"
+"origin" "-868 -672 -228"
+"classname" "key_blue_key"
+"target" "t174"
+}
+{
+"spawnflags" "2048"
+"item" "key_blue_key"
+"origin" "120 -308 68"
+"target" "t144"
+"targetname" "t143"
+"classname" "trigger_key"
+}
+{
+"model" "*20"
+"spawnflags" "2048"
+"target" "t143"
+"classname" "trigger_multiple"
+}
+{
+"origin" "416 416 88"
+"item" "key_red_key"
+"targetname" "t142"
+"target" "t141"
+"classname" "trigger_key"
+"spawnflags" "2048"
+}
+{
+"model" "*21"
+"target" "t142"
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+}
+{
+"style" "3"
+"targetname" "t108"
+"classname" "func_areaportal"
+}
+{
+"style" "4"
+"targetname" "t112"
+"classname" "func_areaportal"
+}
+{
+"style" "5"
+"targetname" "t138"
+"classname" "func_areaportal"
+}
+{
+"classname" "misc_explobox"
+"origin" "-2840 640 0"
+}
+{
+"classname" "ammo_grenades"
+"origin" "-2984 744 16"
+}
+{
+"classname" "item_health_large"
+"origin" "-2584 -176 16"
+}
+{
+"model" "*22"
+"spawnflags" "2048"
+"classname" "func_door"
+"speed" "300"
+"angle" "-1"
+"wait" "-1"
+"_minlight" ".2"
+"targetname" "t136"
+}
+{
+"model" "*23"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+"target" "t135"
+}
+{
+"model" "*24"
+"spawnflags" "2048"
+"classname" "func_door"
+"angle" "-1"
+"wait" "-1"
+"_minlight" ".2"
+"targetname" "t136"
+"lip" "8"
+"speed" "300"
+}
+{
+"classname" "ammo_shells"
+"origin" "-1466 728 160"
+}
+{
+"classname" "item_health"
+"origin" "-1880 680 160"
+}
+{
+"classname" "item_health"
+"origin" "-1824 680 160"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-816 864 176"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-816 800 176"
+}
+{
+"classname" "monster_gunner"
+"angle" "180"
+"origin" "-1208 832 232"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-1168 216 16"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-1168 136 16"
+}
+{
+"spawnflags" "2"
+"classname" "monster_flyer"
+"angle" "180"
+"targetname" "t134"
+"origin" "-796 864 156"
+}
+{
+"spawnflags" "2"
+"classname" "monster_flyer"
+"angle" "180"
+"targetname" "t134"
+"origin" "-796 800 156"
+}
+{
+"model" "*25"
+"classname" "func_explosive"
+"dmg" "1"
+"targetname" "t134"
+}
+{
+"classname" "ammo_grenades"
+"origin" "-856 936 16"
+}
+{
+"model" "*26"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+"target" "t133"
+}
+{
+"classname" "monster_berserk"
+"targetname" "t133"
+"origin" "-1232 848 72"
+"target" "t134"
+"spawnflags" "1"
+}
+{
+"classname" "item_health"
+"origin" "-88 792 0"
+}
+{
+"classname" "item_health"
+"origin" "-88 736 0"
+}
+{
+"classname" "ammo_bullets"
+"origin" "-120 568 216"
+}
+{
+"spawnflags" "3584"
+"classname" "ammo_bullets"
+"origin" "-160 608 216"
+}
+{
+"classname" "weapon_chaingun"
+"origin" "0 480 216"
+}
+{
+"model" "*27"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+"target" "t132"
+}
+{
+"classname" "monster_gladiator"
+"angle" "90"
+"targetname" "t132"
+"origin" "0 160 264"
+"spawnflags" "1"
+}
+{
+"model" "*28"
+"classname" "trigger_once"
+"target" "t131"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "0 -1488 96"
+}
+{
+"origin" "0 -1524 104"
+"angle" "270"
+"classname" "info_player_start"
+"targetname" "jail1" // b#2: added this
+}
+{
+"model" "*29"
+"classname" "func_button"
+"angle" "90"
+"target" "t130"
+}
+{
+"origin" "224 -1880 88"
+"classname" "item_health_large"
+}
+{
+"origin" "280 -1880 88"
+"classname" "item_health_large"
+}
+{
+"origin" "-64 -1184 8"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-672 -864 -120"
+"classname" "ammo_shells"
+}
+{
+"origin" "-736 -864 -120"
+"classname" "ammo_shells"
+}
+{
+"origin" "-984 -864 -240"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-1048 -864 -240"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-864 -416 -240"
+"classname" "item_health"
+}
+{
+"origin" "-2944 800 28"
+"classname" "monster_medic"
+"angle" "270"
+"spawnflags" "2"
+"targetname" "t136"
+}
+{
+"spawnflags" "258"
+"origin" "-2624 -232 28"
+"angle" "90"
+"classname" "monster_medic"
+"targetname" "t136"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-796 734 34"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#5: added this
+"delay" "2"
+"targetname" "t127"
+"target" "t129"
+"origin" "-1288 -616 -64"
+}
+{
+"target" "t146"
+"angle" "0"
+"spawnflags" "258"
+"classname" "monster_flyer"
+"targetname" "t129"
+"origin" "-1008 -664 88"
+}
+{
+"target" "t145"
+"angle" "180"
+"spawnflags" "2"
+"classname" "monster_flyer"
+"targetname" "t129"
+"origin" "-1008 -544 96"
+}
+{
+"target" "t147"
+"classname" "monster_flyer"
+"spawnflags" "2"
+"angle" "45"
+"targetname" "t129"
+"origin" "-1008 -800 80"
+}
+{
+"style" "32"
+"spawnflags" "1"
+"light" "250"
+"classname" "light"
+"targetname" "t127"
+"origin" "-1320 -688 -112"
+}
+{
+"style" "32"
+"spawnflags" "1"
+"light" "250"
+"classname" "light"
+"targetname" "t127"
+"origin" "-1304 -496 -112"
+}
+{
+"style" "32"
+"classname" "light"
+"light" "250"
+"spawnflags" "1"
+"targetname" "t127"
+"origin" "-1280 -824 -112"
+}
+{
+"origin" "-992 320 16"
+"classname" "item_quad"
+}
+{
+"model" "*30"
+"targetname" "t20"
+"classname" "func_wall"
+"spawnflags" "2054"
+}
+{
+"model" "*31"
+"targetname" "t21"
+"spawnflags" "2050"
+"classname" "func_wall"
+}
+{
+"model" "*32"
+"targetname" "t22"
+"spawnflags" "2054"
+"classname" "func_wall"
+}
+{
+"model" "*33"
+"targetname" "t24"
+"classname" "func_wall"
+"spawnflags" "2054"
+}
+{
+"model" "*34"
+"targetname" "t23"
+"classname" "func_wall"
+"spawnflags" "2054"
+}
+{
+"model" "*35"
+"targetname" "t25"
+"spawnflags" "2050"
+"classname" "func_wall"
+}
+{
+"delay" "1"
+"origin" "-1248 -668 -132"
+"targetname" "t128"
+"target" "t127"
+"classname" "trigger_relay"
+}
+{
+"style" "32"
+"origin" "-1160 -608 -28"
+"targetname" "t127"
+"classname" "light"
+"spawnflags" "1"
+}
+{
+"style" "32"
+"origin" "-1164 -736 -28"
+"targetname" "t127"
+"spawnflags" "1"
+"classname" "light"
+}
+{
+"origin" "-1144 -608 -28"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1144 -736 -28"
+"light" "80"
+"classname" "light"
+}
+{
+"pathtarget" "brandon"
+"origin" "-792 -512 -248"
+"targetname" "t126"
+"classname" "point_combat"
+}
+{
+"origin" "-1032 -448 -232"
+"target" "t126"
+"spawnflags" "1"
+"angle" "315"
+"classname" "monster_gladiator"
+}
+{
+"origin" "-2816 16 24"
+"target" "t123"
+"angle" "0"
+"classname" "monster_infantry"
+"spawnflags" "768"
+}
+{
+"origin" "-2776 8 8"
+"target" "t124"
+"targetname" "t123"
+"classname" "path_corner"
+"spawnflags" "2816" // b#5: added this
+}
+{
+"origin" "-2544 8 8"
+"targetname" "t124"
+"target" "t123"
+"classname" "path_corner"
+"spawnflags" "2816" // b#5: added this
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2944 768 112"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2912 544 112"
+}
+{
+"origin" "-2968 296 16"
+"classname" "monster_tank"
+"angle" "0"
+"targetname" "t135"
+"target" "t136"
+}
+{
+"spawnflags" "1"
+"origin" "-1360 240 24"
+"target" "t116"
+"angle" "180"
+"classname" "monster_gladiator"
+}
+{
+"spawnflags" "257"
+"origin" "-2040 408 24"
+"target" "t119"
+"angle" "0"
+"classname" "monster_gladiator"
+}
+{
+"origin" "-1984 408 8"
+"targetname" "t119"
+"target" "t118"
+"classname" "path_corner"
+"spawnflags" "2304" // b#5: added this
+}
+{
+"origin" "-1488 408 8"
+"target" "t119"
+"targetname" "t118"
+"classname" "path_corner"
+"spawnflags" "2304" // b#5: added this
+}
+{
+"origin" "-1416 240 8"
+"target" "t117"
+"targetname" "t116"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "-1912 240 8"
+"targetname" "t117"
+"target" "t116"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"model" "*36"
+"target" "t115"
+"classname" "trigger_once"
+"spawnflags" "2304" // b#5: added this
+}
+{
+"spawnflags" "257"
+"origin" "-1736 592 168"
+"targetname" "t115"
+"classname" "monster_infantry"
+"angle" "270"
+}
+{
+"spawnflags" "257"
+"origin" "-1504 576 168"
+"targetname" "t115"
+"angle" "270"
+"classname" "monster_infantry"
+}
+{
+"spawnflags" "1"
+"origin" "-1576 832 176"
+"target" "t113"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"origin" "-1608 832 160"
+"target" "t114"
+"targetname" "t113"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "-1792 832 160"
+"targetname" "t114"
+"target" "t113"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"spawnflags" "1"
+"origin" "-560 384 16"
+"targetname" "t112"
+"angle" "0"
+"classname" "monster_berserk"
+}
+{
+"model" "*37"
+"target" "t111"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "736 -16 32"
+"targetname" "t111"
+"angle" "180"
+"classname" "monster_parasite"
+"spawnflags" "1"
+}
+{
+"spawnflags" "1"
+"origin" "1280 80 32"
+"targetname" "t108"
+"angle" "90"
+"classname" "monster_parasite"
+}
+{
+"spawnflags" "1"
+"origin" "1248 880 144"
+"target" "t107"
+"angle" "270"
+"classname" "monster_infantry"
+}
+{
+"model" "*38"
+"target" "t107"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "1608 208 112"
+"targetname" "t107"
+"angle" "270"
+"classname" "monster_infantry"
+}
+{
+"origin" "1144 504 8"
+"spawnflags" "257" // b#5: 1 -> 257
+"targetname" "t105"
+"classname" "point_combat"
+}
+{
+"origin" "1392 672 16"
+"spawnflags" "1"
+"targetname" "t104"
+"classname" "point_combat"
+}
+{
+"spawnflags" "257"
+"origin" "1224 408 24"
+"target" "t105"
+"classname" "monster_infantry"
+"angle" "90"
+"item" "ammo_bullets"
+}
+{
+"spawnflags" "1"
+"origin" "1264 408 24"
+"target" "t104"
+"angle" "90"
+"classname" "monster_infantry"
+"item" "ammo_bullets"
+}
+{
+"spawnflags" "1"
+"origin" "680 680 32"
+"angle" "0"
+"classname" "monster_parasite"
+}
+{
+"spawnflags" "1"
+"origin" "832 248 32"
+"angle" "90"
+"classname" "monster_parasite"
+}
+{
+"spawnflags" "769"
+"classname" "monster_medic"
+"angle" "270"
+"origin" "320 728 20"
+}
+{
+"model" "*39"
+"lip" "4"
+"wait" "-1"
+"angle" "-2"
+"classname" "func_door"
+"targetname" "t131"
+"_minlight" ".2"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "328 728 72"
+}
+{
+"origin" "-328 728 72"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*40"
+"lip" "4"
+"classname" "func_door"
+"angle" "-2"
+"wait" "-1"
+"targetname" "t131"
+"_minlight" ".2"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"targetname" "t97"
+"target" "t98"
+"origin" "280 496 0"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"target" "t97"
+"targetname" "t98"
+"origin" "280 208 0"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"targetname" "t95"
+"target" "t94"
+"origin" "0 304 0"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"targetname" "t94"
+"target" "t95"
+"origin" "-272 304 0"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"target" "t94"
+"targetname" "t95"
+"origin" "-272 512 0"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+"target" "t94"
+"targetname" "t96"
+"origin" "-240 320 0"
+}
+{
+"angle" "270"
+"classname" "monster_berserk"
+"target" "t96"
+"origin" "-280 560 16"
+"spawnflags" "0"
+}
+{
+"classname" "monster_berserk"
+"angle" "270"
+"target" "t97"
+"origin" "280 560 16"
+"spawnflags" "0"
+}
+{
+"model" "*41"
+"_minlight" ".2"
+"spawnflags" "1"
+"classname" "func_plat"
+}
+{
+"spawnflags" "1"
+"classname" "monster_gunner"
+"angle" "270"
+"origin" "88 520 224"
+}
+{
+"origin" "0 -896 0"
+"target" "t88"
+"targetname" "t87"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "0 -1072 0"
+"targetname" "t88"
+"target" "t87"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"spawnflags" "1"
+"origin" "0 -936 16"
+"target" "t88"
+"classname" "monster_infantry"
+}
+{
+"model" "*42"
+"target" "t86"
+"classname" "trigger_once"
+"spawnflags" "2304" // b#5: added this
+}
+{
+"origin" "8 -1128 8"
+"spawnflags" "257"
+"targetname" "t86"
+"angle" "270"
+"classname" "monster_infantry"
+}
+{
+"origin" "-264 -1456 88"
+"spawnflags" "257"
+"target" "t85"
+"angle" "90"
+"classname" "monster_gunner"
+}
+{
+"origin" "-264 -1112 16"
+"target" "t85"
+"targetname" "t84"
+"classname" "path_corner"
+"spawnflags" "2304" // b#5: added this
+}
+{
+"origin" "-264 -1408 72"
+"targetname" "t85"
+"target" "t84"
+"classname" "path_corner"
+"spawnflags" "2304" // b#5: added this
+}
+{
+"origin" "256 -1096 32"
+"spawnflags" "1"
+"target" "t82"
+"angle" "270"
+"classname" "monster_gunner"
+}
+{
+"origin" "256 -1128 16"
+"target" "t83"
+"targetname" "t82"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"origin" "256 -1408 80"
+"targetname" "t83"
+"target" "t82"
+"classname" "path_corner"
+"spawnflags" "2048" // b#5: added this
+}
+{
+"model" "*43"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+"target" "t81"
+}
+{
+"spawnflags" "1"
+"classname" "monster_infantry"
+"angle" "90"
+"targetname" "t81"
+"origin" "-664 -656 -112"
+}
+{
+"model" "*44"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#5: added this
+"target" "t81"
+}
+{
+"spawnflags" "1"
+"classname" "monster_tank"
+"angle" "180"
+"origin" "272 -352 8"
+}
+{
+"origin" "-3296 288 -16"
+"targetname" "jail3b"
+"classname" "info_player_start"
+"angle" "0"
+}
+{
+"origin" "-3448 304 16"
+"map" "jail3$jail2b"
+"targetname" "t80"
+"classname" "target_changelevel"
+}
+{
+"model" "*45"
+"angle" "180"
+"target" "t80"
+"classname" "trigger_multiple"
+}
+{
+"origin" "-64 -1536 264"
+"target" "jail2"
+"map" "jail1$jail2"
+"targetname" "t79"
+"classname" "target_changelevel"
+}
+{
+"model" "*46"
+"target" "t79"
+"classname" "trigger_multiple"
+}
+{
+"spawnflags" "2081"
+"origin" "182 112 320"
+"dmg" "1000"
+"angle" "180"
+"classname" "target_laser"
+"targetname" "t148" // b#6: t149 -> t148
+}
+{
+"spawnflags" "2081"
+"origin" "182 112 288"
+"classname" "target_laser"
+"angle" "180"
+"dmg" "1000"
+"targetname" "t148" // b#6: t149 -> t148
+}
+{
+"spawnflags" "2081"
+"origin" "182 112 254"
+"classname" "target_laser"
+"angle" "180"
+"dmg" "1000"
+"targetname" "t148" // b#6: t149 -> t148
+}
+{
+"model" "*47"
+"targetname" "t29"
+"classname" "func_door"
+"angle" "-2"
+"_minlight" ".3"
+"sounds" "3"
+"wait" "5"
+"spawnflags" "2048"
+}
+{
+"origin" "-2880 240 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2912 0 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2640 48 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2544 48 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2400 32 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2272 32 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2272 320 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2272 544 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2400 544 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2544 512 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2640 512 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2624 -208 112"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2880 336 112"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-3076 32 100"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-3076 540 100"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-3076 608 100"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-3076 -36 100"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-3248 360 96"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-3248 416 96"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-3248 224 96"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-3248 168 96"
+"light" "80"
+"classname" "light"
+}
+{
+"model" "*48"
+"sounds" "3"
+"_minlight" ".3"
+"targetname" "t27"
+"angle" "-2"
+"classname" "func_door"
+"wait" "-1"
+"spawnflags" "2048"
+"message" "This door is opened elsewhere."
+}
+{
+"origin" "-2300 320 36"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-3008 288 120"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "-3136 288 120"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "-2912 -64 120"
+"light" "200"
+"classname" "light"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-2768 288 -24"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-2768 584 -92"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-96 608 272"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "96 608 272"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "0 136 344"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "0 -40 344"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "72 40 344"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "312 40 344"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "504 40 344"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-72 40 344"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "728 32 168"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "616 32 328"
+}
+{
+"origin" "1648 656 148"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1656 776 120"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "1808 540 -84"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "1872 536 -84"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "1948 540 -84"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "1960 632 -84"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "1956 708 -84"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "1956 804 -84"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "1956 884 -84"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "1956 952 -84"
+}
+{
+"classname" "light"
+"light" "48"
+"origin" "1708 536 -84"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1824 880 -64"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1728 880 8"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1656 864 72"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1592 556 172"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1824 760 -104"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1320 672 -40"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "1768 672 -104"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1760 800 -104"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "1152 800 88"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "1768 728 120"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "1472 64 120"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1280 64 120"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1440 64 240"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1608 64 240"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1608 256 240"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1608 416 240"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1280 64 240"
+}
+{
+"origin" "1108 320 92"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "1168 672 88"
+"classname" "light"
+"light" "175"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1408 272 56"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "1296 672 120"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "1288 240 88"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1600 20 108"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1480 704 16"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1480 832 16"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1480 576 16"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1464 800 128"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1464 600 128"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1336 416 128"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1488 248 128"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1248 824 128"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "1384 792 232"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "1408 544 232"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "1192 544 232"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "1408 288 232"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "1192 288 232"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "1168 792 232"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "1728 576 -176"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "1664 576 -176"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "1728 884 -176"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "1792 884 -176"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "1696 672 240"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "1840 672 240"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "1840 808 240"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "1696 808 240"
+}
+{
+"origin" "1288 912 200"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "1208 912 200"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1072 776 -40"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1072 888 -40"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-848 776 -40"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-848 888 -40"
+"classname" "light"
+"light" "64"
+}
+{
+"model" "*49"
+"targetname" "t144"
+"classname" "func_door"
+"angle" "0"
+"wait" "-1"
+"speed" "30"
+"sounds" "4"
+"_minlight" ".3"
+"lip" "64"
+}
+{
+"model" "*50"
+"target" "t138"
+"targetname" "t144"
+"spawnflags" "0"
+"classname" "func_door"
+"angle" "180"
+"_minlight" ".3"
+"wait" "-1"
+"sounds" "4"
+"lip" "64"
+"speed" "30"
+}
+{
+"origin" "-1344 248 80"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1344 392 80"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-1376 832 192"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-992 944 96"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1536 880 224"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1248 832 120"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1280 832 256"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "1200 616 -40"
+}
+{
+"classname" "light"
+"light" "48"
+"origin" "1200 728 -40"
+}
+{
+"light" "48"
+"classname" "light"
+"origin" "1424 728 -40"
+}
+{
+"classname" "light"
+"light" "48"
+"origin" "1424 616 -40"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1984 64 224"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1728 64 224"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1728 880 224"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-848 832 96"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1472 64 224"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1896 864 224"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1856 864 200"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1856 736 200"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1896 736 224"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1488 608 232"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1488 608 176"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1472 672 200"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1840 800 176"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1840 800 232"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1432 672 224"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1432 560 200"
+}
+{
+"model" "*51"
+"classname" "func_button"
+"angle" "0"
+"health" "1"
+"target" "t75"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1180 832 244"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1472 832 368"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1472 640 368"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1728 640 368"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1728 832 368"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2048 320 304"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1920 320 304"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1792 320 304"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1664 320 304"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1536 320 304"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1408 320 304"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1280 832 368"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-2096 248 80"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-2096 392 80"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-224 -1844 92"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-160 -1844 92"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "100 -1840 156"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "96 -1840 92"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-224 -1888 144"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "160 -1856 116"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "28 -1856 116"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-36 -1856 116"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-100 -1916 160"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-156 -1844 156"
+}
+{
+"origin" "-272 -1352 136"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "0 -1656 152"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-76 -1692 152"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-76 -1692 264"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "88 -1688 264"
+"classname" "light"
+"light" "120"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-88 -1824 264"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-256 -1816 264"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "256 -1820 264"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "88 -1688 152"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "272 -1352 136"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "108 -1828 264"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "316 -1120 96"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "316 -1536 148"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-316 -1536 148"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-164 -1744 148"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "164 -1744 148"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-316 -1120 96"
+}
+{
+"origin" "-840 -672 -200"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-800 -672 -176"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-848 -608 -200"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-800 -608 -108"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1128 -720 -344"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1096 -632 -392"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1000 -568 -392"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-336 -656 -248"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-272 -688 -360"
+}
+{
+"classname" "light"
+"origin" "-40 -368 -240"
+"light" "150"
+}
+{
+"origin" "-1192 -544 -336"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1192 -672 -336"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1192 -800 -336"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1048 -440 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1088 -672 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1016 -624 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-912 -584 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-760 -400 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-544 -440 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-520 -640 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-592 -584 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-704 -568 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-656 -416 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-720 -504 -352"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-392 -328 -392"
+"classname" "light"
+"light" "64"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-392 -472 -392"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-400 -584 -392"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-408 -688 -392"
+}
+{
+"origin" "-256 -472 -360"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-264 -584 -360"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-344 -336 -248"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-496 -632 -392"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-536 -440 -392"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-592 -512 -392"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-984 -440 -352"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-1000 -568 -352"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-864 -520 -352"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-1136 -496 -352"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-592 -512 -352"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1160 -856 -344"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-864 -520 -392"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-720 -504 -392"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-256 -328 -360"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-984 -440 -392"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1160 -800 -392"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1160 -672 -392"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1160 -544 -392"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1080 -672 -248"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1080 -544 -248"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-1080 -800 -248"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1060 -876 -160"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-864 -404 -160"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-736 -884 -112"
+}
+{
+"origin" "-608 -816 -64"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-992 -736 -32"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-992 -608 -32"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-848 -800 -32"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-672 -512 -40"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-672 -640 -40"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-672 -800 -32"
+}
+{
+"origin" "-804 -408 -108"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-856 -872 -56"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-752 -800 -32"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-560 -512 -40"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "64 -1056 288"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1504 832 96"
+"light" "100"
+"classname" "light"
+}
+{
+"model" "*52"
+"target" "t76"
+"wait" "5"
+"_minlight" ".2"
+"angle" "180"
+"classname" "func_button"
+}
+{
+"model" "*53"
+"targetname" "t76"
+"wait" "10"
+"lip" "-108"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*54"
+"targetname" "t76"
+"lip" "-76"
+"wait" "10"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*55"
+"targetname" "t76"
+"wait" "10"
+"angle" "-1"
+"lip" "-44"
+"classname" "func_door"
+}
+{
+"model" "*56"
+"lip" "-12"
+"targetname" "t76"
+"wait" "10"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"model" "*57"
+"targetname" "t75"
+"lip" "-4"
+"wait" "-1"
+"angle" "270"
+"classname" "func_door"
+}
+{
+"classname" "light"
+"light" "50"
+"origin" "1608 40 24"
+}
+{
+"classname" "light"
+"light" "50"
+"origin" "1608 88 40"
+}
+{
+"classname" "item_health"
+"origin" "1512 712 128"
+}
+{
+"origin" "1608 456 200"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "1608 376 200"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "50"
+"origin" "1608 280 104"
+}
+{
+"light" "50"
+"classname" "light"
+"origin" "1608 328 120"
+}
+{
+"classname" "light"
+"light" "50"
+"origin" "1608 232 88"
+}
+{
+"classname" "light"
+"light" "50"
+"origin" "1608 184 72"
+}
+{
+"classname" "light"
+"light" "50"
+"origin" "1608 136 56"
+}
+{
+"light" "50"
+"classname" "light"
+"origin" "1592 104 24"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1488 760 200"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1488 840 200"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1280 -32 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1280 104 80"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1280 184 80"
+}
+{
+"model" "*58"
+"spawnflags" "8"
+"target" "t108"
+"_minlight" "0.4"
+"classname" "func_door"
+"angle" "-2"
+"sounds" "2"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1376 192 128"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1480 456 200"
+}
+{
+"origin" "1480 376 200"
+"light" "80"
+"classname" "light"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1280 32 104"
+}
+{
+"origin" "0 752 432"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "0 896 424"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "64 752 160"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "0 656 368"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-64 752 160"
+"light" "80"
+"classname" "light"
+}
+{
+"model" "*59"
+"_minlight" ".3"
+"spawnflags" "1"
+"classname" "func_plat"
+}
+{
+"origin" "-992 560 120"
+"classname" "light"
+"light" "40"
+}
+{
+"origin" "-1472 688 88"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1728 688 88"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-1040 608 16"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-944 608 16"
+}
+{
+"origin" "-160 -512 -104"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-288 -512 -168"
+"light" "80"
+"classname" "light"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-464 -440 -48"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-432 -448 -196"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "-32 -496 -164"
+}
+{
+"origin" "-432 -576 -196"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-32 -624 -164"
+"classname" "light"
+"light" "175"
+}
+{
+"origin" "-56 -672 -8"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-464 -424 -112"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "150"
+"origin" "-32 -576 -240"
+"classname" "light"
+}
+{
+"model" "*60"
+"_minlight" ".1"
+"wait" "-1"
+"targetname" "t141"
+"target" "t139"
+"classname" "func_door"
+"angle" "-2"
+"sounds" "2"
+"spawnflags" "0"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-32 -1232 80"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "32 -1232 80"
+}
+{
+"origin" "64 -1120 288"
+"light" "80"
+"classname" "light"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "0 -1120 248"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "64 -1184 248"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "-32 -368 -164"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-64 -1184 288"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-928 -544 -32"
+}
+{
+"model" "*61"
+"classname" "func_door"
+"spawnflags" "1"
+"_minlight" ".2"
+//"sounds" "1" // b#4: removed this
+"targetname" "t130"
+"angle" "-2"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1040 272 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1040 320 16"
+"light" "60"
+"classname" "light"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-1112 288 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-1200 160 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-1104 224 16"
+"light" "60"
+"classname" "light"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-1184 112 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-1056 208 16"
+"light" "60"
+"classname" "light"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-992 112 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-992 208 16"
+"light" "60"
+"classname" "light"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-928 112 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-928 208 16"
+"light" "60"
+"classname" "light"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-736 336 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-864 560 16"
+"light" "60"
+"classname" "light"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-672 336 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-672 432 16"
+"light" "60"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-1040 416 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-624 480 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "0.717647 1.000000 0.717647"
+"origin" "-624 288 16"
+"classname" "light"
+"light" "60"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"origin" "-944 416 16"
+"light" "60"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-2408 376 40"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-2440 408 40"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-2440 408 120"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-2408 376 120"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-2744 168 40"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-2776 200 40"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-2776 200 120"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-2744 168 120"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-2776 376 40"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-2744 408 40"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-2744 408 120"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-2776 376 120"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-2408 200 40"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-2408 200 120"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "-2440 168 120"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-2440 168 40"
+}
+{
+"model" "*62"
+"target" "t22"
+"classname" "func_button"
+"angle" "90"
+"lip" "-8"
+"sounds" "3"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1584 480 56"
+}
+{
+"model" "*63"
+"sounds" "3"
+"lip" "-8"
+"angle" "270"
+"classname" "func_button"
+"target" "t24"
+}
+{
+"origin" "-1616 160 56"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1360 160 56"
+"light" "80"
+"classname" "light"
+}
+{
+"model" "*64"
+"sounds" "3"
+"lip" "-8"
+"angle" "270"
+"classname" "func_button"
+"target" "t23"
+}
+{
+"model" "*65"
+"classname" "func_button"
+"angle" "270"
+"lip" "-8"
+"sounds" "3"
+"target" "t25"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1872 160 56"
+}
+{
+"model" "*66"
+"classname" "func_button"
+"angle" "90"
+"lip" "-8"
+"sounds" "3"
+"target" "t20"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-2096 480 56"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "960 -128 104"
+}
+{
+"origin" "1088 -128 104"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1216 -128 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "832 -128 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1280 -128 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "768 672 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "832 768 104"
+}
+{
+"origin" "832 320 104"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "832 448 104"
+}
+{
+"origin" "768 384 104"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "640 384 104"
+}
+{
+"origin" "688 -128 104"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-768 384 120"
+"classname" "light"
+"light" "40"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "640 32 56"
+}
+{
+"origin" "-912 160 120"
+"classname" "light"
+"light" "40"
+}
+{
+"targetname" "jail1"
+"origin" "0 -1548 104"
+"angle" "270"
+"classname" "info_player_start"
+}
+{
+"origin" "424 384 64"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "504 384 64"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-2752 544 104"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1472 -48 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1472 560 72"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1472 496 72"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1472 144 72"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1472 80 72"
+}
+{
+"origin" "-1984 80 72"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1984 144 72"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2864 288 72"
+"classname" "light"
+"light" "120"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-2800 288 72"
+}
+{
+"origin" "-1728 80 72"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1728 144 72"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1728 496 72"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1728 560 72"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1984 -48 88"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1728 -48 88"
+}
+{
+"origin" "-1984 688 88"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1952 -48 16"
+"classname" "item_health"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1984 496 72"
+}
+{
+"origin" "-1984 560 72"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-2592 432 72"
+}
+{
+"origin" "-2592 496 72"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-2592 144 72"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-504 384 64"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-424 384 64"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-2744 288 64"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2652 200 64"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2652 376 64"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2532 200 64"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2636 288 -48"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2504 288 64"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2440 288 64"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2560 288 32"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "720 48 56"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "512 32 56"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2664 160 16"
+"classname" "item_health_large"
+}
+{
+"model" "*67"
+"targetname" "t60"
+"lip" "8"
+"wait" "15"
+"sounds" "3"
+"speed" "30"
+"angle" "-2"
+"classname" "func_door"
+"spawnflags" "2048"
+}
+{
+"model" "*68"
+"angle" "180"
+"target" "t60"
+"classname" "func_button"
+"wait" "13"
+"spawnflags" "2048"
+}
+{
+"origin" "-2408 232 8"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-2408 344 8"
+"classname" "light"
+"light" "100"
+}
+{
+"spawnflags" "2048"
+"origin" "-2792 344 136"
+"target" "t29"
+"targetname" "t61"
+"classname" "trigger_relay"
+}
+{
+"spawnflags" "2048"
+"origin" "-2536 424 136"
+"target" "t27"
+"targetname" "t61"
+"classname" "trigger_relay"
+}
+{
+"model" "*69"
+"target" "t112"
+"classname" "func_door"
+"angle" "-2"
+"sounds" "2"
+"_minlight" "0.5"
+}
+{
+"light" "40"
+"classname" "light"
+"origin" "-912 512 120"
+}
+{
+"light" "40"
+"classname" "light"
+"origin" "-832 448 120"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "832 576 104"
+}
+{
+"light" "40"
+"classname" "light"
+"origin" "-832 320 120"
+}
+{
+"light" "40"
+"classname" "light"
+"origin" "-832 208 120"
+}
+{
+"light" "40"
+"classname" "light"
+"origin" "-1072 160 120"
+}
+{
+"light" "40"
+"classname" "light"
+"origin" "-1152 240 120"
+}
+{
+"light" "40"
+"classname" "light"
+"origin" "-1152 416 120"
+}
+{
+"light" "40"
+"classname" "light"
+"origin" "-1072 512 120"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "40"
+"classname" "light"
+"origin" "-992 432 120"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1248 320 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1600 320 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1856 320 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2256 320 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2272 432 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2272 224 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2272 128 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2832 544 104"
+}
+{
+"origin" "-2912 464 104"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2432 544 104"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2352 544 104"
+}
+{
+"origin" "-2352 32 104"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2432 32 104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-2912 112 104"
+}
+{
+"origin" "-2752 32 88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2832 32 88"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2680 288 64"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-2624 288 32"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-2624 288 -32"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-2532 376 64"
+}
+{
+"model" "*70"
+"sounds" "3"
+"target" "t21"
+"lip" "-8"
+"angle" "90"
+"classname" "func_button"
+}
+{
+"origin" "-1840 480 56"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-48 720 304"
+"classname" "item_health"
+}
+{
+"origin" "-32 -36 256"
+"classname" "info_player_deathmatch"
+"angle" "90"
+}
+{
+"origin" "-2024 -32 24"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-64 -1484 548"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "60 -1484 548"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "0 -1536 704"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "0 -1768 704"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "0 -1656 704"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "0 -1592 568"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-8 -1736 568"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-80 -1520 296"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "88 -1512 296"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "80 -1520 408"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-88 -1528 408"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-856 -832 -88"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-920 -832 -88"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-920 -872 -56"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-784 -864 -56"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-656 -864 -64"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-800 -456 -176"
+}
+{
+"model" "*71"
+"_minlight" ".3"
+"angle" "-2"
+"classname" "func_door"
+"sounds" "4"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-3436 224 -40"
+}
+{
+"origin" "-3316 224 -40"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-3316 352 -40"
+}
+{
+"origin" "-3436 352 -40"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-3376 288 80"
+}
+{
+"model" "*72"
+"classname" "func_wall"
+}
+{
+"classname" "func_group"
+}
+{
+"model" "*73"
+"lip" "16"
+"wait" "-1"
+"angle" "270"
+"classname" "func_button"
+"target" "t148"
+"spawnflags" "2048"
+}
+{
+"origin" "-60 -71 252"
+"light" "48"
+"classname" "light"
+}
+{
+"origin" "-84 -71 252"
+"classname" "light"
+"light" "48"
+}

--- a/stuff/mapfixes/baseq2/mine1@de20.ent
+++ b/stuff/mapfixes/baseq2/mine1@de20.ent
@@ -1,0 +1,6145 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Added missing target names to info_player_coop (b#1)
+//
+// 2. Swapped (b#21) and (b#22) info_player_start
+// 
+// This makes the player spawn in the right bulkhead
+// when loading from console.
+//
+// 3. Added spawnflag 1 to 4x target_speaker (b#3)
+//
+// 4. Removed unused entities/fields (b#4)
+//
+// 5. Moved secret message from trigger (b#5)
+//
+// 6. Added spawnflag 2048 to SP/co-op entities (b#6)
+//
+// 7. Added difficulty spawnflags to monster-related entities (b#7)
+//
+// 8. Fix target_splash near quad secret appearing in DM (b#8)
+//
+// 9. Moved triggered monster_mutant down a bit (b#9)
+{
+"sky" "unit4_"
+"sounds" "2"
+"message" "Upper Mines"
+"classname" "worldspawn"
+"nextmap" "mine2"
+}
+{
+"classname" "point_combat"
+"spawnflags" "1"
+"targetname" "t185"
+"origin" "-1312 -2320 808"
+}
+{
+"model" "*1"
+"classname" "func_door"
+"angle" "180"
+"_minlight" ".18"
+"team" "d1"
+}
+{
+"model" "*2"
+"team" "d2"
+"_minlight" ".18"
+"angle" "360"
+"classname" "func_door"
+}
+{
+"classname" "ammo_rockets"
+"origin" "-1768 -2356 792"
+}
+{
+"classname" "point_combat"
+"targetname" "t184"
+"origin" "-960 -2552 792"
+"spawnflags" "1"
+}
+{
+"angle" "180"
+"classname" "info_player_coop"
+"targetname" "mine2" // b#1: added this
+"origin" "-808 -112 -56"
+}
+{
+"angle" "270"
+"classname" "info_player_coop"
+"targetname" "mine2" // b#1: added this
+"origin" "-984 464 -152"
+}
+{
+"classname" "info_player_coop"
+"angle" "180"
+"targetname" "mine2"
+"origin" "-872 -24 -56"
+}
+{
+"angle" "90"
+"classname" "info_player_coop"
+"targetname" "mintro" // b#1: added this
+"origin" "-1184 -3008 120"
+}
+{
+"angle" "90"
+"classname" "info_player_coop"
+"targetname" "mintro" // added this
+"origin" "-1248 -3008 120"
+}
+{
+"classname" "info_player_coop"
+"angle" "90"
+"targetname" "mintro"
+"origin" "-1216 -3072 120"
+}
+{
+"model" "*3"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#6: added this
+"target" "t183"
+}
+{
+"origin" "-1272 -2556 116"
+"spawnflags" "1792"
+"light" "150"
+"classname" "light"
+}
+{
+"spawnflags" "1792"
+"target" "t181"
+"origin" "-1272 -2556 108"
+"angle" "90"
+"classname" "misc_teleporter"
+}
+{
+"model" "*4"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"targetname" "t181"
+"origin" "-152 -988 828"
+"spawnflags" "1792"
+"angle" "360"
+"classname" "misc_teleporter_dest"
+}
+{
+"origin" "-1920 -2664 816"
+"spawnflags" "2048"
+"target" "t180"
+"targetname" "t2"
+"delay" "4"
+"classname" "trigger_relay"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+"origin" "-360 -1936 888"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+"origin" "-360 -1968 888"
+}
+{
+"classname" "item_health_large"
+"spawnflags" "2048"
+"origin" "-400 -1952 888"
+}
+{
+"model" "*5"
+"target" "t89"
+"spawnflags" "2048"
+"classname" "trigger_once"
+}
+{
+"model" "*6"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-176 -1032 820"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-176 -944 820"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t77"
+"spawnflags" "2816" // b#6: 768 -> 2816
+"target" "t179"
+"origin" "60 -1972 820"
+}
+{
+"model" "*7"
+"classname" "func_explosive"
+"targetname" "t179"
+"mass" "150"
+}
+{
+"model" "*8"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#6: added this
+"target" "t178"
+}
+{
+"classname" "monster_gunner"
+"angle" "90"
+"target" "t177"
+"targetname" "t178"
+"origin" "384 -944 832"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+"origin" "-672 -672 824"
+}
+{
+"classname" "monster_mutant"
+"angle" "360"
+"spawnflags" "1"
+"targetname" "t89"
+"origin" "-1304 -544 840"
+}
+{
+"classname" "monster_mutant"
+"angle" "225"
+"spawnflags" "768"
+"targetname" "t89"
+"origin" "-568 -368 840"
+}
+{
+"origin" "-1892 -2600 892"
+"targetname" "t2"
+"spawnflags" "2048"
+"noise" "world/ventsys.wav"
+"attenuation" "-1"
+"classname" "target_speaker"
+}
+{
+"origin" "-2024 -1880 112"
+"targetname" "t176"
+"classname" "point_combat"
+"spawnflags" "256" // b#7: added this
+}
+{
+"origin" "-960 -1728 888"
+"spawnflags" "1792"
+"classname" "weapon_grenadelauncher"
+}
+{
+"model" "*9"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "-1736 -1168 544"
+"team" "woop"
+"spawnflags" "1792"
+"classname" "item_armor_combat"
+}
+{
+"team" "woop"
+"origin" "-1736 -1168 544"
+"spawnflags" "1792"
+"classname" "item_invulnerability"
+}
+{
+"classname" "weapon_railgun"
+"spawnflags" "1792"
+"origin" "-1784 -2296 792"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health"
+"origin" "-40 -920 824"
+}
+{
+"classname" "item_health"
+"spawnflags" "1792"
+"origin" "-40 -1056 824"
+}
+{
+"model" "*10"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"model" "*11"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"model" "*12"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"model" "*13"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-1968 -1328 544"
+}
+{
+"model" "*14"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "item_armor_combat"
+"origin" "240 128 644"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-352 -1952 948"
+}
+{
+"model" "*15"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "item_quad"
+"spawnflags" "1792"
+"origin" "-1232 -2576 736"
+}
+{
+"model" "*16"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "target_secret"
+"message" "You have found a secret."
+"spawnflags" "2048"
+"origin" "-368 -1944 920"
+"targetname" "t183"
+}
+{
+"model" "*17"
+"classname" "func_door"
+"angle" "-1"
+"health" "1"
+"spawnflags" "8"
+"speed" "150"
+}
+{
+"classname" "item_armor_body"
+"spawnflags" "1792"
+"origin" "-368 -1952 888"
+}
+{
+"classname" "weapon_chaingun"
+"spawnflags" "1792"
+"origin" "168 144 648"
+}
+{
+"classname" "ammo_slugs"
+"spawnflags" "1792"
+"origin" "-40 -1896 824"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "1792"
+"origin" "232 -1896 832"
+}
+{
+"classname" "weapon_hyperblaster"
+"spawnflags" "1792"
+"origin" "96 -1528 824"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "176 -640 752"
+}
+{
+"classname" "weapon_machinegun"
+"spawnflags" "1792"
+"origin" "136 -624 752"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+"origin" "-512 -584 832"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-512 -544 832"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1792"
+"origin" "-1576 -216 640"
+}
+{
+"classname" "weapon_supershotgun"
+"spawnflags" "1792"
+"origin" "-1560 -256 640"
+}
+{
+"spawnflags" "1792"
+"classname" "item_health_small"
+"origin" "-1224 304 648"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "1792"
+"origin" "-1264 304 648"
+}
+{
+"classname" "item_health_small"
+"spawnflags" "1792"
+"origin" "-1184 304 648"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-1240 -304 656"
+}
+{
+"classname" "weapon_grenadelauncher"
+"spawnflags" "1792"
+"origin" "-1200 -336 656"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "1792"
+"origin" "-856 -792 824"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1792"
+"origin" "-648 -832 824"
+}
+{
+"classname" "weapon_shotgun"
+"spawnflags" "1792"
+"origin" "-608 -832 824"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-776 -1336 888"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "1792"
+"origin" "-608 -1512 896"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "1792"
+"origin" "-856 -1544 888"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+"origin" "-1224 -2024 816"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-1264 -2040 816"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "-1616 -1888 744"
+}
+{
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+"origin" "-1576 -1888 744"
+}
+{
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+"origin" "-1656 -1888 744"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-1832 -1880 752"
+}
+{
+"classname" "weapon_machinegun"
+"spawnflags" "1792"
+"origin" "-1880 -1848 752"
+}
+{
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+"origin" "-2184 -1024 720"
+}
+{
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+"origin" "-2144 -1024 720"
+}
+{
+"classname" "weapon_chaingun"
+"spawnflags" "1792"
+"origin" "-1944 -1360 576"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+"origin" "-1368 -2704 120"
+}
+{
+"classname" "weapon_machinegun"
+"spawnflags" "1792"
+"origin" "-1408 -2704 120"
+}
+{
+"classname" "weapon_bfg"
+"spawnflags" "1792"
+"origin" "-976 -144 -64"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"origin" "-1568 56 656"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "270"
+"origin" "-608 -1912 896"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "315"
+"origin" "-1896 -2328 800"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "0"
+"origin" "-1504 -2368 800"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "-620 -2836 896"
+}
+{
+"origin" "-216 -2400 896"
+"angle" "180"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-104 -1824 832"
+"angle" "360"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "280 -1824 832"
+"angle" "180"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "424 -488 748"
+"angle" "225"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-672 -676 832"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1376 -244 824"
+"angle" "0"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-768 -1536 896"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1424 -2044 816"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1584 -1696 752"
+"angle" "180"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1584 -1032 724"
+"angle" "225"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1852 -1592 128"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1216 -2800 116"
+"angle" "90"
+"classname" "info_player_deathmatch"
+}
+{
+"origin" "-1288 -2620 540"
+"target" "t2"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"origin" "-936 -188 376"
+"target" "t2"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"model" "*18"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"model" "*19"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*20"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"origin" "-880 -1712 856"
+"target" "t163"
+"spawnflags" "1792"
+"classname" "trigger_always"
+}
+{
+"classname" "info_player_intermission"
+"angles" "33 225 0"
+"origin" "-808 -2288 1120"
+}
+{
+"model" "*21"
+"classname" "func_plat"
+"spawnflags" "1"
+"dmg" "1"
+"_minlight" ".18"
+}
+{
+"model" "*22"
+"classname" "func_door"
+"angle" "-2"
+"dmg" "1"
+"speed" "175"
+"targetname" "t25"
+"_minlight" ".18"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t173"
+"target" "t174"
+"origin" "-692 -24 1088"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t174"
+"target" "t173"
+"origin" "-1256 60 1088"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t171"
+"target" "t172"
+"origin" "-1232 4 1024"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t172"
+"target" "t171"
+"origin" "-900 -304 1024"
+}
+{
+"targetname" "t144"
+"origin" "-1500 -2440 1236"
+"classname" "monster_hover"
+"angle" "0"
+"spawnflags" "3"
+}
+{
+"origin" "184 -420 736"
+"targetname" "t170"
+"spawnflags" "257" // b#7: 1 -> 257
+"classname" "point_combat"
+}
+{
+"model" "*23"
+"spawnflags" "2048"
+"classname" "trigger_push"
+"angle" "-1"
+"speed" "40"
+}
+{
+"spawnflags" "2304" // b#6: 256 -> 2304
+"classname" "trigger_relay"
+"targetname" "t167"
+"target" "t168"
+"delay" "1.5"
+"origin" "-728 92 1024"
+}
+{
+"spawnflags" "2048" // b#6: 0 -> 2048
+"classname" "trigger_relay"
+"targetname" "t166"
+"target" "t167"
+"origin" "-692 92 1024"
+}
+{
+"spawnflags" "2816" // b#6: 768 -> 2816
+"classname" "trigger_relay"
+"targetname" "t168"
+"delay" "1.5"
+"origin" "-756 92 1024"
+"target" "t169"
+}
+{
+"model" "*24"
+"targetname" "poo"
+"classname" "trigger_counter"
+"spawnflags" "2049"
+"target" "t166"
+}
+{
+"spawnflags" "258"
+"angle" "225"
+"classname" "monster_hover"
+"origin" "-580 132 956"
+"targetname" "t168"
+}
+{
+"spawnflags" "770"
+"angle" "270"
+"classname" "monster_hover"
+"origin" "-580 132 864"
+"targetname" "t169"
+}
+{
+"classname" "monster_hover"
+"angle" "270"
+"spawnflags" "2"
+"origin" "-580 132 1024"
+"targetname" "t167"
+}
+{
+"light" "72"
+"origin" "-1844 -1328 36"
+"classname" "light"
+}
+{
+"model" "*25"
+"spawnflags" "2048"
+"classname" "func_wall"
+"targetname" "kp1"
+}
+{
+"origin" "-1944 -2568 841"
+"noise" "world/lite_on3.wav"
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t2"
+}
+{
+"spawnflags" "2048"
+"origin" "-1808 -2284 792"
+"classname" "ammo_shells"
+}
+{
+"spawnflags" "2048"
+"origin" "-1784 -2296 792"
+"classname" "ammo_shells"
+}
+{
+"origin" "-1832 -2304 776"
+"angle" "270"
+"spawnflags" "2056"
+"classname" "misc_deadsoldier"
+}
+{
+"model" "*26"
+"spawnflags" "2048"
+"targetname" "kp1"
+"message" "Bridge access denied."
+"classname" "trigger_once"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t77"
+"killtarget" "t162"
+"origin" "172 -1976 844"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "3840" // b#4: added this
+"targetname" "t29"
+"target" "t161"
+"origin" "80 -1252 844"
+}
+{
+"delay" "1.75"
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t29"
+"target" "t162"
+"origin" "104 -1252 844"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t29"
+"target" "t39"
+"origin" "128 -1252 844"
+}
+{
+"delay" "1.75"
+"classname" "trigger_relay"
+"spawnflags" "3840" // b#4: added this
+"targetname" "t29"
+"target" "t38"
+"origin" "56 -1252 844"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-776 -344 684"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+"noise" "world/lite_on3.wav"
+"targetname" "t2"
+"origin" "-1944 -2616 841"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "3840" // b#4: added this, t2 (vent button) should not target the vent trap (t162)
+"targetname" "t2"
+"target" "t161"
+"origin" "-1940 -2528 896"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-1628 -1260 104"
+}
+{
+"classname" "target_explosion"
+"spawnflags" "2048" // b#6: added this
+"dmg" "10"
+"targetname" "t154"
+"origin" "-1932 -2840 848"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_cells"
+"origin" "-1568 232 648"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_cells"
+"origin" "-1156 -2028 892"
+}
+{
+"origin" "-1104 -2604 96"
+"classname" "misc_deadsoldier"
+"spawnflags" "2056"
+"angle" "45"
+}
+{
+"spawnflags" "2048"
+"origin" "-1440 -2724 124"
+"classname" "item_health_large"
+}
+{
+"spawnflags" "2048"
+"origin" "-608 -2856 888"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-568 -2856 888"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-648 -2856 888"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "96 -1528 824"
+"classname" "weapon_rocketlauncher"
+}
+{
+"target" "t170"
+"origin" "200 -464 752"
+"spawnflags" "257"
+"angle" "90"
+"classname" "monster_gladiator"
+}
+{
+"angle" "270"
+"spawnflags" "0"
+"origin" "-776 -344 648"
+"classname" "item_health_mega"
+}
+{
+"spawnflags" "0"
+"origin" "-1512 -2812 792"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "0"
+"origin" "-1512 -2852 792"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "0"
+"origin" "-1512 -2772 792"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-1256 -344 648"
+"classname" "item_health"
+}
+{
+"spawnflags" "0"
+"origin" "-1368 152 648"
+"classname" "item_health"
+}
+{
+"model" "*27"
+"spawnflags" "2064"
+"targetname" "kp1"
+"dmg" "1"
+"classname" "trigger_hurt"
+}
+{
+"spawnflags" "0"
+"origin" "-1072 -2648 116"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "0"
+"origin" "-2048 -1144 128"
+"classname" "ammo_bullets"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2048"
+"angle" "90"
+"origin" "-1876 -2880 776"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-1860 -2904 792"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-1900 -2904 792"
+}
+{
+"spawnflags" "0"
+"classname" "item_health"
+"origin" "-1820 -2904 792"
+}
+{
+"classname" "target_speaker"
+"noise" "world/airhiss1.wav"
+"spawnflags" "2050" // b#6: 2 -> 2050
+"targetname" "t2"
+"origin" "-1944 -2592 848"
+}
+{
+"spawnflags" "1"
+"origin" "-572 -2116 888"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"volume" ".7"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2050"
+"angle" "315"
+"origin" "-556 -2252 872"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_large"
+"origin" "-536 -2280 888"
+}
+{
+"spawnflags" "2048"
+"classname" "weapon_chaingun"
+"origin" "-1292 -1992 808"
+}
+{
+"classname" "misc_deadsoldier"
+"angle" "315"
+"spawnflags" "2056"
+"origin" "-1280 -1980 792"
+}
+{
+"spawnflags" "2048"
+"origin" "-1580 -1888 760"
+"classname" "ammo_bullets"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2050"
+"angle" "135"
+"origin" "-1120 -2356 120"
+}
+{
+"classname" "item_armor_jacket"
+"origin" "-1148 -2340 136"
+}
+{
+"classname" "ammo_rockets"
+"origin" "-1852 -1576 64"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"model" "*28"
+"killtarget" "po1"
+"classname" "trigger_once"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t154"
+}
+{
+"classname" "target_secret"
+"targetname" "t154"
+"message" "You have found a secret." // b#5: moved this here from the trigger
+"origin" "-1948 -2824 872"
+}
+{
+"targetname" "po1"
+"classname" "func_timer"
+"random" "3"
+"wait" "4"
+"target" "t153"
+"spawnflags" "2049" // b#6, b#8: 1 -> 2049
+"origin" "-1916 -2848 872"
+}
+{
+"classname" "target_splash"
+"spawnflags" "2048" // b#6, b#8: added this
+"angle" "0"
+"sounds" "1"
+"targetname" "t153"
+"origin" "-1958 -2868 872"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+"origin" "-1948 -2848 812"
+}
+{
+"spawnflags" "2048"
+"classname" "item_quad"
+"origin" "-1992 -2848 820"
+}
+{
+"model" "*29"
+"classname" "func_explosive"
+"mass" "600"
+"target" "t154"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-484 -1908 888"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2048"
+"angle" "135"
+"origin" "-1484 -2816 776"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_small"
+"origin" "-320 -2668 888"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_small"
+"origin" "-284 -2668 888"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_small"
+"origin" "-356 -2668 888"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb10.wav"
+"origin" "184 -2168 976"
+"spawnflags" "1"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "2816"
+"origin" "-168 -2144 824"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "2816"
+"origin" "256 -1976 824"
+}
+{
+"spawnflags" "0"
+"classname" "ammo_shells"
+"origin" "296 -1976 824"
+}
+{
+"spawnflags" "768"
+"classname" "ammo_grenades"
+"origin" "-40 -1976 824"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "296 -2208 832"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "296 -2168 832"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "296 -2248 832"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2048"
+"angle" "45"
+"origin" "112 -1504 808"
+}
+{
+"spawnflags" "2048"
+"origin" "280 -1824 824"
+"classname" "item_health"
+}
+{
+"classname" "item_health"
+"origin" "-104 -1824 824"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1"
+"noise" "world/lava1.wav"
+"classname" "target_speaker"
+"origin" "216 -1632 800"
+}
+{
+"spawnflags" "1"
+"noise" "world/lava1.wav"
+"classname" "target_speaker"
+"origin" "216 -1376 800"
+}
+{
+"classname" "target_speaker"
+"noise" "world/lava1.wav"
+"spawnflags" "1"
+"origin" "-24 -1504 800"
+}
+{
+"classname" "item_health"
+"spawnflags" "3072"
+"origin" "152 -672 744"
+}
+{
+"classname" "item_health"
+"spawnflags" "3072"
+"origin" "192 -684 744"
+}
+{
+"classname" "misc_deadsoldier"
+"angle" "225"
+"spawnflags" "2052"
+"origin" "196 124 624"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-32 172 644"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_small"
+"origin" "-1408 -296 632"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_small"
+"origin" "-1368 -296 632"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_small"
+"origin" "-1576 -296 632"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_small"
+"origin" "-1536 -296 632"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_rockets"
+"origin" "-1000 -84 -84"
+}
+{
+"classname" "misc_deadsoldier"
+"angle" "135"
+"spawnflags" "2050"
+"origin" "-1016 -108 -112"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_large"
+"origin" "-884 -356 -68"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_large"
+"origin" "-1068 -352 -68"
+}
+{
+"spawnflags" "0"
+"origin" "-1172 -788 840"
+"classname" "item_health"
+}
+{
+"spawnflags" "0"
+"origin" "-1172 -972 840"
+"classname" "item_health_large"
+}
+{
+"spawnflags" "0"
+"origin" "-560 -944 848"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "0"
+"origin" "-560 -984 848"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "0"
+"origin" "-560 -864 848"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "0"
+"origin" "-560 -824 848"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "-592 -1508 892"
+"classname" "ammo_grenades"
+}
+{
+"spawnflags" "2048"
+"origin" "-628 -1532 892"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-1236 -1300 808"
+"classname" "item_health"
+}
+{
+"origin" "-1272 -1300 808"
+"classname" "item_health"
+}
+{
+"spawnflags" "2048"
+"origin" "-1896 -1896 744"
+"classname" "item_health"
+}
+{
+"spawnflags" "2048"
+"origin" "-1860 -1896 744"
+"classname" "item_health"
+}
+{
+"spawnflags" "2048"
+"origin" "-1948 -1368 544"
+"classname" "weapon_machinegun"
+}
+{
+"spawnflags" "2048"
+"origin" "-1908 -1396 544"
+"classname" "item_adrenaline"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-1628 -1224 104"
+}
+{
+"origin" "-1232 -2444 632"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-976 -40 488"
+"light" "120"
+"classname" "light"
+}
+{
+"spawnflags" "2048"
+"origin" "-1896 -2624 848"
+"targetname" "t2"
+"classname" "target_goal"
+}
+{
+"message" "Toxic conditions found in\nlower mines. Activate\nventilation systems."
+"origin" "-1531 -2547 156"
+"classname" "target_help"
+"spawnflags" "2048"
+"targetname" "t160"
+}
+{
+"model" "*30"
+"classname" "trigger_once"
+"target" "t160"
+"spawnflags" "2048"
+}
+{
+"origin" "-756 -144 56"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+"spawnflags" "1" // b#3: added this
+}
+{
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+"origin" "-844 124 804"
+"volume" ".6"
+}
+{
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+"origin" "-832 0 896"
+"volume" ".8"
+}
+{
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-632 -344 896"
+}
+{
+"model" "*31"
+"spawnflags" "2048"
+"targetname" "m1"
+"classname" "func_wall"
+}
+{
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-1012 -276 896"
+}
+{
+"volume" ".8"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+"origin" "-1208 -168 896"
+}
+{
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+"origin" "-984 -708 896"
+}
+{
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+"origin" "-828 -544 896"
+}
+{
+"targetname" "t151"
+"classname" "target_speaker"
+"noise" "world/fan1.wav"
+"spawnflags" "2050" // b#6: 2 -> 2050
+"origin" "-956 -144 548"
+}
+{
+"targetname" "t151"
+"spawnflags" "2050" // b#6: 2 -> 2050
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+"origin" "-996 -144 548"
+}
+{
+"targetname" "t151"
+"origin" "-1232 -2676 636"
+"spawnflags" "2050"
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t151"
+"origin" "-1232 -2484 636"
+"classname" "target_speaker"
+"noise" "world/fan1.wav"
+"spawnflags" "2050"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1296 -1712 292"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1012 -1728 424"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+"origin" "-1740 -1676 160"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+"origin" "-2104 -1572 160"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+"origin" "-1988 -1724 160"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"origin" "-1192 260 700"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"origin" "-1452 260 700"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"origin" "-1560 44 700"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"origin" "-1440 -140 700"
+}
+{
+"origin" "-1524 320 704"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+}
+{
+"origin" "-1564 244 704"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+}
+{
+"origin" "-1420 96 704"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+}
+{
+"origin" "-1420 96 692"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "-1524 320 692"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "-1564 244 692"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "-1472 372 688"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1472 -308 688"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1440 -140 440"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "-1440 -140 264"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "-1440 -140 72"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"volume" ".7"
+"origin" "-1256 -140 -40"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"volume" ".8"
+"origin" "-1344 -140 -40"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"volume" ".6"
+"origin" "-1168 -140 -40"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "-1292 284 700"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-976 284 -84"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-908 40 -64"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+}
+{
+"spawnflags" "1"
+"origin" "-1044 40 -64"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+}
+{
+"targetname" "t151"
+"origin" "-996 -144 232"
+"classname" "target_speaker"
+"noise" "world/fan1.wav"
+"spawnflags" "2050" // b#6: 2 -> 2050
+}
+{
+"targetname" "t151"
+"origin" "-956 -144 232"
+"spawnflags" "2050" // b#6: 2 -> 2050
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-936 -136 -36"
+"target" "t152"
+"wait" "4"
+"random" "3"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"origin" "-1016 -184 -16"
+"spawnflags" "1"
+"classname" "target_speaker"
+"noise" "world/drip_amb.wav"
+}
+{
+"origin" "-936 -104 -16"
+"targetname" "t152"
+"spawnflags" "0"
+"noise" "world/drip_amb.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-912 -76 -88"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1044 -76 -88"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1044 -216 -88"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-912 -216 -88"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-696 -1984 888"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"volume" ".7"
+}
+{
+"volume" ".7"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+"origin" "-620 -1984 888"
+"spawnflags" "1"
+}
+{
+"spawnflags" "1"
+"origin" "-572 -2184 888"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-792 -1984 888"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-952 -1984 888"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"volume" ".7"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+"origin" "-572 -2152 952"
+"spawnflags" "1"
+}
+{
+"volume" ".7"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+"origin" "-952 -1864 888"
+"spawnflags" "1"
+}
+{
+"origin" "-1824 -2268 912"
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1840 -2908 912"
+"spawnflags" "1"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1608 -2704 864"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1608 -2456 864"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+"origin" "-400 -2384 928"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+"origin" "-256 -2240 928"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+"origin" "-100 -2240 928"
+}
+{
+"origin" "-320 -2664 960"
+"spawnflags" "1"
+"noise" "world/amb11.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-208 -2400 960"
+"spawnflags" "1"
+"noise" "world/amb11.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-236 -2400 944"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-416 -2424 972"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"origin" "-320 -2672 944"
+"spawnflags" "1"
+}
+{
+"spawnflags" "1"
+"origin" "184 -2168 840"
+"noise" "world/amb10.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-1336 -1500 868"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-980 -892 852"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-1076 -892 852"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-864 -892 852"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-672 -892 852"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-672 -1188 888"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-672 -1436 888"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-892 -1436 888"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-956 -1592 888"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"volume" ".7"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+"origin" "-1340 -1976 868"
+"spawnflags" "1"
+}
+{
+"spawnflags" "1"
+"origin" "-1336 -1476 868"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-1388 -1756 868"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"volume" ".7"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+"origin" "-756 -892 852"
+"spawnflags" "1"
+}
+{
+"volume" ".7"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+"origin" "-1140 -1436 896"
+"spawnflags" "1"
+}
+{
+"volume" ".7"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+"origin" "-1560 -1756 792"
+"spawnflags" "1"
+}
+{
+"volume" ".7"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+"origin" "-1772 -1752 792"
+"spawnflags" "1"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+"origin" "-2104 -1096 792"
+"spawnflags" "1"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"origin" "-1844 -1280 272"
+}
+{
+"light" "100"
+"origin" "-1008 -2504 256"
+"classname" "light"
+}
+{
+"light" "100"
+"origin" "-1192 -2276 272"
+"classname" "light"
+}
+{
+"light" "100"
+"origin" "-1224 -2276 272"
+"classname" "light"
+}
+{
+"light" "100"
+"origin" "-1456 -2448 256"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-1008 -2536 256"
+"light" "100"
+}
+{
+"classname" "light"
+"origin" "-1384 -2392 280"
+"light" "140"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"light" "140"
+"origin" "-1064 -2392 280"
+"classname" "light"
+}
+{
+"spawnflags" "1"
+"origin" "-1864 -1464 792"
+"volume" ".7"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-1620 -1464 792"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-1620 -1096 792"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-1864 -1096 792"
+"volume" ".7"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-2104 -1232 792"
+"volume" ".7"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-1120 -1984 888"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-2104 -1464 792"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"volume" ".7"
+}
+{
+"spawnflags" "1"
+"origin" "-1616 -1260 792"
+"volume" ".7"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"origin" "-2256 -1232 192"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"origin" "-1844 -1280 164"
+}
+{
+"origin" "-1096 -2192 1012"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1096 -2924 1012"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-872 -2412 1020"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".9"
+"spawnflags" "1"
+"origin" "-1032 -2420 924"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".9"
+"spawnflags" "1"
+"origin" "-1032 -2740 924"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+}
+{
+"volume" ".5"
+"spawnflags" "1"
+"origin" "-1280 -2576 924"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".7"
+"spawnflags" "1"
+"origin" "-1172 -2740 924"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+}
+{
+"volume" ".7"
+"spawnflags" "1"
+"origin" "-1172 -2420 924"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".5"
+"spawnflags" "1"
+"origin" "-1324 -2740 924"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+}
+{
+"volume" ".5"
+"spawnflags" "1"
+"origin" "-1324 -2420 924"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".9"
+"spawnflags" "1"
+"origin" "-996 -2564 924"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+}
+{
+"spawnflags" "1"
+"origin" "-696 -2560 960"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+}
+{
+"spawnflags" "1"
+"origin" "-872 -2732 1020"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1800 -2796 968"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1800 -2368 968"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1928 -2364 820"
+"spawnflags" "1"
+"noise" "world/comp_hum3.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1944 -2364 820"
+"classname" "target_speaker"
+"noise" "world/comp_hum1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1936 -2784 820"
+"spawnflags" "1"
+"noise" "world/comp_hum3.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1952 -2784 820"
+"classname" "target_speaker"
+"noise" "world/comp_hum1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1856 -2892 820"
+"spawnflags" "1"
+"noise" "world/comp_hum3.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1856 -2908 820"
+"classname" "target_speaker"
+"noise" "world/comp_hum1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1808 -2288 820"
+"classname" "target_speaker"
+"noise" "world/comp_hum3.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1808 -2272 820"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t151"
+"spawnflags" "2050"
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+"origin" "-1252 -2576 724"
+}
+{
+"targetname" "t151"
+"classname" "target_speaker"
+"noise" "world/fan1.wav"
+"spawnflags" "2050"
+"origin" "-1212 -2576 724"
+}
+{
+"targetname" "t151"
+"origin" "-956 -144 624"
+"spawnflags" "2050" // b#6: 2 -> 2050
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t151"
+"origin" "-996 -144 624"
+"classname" "target_speaker"
+"noise" "world/fan1.wav"
+"spawnflags" "2050" // b#6: 2 -> 2050
+}
+{
+"origin" "-1892 -2576 824"
+"target" "t151"
+"targetname" "t2"
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+"killtarget" "kp1"
+}
+{
+"targetname" "t151"
+"classname" "target_speaker"
+"noise" "world/fan1.wav"
+"spawnflags" "2050" // b#6: 2 -> 2050
+"origin" "-956 -144 80"
+}
+{
+"targetname" "t151"
+"spawnflags" "2050" // b#6: 2 -> 2050
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+"origin" "-996 -144 80"
+}
+{
+"targetname" "t151"
+"origin" "-1252 -2576 464"
+"classname" "target_speaker"
+"noise" "world/fan1.wav"
+"spawnflags" "2050" // b#6: 2 -> 2050
+}
+{
+"targetname" "t151"
+"origin" "-1212 -2576 464"
+"spawnflags" "2050" // b#6: 2 -> 2050
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "96 -2236 884"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "96 -2056 884"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "308 -2048 884"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-452 -2564 928"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "128 -2300 884"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/bigpump2.wav"
+"origin" "96 -1680 900"
+}
+{
+"noise" "world/bigpump2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "96 -1388 900"
+}
+{
+"noise" "world/bigpump2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "96 -1224 900"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"origin" "380 -800 836"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"origin" "-1844 -1280 52"
+}
+{
+"origin" "96 -1556 900"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/bigpump2.wav"
+}
+{
+"origin" "96 -1472 900"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/bigpump2.wav"
+}
+{
+"origin" "96 -1292 900"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/bigpump2.wav"
+}
+{
+"origin" "96 -1800 900"
+"noise" "world/bigpump2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "12 -1632 864"
+"targetname" "t36"
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+"noise" "world/airhiss1.wav"
+}
+{
+"origin" "8 -1504 864"
+"targetname" "t36" // b#4: t28 -> t36
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+"noise" "world/airhiss1.wav"
+}
+{
+"origin" "172 -1632 864"
+"targetname" "t37"
+"noise" "world/airhiss1.wav"
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "188 -1376 864"
+"targetname" "t37" // b#4: t35 -> t37
+"noise" "world/airhiss1.wav"
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "136 -556 656"
+"spawnflags" "1"
+"noise" "world/lava1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "476 -600 820"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1" // b#3: added this
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"origin" "384 -516 820"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"origin" "168 -580 820"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"origin" "172 -356 820"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"origin" "172 40 672"
+}
+{
+"origin" "76 -600 820"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1" // b#3: added this
+}
+{
+"origin" "404 -968 884"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+"spawnflags" "1" // b#3: added this
+}
+{
+"origin" "352 -592 596"
+"wait" "4"
+"random" "3"
+"target" "t150"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"origin" "416 -220 596"
+"classname" "target_speaker"
+"noise" "world/lava1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "384 -560 656"
+"targetname" "t150"
+"spawnflags" "1"
+"noise" "world/lava1.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"origin" "0 128 672"
+}
+{
+"origin" "-180 36 672"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "-180 -180 672"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "-40 -992 916"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "1"
+"origin" "-156 -128 600"
+"classname" "target_speaker"
+"noise" "world/lava1.wav"
+}
+{
+"spawnflags" "1"
+"origin" "76 48 600"
+"noise" "world/lava1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-832 -168 896"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-832 -344 896"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1208 -344 896"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-464 -228 872"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".5"
+"origin" "-1040 124 696"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1208 0 896"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-632 -168 896"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-968 -4 896"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-560 -560 896"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1128 -544 896"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"volume" ".8"
+"origin" "-1136 200 896"
+"classname" "target_speaker"
+"noise" "world/wind2.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-836 200 896"
+"spawnflags" "1"
+"noise" "world/wind2.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1408 -288 836"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-776 -616 936"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1208 -616 936"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1192 -904 888"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1088 -1000 888"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-960 -1000 888"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-736 -792 888"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-640 -792 888"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-568 -904 888"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-776 -1216 924"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-896 -1336 952"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1088 -1336 952"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1344 -1312 856"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1448 -1440 856"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1224 -1984 856"
+}
+{
+"origin" "-1448 -2008 856"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1728 -1896 808"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1896 -1728 808"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-504 -228 840"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2140 -1232 192"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2032 -1120 216"
+"spawnflags" "1"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "-1656 -1120 216"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/pump1.wav"
+"spawnflags" "1"
+"origin" "-1844 -1280 36"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+"origin" "-1988 -1980 160"
+}
+{
+"origin" "-1076 -1676 324"
+"angle" "0"
+"spawnflags" "2049"
+"classname" "misc_deadsoldier"
+}
+{
+"classname" "target_speaker"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"origin" "-1268 -1724 308"
+}
+{
+"origin" "-1432 -1700 308"
+"classname" "target_speaker"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1140 -1696 344"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1844 -1280 424"
+"spawnflags" "1"
+"noise" "world/pump1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1556 -1672 160"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1988 -2180 160"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1988 -2384 160"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1988 -2584 160"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1800 -2584 160"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1624 -2584 160"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1456 -2584 160"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1844 -1280 68"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1032 -2488 216"
+"classname" "target_speaker"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1236 -2544 100"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1256 -2312 80"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1360 -2832 80"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1040 -2760 80"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-1424 -2448 80"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-1216 -3062 216"
+}
+{
+"angle" "180"
+"origin" "-1924 -1372 528"
+"spawnflags" "2056"
+"classname" "misc_deadsoldier"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1940 -1356 624"
+}
+{
+"model" "*32"
+"spawnflags" "2048"
+"classname" "func_wall"
+"targetname" "m1"
+}
+{
+"style" "32"
+"classname" "light"
+"light" "140"
+"_color" "0.384615 1.000000 0.307692"
+"origin" "-1036 248 -118"
+"targetname" "t2"
+}
+{
+"style" "32"
+"classname" "light"
+"light" "140"
+"_color" "0.384615 1.000000 0.307692"
+"origin" "-976 240 -118"
+"targetname" "t2"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+"killtarget" "m1"
+"targetname" "t2"
+"origin" "-1912 -2560 824"
+}
+{
+"style" "32"
+"origin" "-916 248 -118"
+"_color" "0.384615 1.000000 0.307692"
+"light" "140"
+"classname" "light"
+"targetname" "t2"
+}
+{
+"origin" "-1088 -1008 892"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "-960 -1016 892"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "-736 -784 888"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "-640 -784 888"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "-560 -904 888"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "-784 -1216 924"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "-896 -1328 952"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "-1088 -1328 952"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "-1344 -1304 856"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"classname" "light"
+"_color" "1.000000 1.000000 0.207843"
+"origin" "-1728 -1904 808"
+}
+{
+"classname" "light"
+"_color" "1.000000 1.000000 0.207843"
+"origin" "-1456 -2008 856"
+}
+{
+"origin" "-1456 -1440 856"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "-1904 -1728 808"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "-1216 -1984 856"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"classname" "light"
+"_color" "1.000000 1.000000 0.207843"
+"origin" "-1200 -904 892"
+}
+{
+"classname" "func_group"
+}
+{
+"model" "*33"
+"classname" "func_door"
+"angle" "-1"
+"speed" "24"
+"spawnflags" "8"
+"targetname" "t2"
+"wait" "-1"
+"sounds" "0"
+}
+{
+"classname" "target_lightramp"
+"message" "az"
+"speed" "2"
+"target" "t149"
+"targetname" "t2"
+"origin" "-1944 -2560 906"
+}
+{
+"style" "33"
+"classname" "light"
+"light" "220"
+"_color" "0.384615 1.000000 0.307692"
+"spawnflags" "1"
+"targetname" "t149"
+"origin" "-2000 -2592 854"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1944 -2592 808"
+}
+{
+"targetname" "t180"
+"spawnflags" "2048"
+"classname" "target_help"
+"message" "Ventilation systems active.\nLower levels accessible."
+"origin" "-1884 -2676 832"
+}
+{
+"light" "80"
+"origin" "-1844 -1328 -120"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-1844 -1232 -120"
+"light" "80"
+}
+{
+"light" "72"
+"origin" "-1844 -1232 36"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-1844 -1276 -108"
+"light" "72"
+}
+{
+"origin" "-1096 -1648 376"
+"light" "100"
+"classname" "light"
+}
+{
+"model" "*34"
+"origin" "-1884 -1280 -20"
+"_minlight" ".2"
+"speed" "400"
+"dmg" "10"
+"spawnflags" "9"
+"classname" "func_rotating"
+}
+{
+"model" "*35"
+"origin" "-1804 -1280 -22"
+"_minlight" ".2"
+"dmg" "10"
+"speed" "400"
+"spawnflags" "11"
+"classname" "func_rotating"
+}
+{
+"model" "*36"
+"target" "t148"
+"classname" "trigger_once"
+"spawnflags" "2816" // b#6, b#7: added this
+}
+{
+"light" "88"
+"classname" "light"
+"origin" "-1936 -1252 624"
+}
+{
+"spawnflags" "2048"
+"classname" "ammo_cells"
+"origin" "-1580 -1688 760"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_large"
+"origin" "-2188 -1512 720"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health_large"
+"origin" "-2152 -1512 720"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1132 -1692 304"
+}
+{
+"classname" "weapon_rocketlauncher"
+"origin" "-1096 -1648 368"
+}
+{
+"spawnflags" "2048"
+"classname" "item_health"
+"origin" "-2104 -1908 132"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-1088 -2680 116"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-1108 -2712 116"
+}
+{
+"spawnflags" "0"
+"classname" "item_health_small"
+"origin" "-1056 -2616 116"
+}
+{
+"spawnflags" "771"
+"angle" "0"
+"classname" "monster_hover"
+"targetname" "t144"
+"origin" "-1476 -2580 1300"
+}
+{
+"classname" "monster_hover"
+"angle" "0"
+"spawnflags" "3"
+"targetname" "t144"
+"origin" "-1440 -2704 1364"
+}
+{
+"model" "*37"
+"classname" "trigger_once"
+"target" "t144"
+"spawnflags" "2052"
+"targetname" "t2"
+}
+{
+"classname" "point_combat"
+"targetname" "t140"
+"origin" "-572 -2016 880"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_gunner"
+"spawnflags" "3"
+"origin" "-704 -1992 904"
+"target" "t140"
+"targetname" "t139"
+}
+{
+"model" "*38"
+"classname" "trigger_once"
+"target" "t139"
+"spawnflags" "2048"
+}
+{
+"model" "*39"
+"classname" "trigger_once"
+"target" "t137"
+"spawnflags" "2048"
+}
+{
+"model" "*40"
+"classname" "trigger_once"
+"target" "t136"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_soldier"
+"angle" "270"
+"targetname" "t136"
+"origin" "-964 -2456 808"
+"target" "t184"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t134"
+"target" "t135"
+"origin" "-1012 -2828 792"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t135"
+"target" "t134"
+"origin" "-1412 -2832 792"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "180"
+"spawnflags" "1"
+"target" "t134"
+"origin" "-972 -2832 808"
+}
+{
+"angle" "360"
+"classname" "monster_soldier_light"
+"origin" "-1480 -2324 824"
+"target" "t185"
+}
+{
+"model" "*41"
+"classname" "trigger_once"
+"target" "t131"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_gladiator"
+"angle" "90"
+"spawnflags" "1"
+"targetname" "t131"
+"origin" "-1616 -2672 800"
+}
+{
+"classname" "point_combat"
+"targetname" "t130"
+"origin" "-868 -2468 964"
+"spawnflags" "1"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "270"
+"target" "t130"
+"origin" "-868 -2240 980"
+"targetname" "t137"
+}
+{
+"classname" "point_combat"
+"targetname" "t129"
+"origin" "-860 -2656 960"
+"spawnflags" "1"
+}
+{
+"classname" "monster_soldier_light"
+"angle" "90"
+"target" "t129"
+"origin" "-860 -2856 976"
+"targetname" "t137"
+}
+{
+"model" "*42"
+"classname" "trigger_once"
+"target" "t128"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "257"
+"angle" "135"
+"classname" "monster_soldier"
+"targetname" "t128"
+"origin" "-1048 -296 -56"
+}
+{
+"classname" "monster_soldier"
+"angle" "225"
+"spawnflags" "257"
+"targetname" "t128"
+"origin" "-1080 -16 -56"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t125"
+"target" "t126"
+"origin" "-800 -144 -72"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t127"
+"origin" "-800 -144 -72"
+"target" "t124"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t124"
+"target" "t125"
+"origin" "-944 -336 -72"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t126"
+"target" "t127"
+"origin" "-952 8 -72"
+}
+{
+"classname" "monster_mutant"
+"angle" "0"
+"spawnflags" "1"
+"target" "t124"
+"origin" "-976 -336 -56"
+}
+{
+"model" "*43"
+"classname" "trigger_once"
+"target" "t123"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_gunner"
+"angle" "0"
+"targetname" "t123"
+"origin" "-1568 56 672"
+"item" "ammo_bullets"
+"spawnflags" "0"
+}
+{
+"model" "*44"
+"target" "t122"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"classname" "monster_soldier"
+"angle" "0"
+"origin" "48 -1040 828"
+"spawnflags" "1"
+}
+{
+"origin" "-2136 -1340 720"
+"targetname" "t118"
+"classname" "point_combat"
+}
+{
+"origin" "-1368 -1400 812"
+"target" "t117"
+"targetname" "t116"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "-1372 -1900 812"
+"target" "t116"
+"targetname" "t117"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "-1368 -1356 828"
+"target" "t116"
+"spawnflags" "1"
+"angle" "270"
+"classname" "monster_gladiator"
+}
+{
+"origin" "-124 -988 830" // b#9: 848 -> 830
+"targetname" "t77"
+"spawnflags" "770"
+"angle" "360"
+"classname" "monster_mutant"
+}
+{
+"model" "*45"
+"delay" "1"
+"target" "t112"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"model" "*46"
+"target" "t111"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "-396 -2560 880"
+"spawnflags" "0"
+"targetname" "t110"
+"classname" "point_combat"
+}
+{
+"origin" "-564 -2560 896"
+"targetname" "t112"
+"target" "t110"
+"angle" "0"
+"classname" "monster_gunner"
+"spawnflags" "1"
+}
+{
+"targetname" "t122"
+"spawnflags" "1"
+"origin" "-216 -2400 904"
+"angle" "180"
+"classname" "monster_gunner"
+"item" "ammo_bullets"
+}
+{
+"target" "t109"
+"targetname" "t108"
+"origin" "-320 -2580 888"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"target" "t108"
+"targetname" "t109"
+"origin" "-320 -2240 888"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"spawnflags" "1"
+"targetname" "t112"
+"origin" "-320 -2624 904"
+"target" "t108"
+"angle" "90"
+"classname" "monster_gladiator"
+}
+{
+"spawnflags" "1"
+"origin" "-16 -2136 824"
+"targetname" "t107"
+"classname" "point_combat"
+}
+{
+"item" "ammo_bullets"
+"spawnflags" "1"
+"targetname" "t111"
+"origin" "-128 -2140 840"
+"target" "t107"
+"angle" "0"
+"classname" "monster_gunner"
+}
+{
+"origin" "136 -2264 828"
+"targetname" "t106"
+"spawnflags" "1"
+"classname" "point_combat"
+}
+{
+"spawnflags" "1"
+"targetname" "t111"
+"origin" "228 -2264 844"
+"target" "t106"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"origin" "96 -1824 816"
+"spawnflags" "769" // b#7: 1 -> 769
+"targetname" "t105"
+"classname" "point_combat"
+}
+{
+"targetname" "t148"
+"spawnflags" "769"
+"origin" "-8 -2060 832"
+"target" "t105"
+"angle" "0"
+"classname" "monster_gladiator"
+}
+{
+"origin" "52 -972 812"
+"spawnflags" "1"
+"targetname" "t104"
+"classname" "point_combat"
+}
+{
+"spawnflags" "1"
+"item" "ammo_shells"
+"origin" "0 -972 828"
+"target" "t104"
+"angle" "0"
+"classname" "monster_soldier"
+}
+{
+"spawnflags" "1"
+"origin" "120 -928 828"
+"angle" "0"
+"classname" "monster_soldier"
+}
+{
+"origin" "380 -760 780"
+"classname" "point_combat"
+"targetname" "t177"
+}
+{
+"origin" "400 -600 772"
+"target" "t101"
+"targetname" "t100"
+"classname" "path_corner"
+"spawnflags" "2304" // b#6, b#7: added this
+}
+{
+"origin" "148 -596 772"
+"target" "t100"
+"targetname" "t101"
+"classname" "path_corner"
+"spawnflags" "2304" // b#6, b#7: added this
+}
+{
+"origin" "140 -488 772"
+"target" "t99"
+"targetname" "t98"
+"classname" "path_corner"
+"spawnflags" "2304" // b#6, b#7: added this
+}
+{
+"origin" "424 -488 772"
+"target" "t98"
+"targetname" "t99"
+"classname" "path_corner"
+"spawnflags" "2304" // b#6, b#7: added this
+}
+{
+"spawnflags" "257"
+"origin" "112 -488 788"
+"target" "t98"
+"classname" "monster_soldier"
+"angle" "0"
+}
+{
+"spawnflags" "257"
+"origin" "424 -600 788"
+"target" "t100"
+"angle" "180"
+"classname" "monster_soldier"
+"item" "ammo_shells"
+}
+{
+"spawnflags" "768" // b#7: 0 -> 768
+"origin" "-56 140 640"
+"targetname" "t95"
+"classname" "point_combat"
+}
+{
+"origin" "104 144 656"
+"targetname" "t97"
+"target" "t95"
+"classname" "monster_gunner"
+"angle" "180"
+"spawnflags" "768"
+}
+{
+"model" "*47"
+"target" "t97"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "-1140 -280 980"
+"target" "t94"
+"targetname" "t93"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "-712 -344 980"
+"target" "t93"
+"targetname" "t94"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"target" "t92"
+"origin" "-1144 64 980"
+"targetname" "t91"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"target" "t91"
+"targetname" "t92"
+"origin" "-808 144 980"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"targetname" "t151"
+"target" "t93"
+"spawnflags" "3"
+"origin" "-1172 -280 996"
+"classname" "monster_hover"
+"angle" "0"
+}
+{
+"targetname" "t151"
+"spawnflags" "3"
+"origin" "-1176 64 996"
+"target" "t91"
+"angle" "0"
+"classname" "monster_hover"
+}
+{
+"model" "*48"
+"target" "t90" // never used
+"classname" "trigger_once"
+"spawnflags" "3840" // b#4: was 2048
+}
+{
+"origin" "-1176 304 644"
+"spawnflags" "3840" // b#4: was 0
+"targetname" "t87" // never used
+"classname" "point_combat"
+}
+{
+"deathtarget" "poo"
+"spawnflags" "1"
+"origin" "-1256 24 1040"
+"classname" "monster_hover"
+"angle" "315"
+"target" "t171"
+}
+{
+"deathtarget" "poo"
+"spawnflags" "1"
+"origin" "-672 -24 1104"
+"angle" "180"
+"classname" "monster_hover"
+"target" "t173"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "3840" // b#4: added this
+"killtarget" "t38"
+"targetname" "t77"
+"origin" "88 -1976 844"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+"killtarget" "t39"
+"targetname" "t77"
+"origin" "124 -1976 844"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "3840" // b#4: added this
+"killtarget" "t161"
+"origin" "148 -1976 844"
+"targetname" "t77"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1972 -1832 168"
+}
+{
+"model" "*49"
+"target" "t76"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "-688 -1472 888"
+"spawnflags" "1"
+"targetname" "t75"
+"classname" "point_combat"
+}
+{
+"spawnflags" "0"
+"origin" "-776 -1400 888"
+"targetname" "t74"
+"classname" "point_combat"
+}
+{
+"spawnflags" "256"
+"targetname" "t76"
+"origin" "-1136 -840 840"
+"classname" "monster_soldier"
+"angle" "0"
+}
+{
+"origin" "-1124 -1436 900"
+"target" "t72"
+"delay" "2"
+"targetname" "t70"
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"target" "t74"
+"origin" "-708 -1172 888"
+"targetname" "t72"
+"classname" "monster_gunner"
+"angle" "270"
+}
+{
+"target" "t75"
+"origin" "-640 -1172 888"
+"targetname" "t72"
+"angle" "270"
+"classname" "monster_gunner"
+}
+{
+"spawnflags" "1"
+"origin" "-672 -964 856"
+"targetname" "t71"
+"classname" "point_combat"
+}
+{
+"origin" "-672 -1436 908"
+"target" "t71"
+"targetname" "t70"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_soldier"
+}
+{
+"origin" "-1000 -1920 900"
+"targetname" "t69"
+"classname" "point_combat"
+}
+{
+"origin" "-1152 -1976 916"
+"targetname" "t70"
+"target" "t69"
+"spawnflags" "2"
+"angle" "0"
+"classname" "monster_gunner"
+"item" "ammo_grenades"
+}
+{
+"model" "*50"
+"target" "t70"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "1"
+"origin" "-920 -1912 884"
+"targetname" "t67"
+"classname" "point_combat"
+}
+{
+"item" "ammo_grenades"
+"origin" "-652 -1980 900"
+"targetname" "t70"
+"target" "t67"
+"spawnflags" "2"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"model" "*51"
+"target" "t66"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "-1160 -1400 892"
+"targetname" "t65"
+"spawnflags" "1"
+"classname" "point_combat"
+}
+{
+"spawnflags" "0"
+"item" "ammo_grenades"
+"origin" "-892 -1400 908"
+"targetname" "t66"
+"target" "t65"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"model" "*52"
+"target" "t62" // never used
+"classname" "trigger_once"
+"spawnflags" "3840" // b#4: was 2048
+}
+{
+"classname" "light"
+"light" "88"
+"origin" "-1836 -1380 624"
+}
+{
+"spawnflags" "1"
+"origin" "-1756 -1696 744"
+"targetname" "t60"
+"classname" "point_combat"
+}
+{
+"item" "ammo_shells"
+"targetname" "t59"
+"origin" "-1584 -1696 760"
+"target" "t60"
+"spawnflags" "2"
+"angle" "180"
+"classname" "monster_soldier"
+}
+{
+"target" "t118"
+"origin" "-2176 -1376 736"
+"targetname" "t59"
+"spawnflags" "1"
+"angle" "90"
+"classname" "monster_soldier"
+}
+{
+"model" "*53"
+"target" "t59"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "-1920 -1260 700"
+"targetname" "t58"
+"classname" "point_combat"
+"spawnflags" "256" // b#7: added this
+}
+{
+"targetname" "t59"
+"origin" "-1788 -1260 460"
+"angle" "180"
+"target" "t58"
+"spawnflags" "258"
+"classname" "monster_hover"
+}
+{
+"origin" "-1784 -1028 708"
+"spawnflags" "1"
+"targetname" "t57"
+"classname" "point_combat"
+}
+{
+"origin" "-1584 -1032 724"
+"targetname" "t59"
+"target" "t57"
+"spawnflags" "1"
+"angle" "180"
+"classname" "monster_soldier"
+}
+{
+"origin" "-1924 -1508 712"
+"spawnflags" "1"
+"targetname" "t56"
+"classname" "point_combat"
+}
+{
+"targetname" "t59"
+"origin" "-1588 -1504 728"
+"spawnflags" "1"
+"angle" "180"
+"target" "t56"
+"classname" "monster_soldier"
+}
+{
+"targetname" "t59"
+"spawnflags" "1"
+"origin" "-2124 -1044 732"
+"angle" "270"
+"classname" "monster_soldier"
+"item" "ammo_shells"
+}
+{
+"origin" "-2032 -1120 240"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-2032 -1120 192"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2032 -1424 240"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-2032 -1424 192"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1656 -1432 240"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1656 -1432 192"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1656 -1528 240"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1656 -1528 192"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-2032 -1520 240"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-2032 -1520 192"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1656 -1120 240"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1656 -1120 192"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "72"
+"origin" "-1796 -1596 64"
+}
+{
+"spawnflags" "0"
+"origin" "-1628 -1188 104"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "0"
+"origin" "-1628 -1296 104"
+"classname" "item_health_small"
+}
+{
+"origin" "-1844 -1540 64"
+"classname" "ammo_bullets"
+}
+{
+"origin" "-1864 -1612 64"
+"classname" "item_health_large"
+}
+{
+"origin" "-1160 -1712 340"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-1140 -1704 720"
+"targetname" "t53"
+"classname" "point_combat"
+"spawnflags" "768" // b#7: added this
+}
+{
+"origin" "-1140 -1772 720"
+"targetname" "t52"
+"classname" "point_combat"
+}
+{
+"target" "t53"
+"origin" "-1288 -1708 900"
+"targetname" "t51"
+"angle" "0"
+"spawnflags" "770"
+"classname" "monster_hover"
+}
+{
+"target" "t52"
+"origin" "-1308 -1768 900"
+"targetname" "t51"
+"spawnflags" "2"
+"classname" "monster_hover"
+"item" "ammo_cells"
+}
+{
+"model" "*54"
+"spawnflags" "2048"
+"target" "t51"
+"classname" "trigger_once"
+}
+{
+"model" "*55"
+"target" "t50"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"model" "*56"
+"target" "t49"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "-1568 -1528 112"
+"spawnflags" "1"
+"targetname" "t47"
+"classname" "point_combat"
+}
+{
+"origin" "-1484 -1502 128"
+"spawnflags" "257" // b#7: 1 -> 257
+"targetname" "t48"
+"classname" "point_combat"
+}
+{
+"origin" "-1632 -1428 100"
+"targetname" "t50"
+"spawnflags" "1"
+"target" "t47"
+"classname" "monster_soldier"
+"angle" "0"
+}
+{
+"item" "ammo_shells"
+"origin" "-1628 -1388 100"
+"targetname" "t50"
+"spawnflags" "257"
+"target" "t48"
+"angle" "0"
+"classname" "monster_soldier"
+}
+{
+"origin" "-2104 -1360 160"
+"target" "t46"
+"targetname" "t45"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "-2104 -1588 160"
+"target" "t45"
+"targetname" "t46"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"targetname" "t50"
+"origin" "-2104 -1328 176"
+"spawnflags" "1"
+"target" "t45"
+"angle" "270"
+"classname" "monster_soldier"
+}
+{
+"target" "t176"
+"targetname" "t50"
+"origin" "-2116 -1868 152"
+"spawnflags" "257"
+"angle" "0"
+"classname" "monster_soldier"
+}
+{
+"spawnflags" "1"
+"origin" "-1988 -2080 128"
+"targetname" "t44"
+"classname" "point_combat"
+}
+{
+"origin" "-1492 -2612 120"
+"spawnflags" "1"
+"targetname" "t43"
+"classname" "point_combat"
+}
+{
+"origin" "-1468 -2556 120"
+"spawnflags" "1"
+"targetname" "t42"
+"classname" "point_combat"
+}
+{
+"targetname" "t49"
+"origin" "-1652 -2564 136"
+"target" "t42"
+"spawnflags" "1"
+"classname" "monster_soldier"
+}
+{
+"item" "ammo_shells"
+"targetname" "t49"
+"origin" "-1740 -2576 136"
+"target" "t44"
+"spawnflags" "1"
+"angle" "0"
+"classname" "monster_soldier"
+}
+{
+"targetname" "t49"
+"origin" "-1700 -2592 136"
+"target" "t43"
+"spawnflags" "1"
+"classname" "monster_soldier"
+"item" "ammo_shells"
+}
+{
+"origin" "-996 568 -132"
+"map" "mine2$mine1"
+"targetname" "t41"
+"classname" "target_changelevel"
+}
+{
+"model" "*57"
+"angle" "90"
+"target" "t41"
+"classname" "trigger_multiple"
+}
+{ // b#21: was mine2's spot
+"targetname" "mintro"
+"origin" "-1216 -2944 120"
+"angle" "90"
+"classname" "info_player_start"
+}
+{
+"map" "mintro$end"
+"origin" "-1192 -3096 160"
+"targetname" "t40"
+"classname" "target_changelevel"
+}
+{
+"model" "*58"
+"angle" "270"
+"target" "t40"
+"classname" "trigger_multiple"
+}
+{
+"model" "*59"
+"spawnflags" "2048"
+"wait" "-1"
+"angle" "-2"
+"_minlight" ".2"
+"classname" "func_button"
+"target" "t77"
+}
+{
+"origin" "184 -1632 904"
+"wait" "3.5"
+"target" "t37"
+"classname" "func_timer"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t162"
+}
+{
+"origin" "184 -1376 904"
+"targetname" "t38"
+"wait" "3.5"
+"target" "t35"
+"classname" "func_timer"
+"spawnflags" "3840" // b#4: added this
+}
+{
+"origin" "8 -1632 904"
+"targetname" "t39"
+"wait" "3.5"
+"target" "t36"
+"classname" "func_timer"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"dmg" "50"
+"origin" "128 -1624 864"
+"targetname" "t37"
+"classname" "target_explosion"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"dmg" "50"
+"origin" "52 -1628 864"
+"targetname" "t36"
+"classname" "target_explosion"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"dmg" "50"
+"origin" "136 -1392 864"
+"targetname" "t37" // b#4: t35 -> t37
+"classname" "target_explosion"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"model" "*60"
+"target" "t29"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "0 -1500 904"
+"wait" "3.5"
+"target" "t28"
+"classname" "func_timer"
+"targetname" "t161"
+"spawnflags" "3840" // b#4: added this
+}
+{
+"dmg" "50"
+"origin" "56 -1504 864"
+"targetname" "t36" // b#4: t28 -> t36
+"classname" "target_explosion"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"model" "*61"
+"target" "t25"
+"classname" "func_button"
+"angle" "270"
+}
+{
+"model" "*62"
+"target" "t25"
+"angle" "0"
+"classname" "func_button"
+}
+{
+"origin" "-1524 -184 232"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-1524 -104 232"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-1524 -184 -24"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-1524 -104 -24"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-1524 -104 488"
+"classname" "light"
+"light" "96"
+}
+{
+"origin" "-1524 -184 488"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "-1408 64 696"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1536 64 696"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-1408 -128 696"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1536 -128 696"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-1536 256 696"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1408 256 696"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-984 168 -40"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*63"
+"message" "Access denied.\nToxic conditions present."
+"spawnflags" "2056"
+"targetname" "t2"
+"wait" "-1"
+"speed" "35"
+"_minlight" ".2"
+"angle" "-1"
+"classname" "func_door"
+"lip" "16"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1214 -2926 180"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1218 -3122 180"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1310 -2842 180"
+}
+{
+"model" "*64"
+"classname" "func_door"
+"angle" "0"
+"team" "d1"
+"_minlight" ".18"
+}
+{
+"classname" "light"
+"origin" "-1328 -2848 800"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1256 -2848 800"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1152 -2848 800"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1088 -2848 800"
+"light" "64"
+}
+{
+"origin" "-1218 -2842 180"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1126 -2838 180"
+"light" "80"
+"classname" "light"
+}
+{ // b#22: was mintro's spot
+"origin" "-984 396 -136"
+"targetname" "mine2"
+"angle" "270"
+"classname" "info_player_start"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "96 -1768 928"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "96 -1632 928"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "96 -1512 928"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "96 -1376 928"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "96 -1224 928"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "96 -1864 928"
+}
+{
+"_color" "1.000000 0.022727 0.000000"
+"light" "80"
+"classname" "light"
+"origin" "88 -1568 1136"
+}
+{
+"_color" "1.000000 0.022727 0.000000"
+"light" "80"
+"classname" "light"
+"origin" "96 -1440 1136"
+}
+{
+"_color" "1.000000 0.022727 0.000000"
+"light" "80"
+"classname" "light"
+"origin" "96 -1312 1136"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.022727 0.000000"
+"origin" "96 -1696 1136"
+}
+{
+"targetname" "t76"
+"angle" "0"
+"classname" "monster_soldier"
+"origin" "-936 -936 840"
+}
+{
+"item" "ammo_shells"
+"targetname" "t76"
+"angle" "0"
+"classname" "monster_soldier"
+"origin" "-960 -832 840"
+}
+{
+"targetname" "t76"
+"classname" "monster_soldier"
+"angle" "0"
+"origin" "-1104 -936 840"
+}
+{
+"classname" "light"
+"light" "180"
+"origin" "-968 -328 64"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-2160 -1160 832"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-2072 -1032 832"
+}
+{
+"origin" "-2160 -1320 832"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-1856 -1032 832"
+"classname" "light"
+"light" "120"
+}
+{
+"light" "180"
+"classname" "light"
+"origin" "-1088 40 64"
+}
+{
+"classname" "light"
+"light" "180"
+"origin" "-864 40 64"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-424 -216 824"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-296 -216 752"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-176 -208 696"
+}
+{
+"classname" "light"
+"light" "250"
+"origin" "-992 -544 1056"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "200 -240 768"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "200 -384 792"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "200 -72 736"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "264 -576 824"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "352 -568 632"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "152 -576 632"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "464 -600 856"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "88 -592 856"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "272 -984 880"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "96 -992 880"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "384 -968 912"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "8 -2016 944"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "68 -2212 1096"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "212 -2048 1096"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "60 -2044 1088"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "224 -2212 1096"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-4 -2160 892"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "128 -2280 924"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "292 -2052 924"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1232 -2396 728"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1232 -2424 680"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1232 -2576 596"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1232 -2704 632"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1232 -2724 680"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1232 -2752 728"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1800 -2584 1064"
+}
+{
+"light" "250"
+"classname" "light"
+"origin" "-1072 -2584 920"
+}
+{
+"light" "250"
+"classname" "light"
+"origin" "-1224 -2592 920"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-888 -2576 872"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1752 -2568 864"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1904 -2304 864"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1760 -2872 864"
+}
+{
+"model" "*65"
+"spawnflags" "2048"
+"classname" "func_button"
+"angle" "180"
+"wait" "-1"
+"target" "t2"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-488 -2600 920"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-488 -2512 920"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-128 -2144 976"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-568 -1088 880"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-752 -1088 880"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-864 -832 904"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-856 -896 960"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-864 -960 904"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1576 -1208 832"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-2168 -1432 832"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1720 -1032 832"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1592 -1032 832"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1584 -1472 832"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-672 -1184 904"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-672 -1048 888"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-672 -1304 912"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1408 -1656 888"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1408 -1776 888"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1104 -1504 984"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-736 -864 1016"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-952 -936 1016"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-952 -856 1016"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1120 -936 1016"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1120 -856 1016"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-632 -896 1016"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-736 -944 1016"
+}
+{
+"origin" "-976 -1520 944"
+"light" "150"
+"classname" "light"
+}
+{
+"model" "*66"
+"spawnflags" "2048"
+"target" "t163"
+"classname" "func_button"
+"_minlight" ".2"
+"angle" "-2"
+"wait" "-1"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-960 -1624 824"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-960 -1832 824"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-728 -1376 928"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-1706 -1398 908"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1978 -1130 908"
+}
+{
+"origin" "-1832 -1252 388"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-2124 -1432 184"
+"classname" "light"
+"light" "72"
+}
+{
+"origin" "-2124 -1580 184"
+"classname" "light"
+"light" "72"
+}
+{
+"origin" "-1996 -1592 168"
+"classname" "light"
+"light" "72"
+}
+{
+"origin" "-1852 -1592 168"
+"classname" "light"
+"light" "72"
+}
+{
+"origin" "-1904 -1724 168"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-1984 -1984 168"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "-2120 -1264 184"
+"light" "72"
+"classname" "light"
+}
+{
+"origin" "-1808 -1680 64"
+"classname" "light"
+"light" "72"
+}
+{
+"origin" "-1856 -1756 64"
+"classname" "light"
+"light" "72"
+}
+{
+"origin" "-1876 -1852 64"
+"classname" "light"
+"light" "72"
+}
+{
+"origin" "-1860 -1580 80"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-1040 -2772 144"
+"light" "140"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1066 302 -84"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-974 306 -84"
+}
+{
+"origin" "-1228 -2572 216"
+"light" "140"
+"classname" "light"
+}
+{
+"origin" "-1320 -2576 444"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1136 -2576 444"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "376 -856 884"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "380 -732 824"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "-1608 -1728 808"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1732 -1728 808"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1884 -1708 808"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1884 -1756 808"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1232 -1960 864"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1232 -2008 864"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1440 -1988 864"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1440 -2036 864"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1436 -1416 864"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1436 -1464 864"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1368 -1328 864"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1320 -1328 864"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1112 -1348 940"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1064 -1348 940"
+}
+{
+"origin" "-1008 -1632 996"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1004 -1828 996"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-868 -1504 984"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-760 -1352 984"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-676 -1524 984"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1104 -1504 920"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-600 -1412 984"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-764 -984 892"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1076 -804 892"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-912 -800 892"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-576 -880 892"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-576 -928 892"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1024 -980 892"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1176 -928 892"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1176 -880 892"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-684 -808 892"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1128 -980 892"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-936 -980 892"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-764 -1240 940"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-764 -1192 940"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-872 -1348 940"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-920 -1348 940"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1752 -1888 808"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1704 -1888 808"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-616 -808 892"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-760 -812 892"
+"light" "80"
+"classname" "light"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1816 -2608 176"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1984 -2544 176"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1984 -2328 176"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-1984 -2088 176"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-1672 -2600 176"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "-1576 -1792 864"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-2112 -1240 768"
+}
+{
+"origin" "-1832 -1480 768"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-2176 -1240 768"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1674 -1284 908"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1778 -1136 908"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1950 -1094 1036"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1970 -1308 908"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-2068 -1442 908"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-2072 -1240 908"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-2074 -1072 908"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1610 -1434 1016"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-1732 -1256 624"
+"classname" "light"
+"light" "88"
+}
+{
+"origin" "-1908 -1356 584"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1836 -1152 624"
+"classname" "light"
+"light" "88"
+}
+{
+"origin" "-1760 -1380 624"
+"light" "88"
+"classname" "light"
+}
+{
+"origin" "-1960 -1384 732"
+"light" "200"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-1964 -1172 732"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-1676 -1384 732"
+}
+{
+"origin" "-1680 -1172 732"
+"light" "200"
+"classname" "light"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-872 -208 -8"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-872 -72 -8"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1072 -72 -8"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1072 -208 -8"
+}
+{
+"classname" "light"
+"light" "140"
+"origin" "-976 -144 440"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-976 -16 528"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-976 8 584"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-976 -272 528"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-976 -248 488"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-976 -296 584"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-936 -192 -96"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-936 -104 -96"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1168 -192 56"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1168 -104 56"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-768 -192 56"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-768 -104 56"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1032 -104 -96"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1032 -192 -96"
+}
+{
+"light" "200"
+"origin" "-1856 -2904 904"
+"classname" "light"
+}
+{
+"light" "200"
+"origin" "-1856 -2688 904"
+"classname" "light"
+}
+{
+"light" "200"
+"origin" "-1856 -2272 904"
+"classname" "light"
+}
+{
+"light" "200"
+"origin" "-1856 -2464 904"
+"classname" "light"
+}
+{
+"origin" "-1704 -2712 840"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1912 -2456 1008"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1912 -2680 1008"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1912 -2896 1008"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1912 -2264 1008"
+"light" "100"
+"classname" "light"
+}
+{
+"model" "*67"
+"targetname" "t163"
+"sounds" "4"
+"wait" "-1"
+"spawnflags" "2049"
+"angle" "270"
+"classname" "func_door"
+"_minlight" ".2"
+}
+{
+"origin" "-576 -2144 984"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-608 -1984 984"
+"classname" "light"
+"light" "175"
+}
+{
+"origin" "-744 -1984 984"
+"classname" "light"
+"light" "175"
+}
+{
+"origin" "-912 -1992 984"
+"classname" "light"
+"light" "175"
+}
+{
+"origin" "-1064 -1984 984"
+"classname" "light"
+"light" "175"
+}
+{
+"origin" "-592 -2256 984"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-392 -2304 920"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-264 -2200 920"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-400 -2200 920"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "148 -1092 884"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "28 -1092 884"
+"light" "100"
+"classname" "light"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-296 -2400 920"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-328 -2568 920"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-672 -1184 1008"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-680 -1412 1044"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1280 -1536 944"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1256 -1360 944"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-880 -1728 984"
+}
+{
+"origin" "-1096 -1456 1112"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1336 -1440 992"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1328 -1664 992"
+"classname" "light"
+"light" "150"
+}
+{
+"classname" "light"
+"light" "250"
+"origin" "-1088 -1720 864"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1200 -1728 1016"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-912 -1440 1128"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1328 -1880 992"
+}
+{
+"spawnflags" "256"
+"light" "150"
+"classname" "light"
+"origin" "-1632 -1784 968"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1816 -1784 968"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1824 -1640 968"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1832 -1496 968"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1088 -1728 1000"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-2280 -1242 800"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-624 -2736 984"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-752 -2352 984"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-648 -2392 984"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-632 -2560 984"
+}
+{
+"light" "250"
+"classname" "light"
+"origin" "-756 -2560 1080"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-848 -2560 984"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-760 -2744 984"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1360 -2696 1096"
+}
+{
+"light" "150"
+"origin" "-1104 -2632 1096"
+"classname" "light"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1304 -2520 1096"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1472 -2472 1096"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1352 -2336 1096"
+}
+{
+"light" "150"
+"origin" "-1112 -2640 1424"
+"classname" "light"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1112 -2392 1424"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1312 -2528 1424"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1480 -2480 1424"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1360 -2344 1424"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1368 -2704 1424"
+}
+{
+"light" "150"
+"origin" "-1104 -2384 1096"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-1312 -2312 800"
+"light" "64"
+}
+{
+"light" "100"
+"origin" "-1128 -312 136"
+"classname" "light"
+}
+{
+"light" "100"
+"origin" "-816 0 136"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-1120 8 136"
+"light" "100"
+}
+{
+"origin" "-976 88 104"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-976 -328 104"
+"classname" "light"
+"light" "100"
+}
+{
+"model" "*68"
+"origin" "-976 -144 372"
+"speed" "400"
+"classname" "func_rotating"
+"spawnflags" "2048"
+"_minlight" "0.3"
+"targetname" "t2"
+"dmg" "33"
+}
+{
+"origin" "-1344 -472 888"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-696 -576 888"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-896 -576 888"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1040 -576 888"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1256 -576 888"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "100"
+"origin" "-808 -296 136"
+"classname" "light"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-608 -472 888"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-616 -344 888"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-616 -192 888"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-624 -64 888"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-704 24 888"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-720 128 888"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-816 200 888"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-976 200 888"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1192 200 888"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1320 168 888"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1248 8 888"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1280 -152 888"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-1304 -264 888"
+}
+{
+"light" "64"
+"origin" "-1272 -360 840"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-896 128 696"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-864 128 720"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-832 128 736"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-800 128 760"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-736 128 760"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-688 72 760"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-760 -8 760"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-688 -80 760"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-760 -160 760"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-688 -216 760"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-760 -288 760"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-688 -352 760"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-688 -440 760"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-760 -440 784"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-800 -440 808"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-840 -440 840"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-888 -360 840"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-976 -360 840"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-1048 -360 840"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-928 128 680"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-992 128 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1056 120 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1128 120 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1192 120 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1256 88 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1256 24 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1240 -48 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1240 -112 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1248 -192 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1248 -248 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1248 -304 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1248 -368 656"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1136 -360 840"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1200 -360 840"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-888 -440 840"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-976 -440 840"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-1048 -440 840"
+"light" "64"
+}
+{
+"light" "64"
+"origin" "-1136 -440 840"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-1200 -440 840"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-1272 -440 840"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-688 -288 760"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-688 -160 760"
+"light" "64"
+}
+{
+"classname" "light"
+"origin" "-688 -8 760"
+"light" "64"
+}
+{
+"origin" "-184 -8 696"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "-552 -208 880"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "24 128 696"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-224 128 696"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "64"
+"origin" "-1000 -2848 800"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-1408 -2864 800"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-1480 -2864 800"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-1504 -2800 800"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-1512 -2344 800"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-1448 -2312 800"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-1384 -2312 800"
+"classname" "light"
+}
+{
+"light" "64"
+"origin" "-1248 -2304 800"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-960 -2784 800"
+"light" "64"
+}
+{
+"origin" "-1504 -2424 1032"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1576 -2264 1032"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1448 -2232 1032"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1232 -2232 1032"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-1072 -2232 1032"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-976 -2304 1032"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-960 -2408 1032"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-880 -2496 1032"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-872 -2624 1032"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-872 -2776 1032"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-864 -2904 1032"
+"classname" "light"
+"light" "150"
+}
+{
+"classname" "light"
+"origin" "-1024 -2632 280"
+"light" "140"
+}
+{
+"classname" "light"
+"origin" "-1064 -2776 280"
+"light" "140"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-1600 -2904 1032"
+}
+{
+"model" "*69"
+"origin" "-1232 -2576 516"
+"dmg" "33"
+"_minlight" "0.3"
+"spawnflags" "2048"
+"classname" "func_rotating"
+"speed" "400"
+"targetname" "t2"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1232 -2808 248"
+}
+{
+"light" "140"
+"classname" "light"
+"origin" "-1240 -2312 248"
+}
+{
+"light" "100"
+"origin" "-1464 -2480 256"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-1132 -2284 280"
+"light" "140"
+}
+{
+"light" "140"
+"origin" "-1400 -2576 280"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "-1384 -2792 280"
+"light" "140"
+}
+{
+"model" "*70"
+"spawnflags" "8"
+"team" "d2"
+"angle" "180"
+"classname" "func_door"
+"_minlight" ".18"
+}
+{
+"origin" "-882 306 -84"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-974 586 -84"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-978 390 -84"
+"classname" "light"
+"light" "100"
+}

--- a/stuff/mapfixes/baseq2/mine2@4a1c.ent
+++ b/stuff/mapfixes/baseq2/mine2@4a1c.ent
@@ -1,0 +1,5178 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Added missing target names to info_player_coop (b#1)
+//
+// 2. Swapped info_player_start entities (b#2)
+//
+// This makes sure the player spawns at the right spot
+// when loading from console.
+//
+// 3. Adding missing target name to target_speaker for func_train pathtarget (b#3)
+//
+// 4. Added missing spawnflag 1 to ambient target_speaker entities (b#4)
+//
+// 5. Removed unused entities (b#5)
+//
+// 6. Added missing 256-2048 spawnflags to some entities (b#6)
+//
+// 7. Moved triggered monster_gunner down a bit to avoid thud sound (b#7)
+{
+"nextmap" "mine3"
+"sounds" "9"
+"sky" "unit4_"
+"message" "Borehole"
+"classname" "worldspawn"
+}
+{
+"classname" "point_combat"
+"targetname" "t160"
+"origin" "2136 2072 -352"
+}
+{
+"classname" "point_combat"
+"targetname" "t161"
+"origin" "2144 2096 -352"
+}
+{
+"classname" "point_combat"
+"targetname" "t159"
+"origin" "2152 2120 -352"
+}
+{
+"classname" "point_combat"
+"targetname" "t162"
+"origin" "2040 2096 -352"
+}
+{
+"origin" "-1088 -416 -56"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-992 -416 -56"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-896 -416 -56"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-800 -416 -56"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-736 -480 -56"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-1248 -480 -56"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-1312 -576 -56"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-1184 -416 -56"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-1312 -704 -56"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-1312 -832 -56"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "-672 -704 -56"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-672 -832 -56"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-672 -576 -56"
+"light" "110"
+"classname" "light"
+}
+{
+"origin" "1984 1112 -168"
+"spawnflags" "2048"
+"classname" "item_health_large"
+}
+{
+"origin" "352 -832 -120"
+"classname" "light"
+"light" "150"
+}
+{
+"model" "*1"
+"origin" "-1248 -512 -128"
+"classname" "func_train"
+"noise" "world/train1.wav"
+"speed" "88"
+"target" "p1"
+"targetname" "t14"
+}
+{
+"light" "64"
+"_color" "1.000000 0.384921 0.011905"
+"classname" "light"
+"origin" "764 -736 60"
+}
+{
+"classname" "light"
+"_color" "1.000000 0.384921 0.011905"
+"light" "64"
+"origin" "764 -600 60"
+}
+{
+"style" "1"
+"targetname" "t149"
+"classname" "func_areaportal"
+}
+{
+"model" "*2"
+"target" "t158"
+"wait" "3"
+"classname" "trigger_multiple"
+}
+{
+"light" "250"
+"classname" "light"
+"origin" "1928 936 -72"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "1936 768 -72"
+}
+{
+"origin" "1936 1104 -72"
+"classname" "light"
+"light" "200"
+}
+{
+"model" "*3"
+"team" "d5"
+"angle" "180"
+"_minlight" ".18"
+"classname" "func_door"
+"target" "t155"
+}
+{
+"model" "*4"
+"angle" "360"
+"team" "d3"
+"_minlight" ".18"
+"classname" "func_door"
+}
+{
+"model" "*5"
+"team" "d4"
+"_minlight" ".18"
+"classname" "func_door"
+}
+{
+"model" "*6"
+"classname" "func_door"
+"_minlight" ".18"
+"angle" "90"
+"team" "td13"
+}
+{
+"model" "*7"
+"origin" "-480 800 -340"
+"target" "t6"
+"targetname" "t16"
+"classname" "func_train"
+"noise" "world/train1.wav"
+"spawnflags" "2048"
+}
+{
+"model" "*8"
+"origin" "-480 800 -532"
+"target" "t1"
+"targetname" "t16"
+"classname" "func_train"
+"noise" "world/train1.wav"
+"spawnflags" "2048"
+}
+{
+"model" "*9"
+"origin" "-480 800 -124"
+"target" "t2"
+"targetname" "t16"
+"spawnflags" "2048"
+"noise" "world/train1.wav"
+"classname" "func_train"
+}
+{
+"origin" "-480 768 -104"
+"classname" "target_speaker"
+"noise" "world/train2.wav"
+"targetname" "backit2" // b#3: added this
+}
+{
+"origin" "-480 768 -672"
+"targetname" "backit1" // b#3: backit2 -> backit1
+"noise" "world/train2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "24 -896 -384"
+"targetname" "stop2"
+"classname" "target_speaker"
+"attenuation" "-1"
+"noise" "world/train2.wav"
+}
+{
+"origin" "24 -896 -584"
+"targetname" "stop1"
+"classname" "target_speaker"
+"attenuation" "-1"
+"noise" "world/train2.wav"
+}
+{
+"origin" "24 -896 -144"
+"attenuation" "-1"
+"targetname" "stop3"
+"classname" "target_speaker"
+"noise" "world/train2.wav"
+}
+{
+"model" "*10"
+"classname" "func_button"
+"angle" "0"
+"pathtarget" "p3"
+"target" "t15"
+}
+{
+"classname" "light"
+"light" "110"
+"origin" "412 -304 -508"
+}
+{
+"origin" "-776 744 -360"
+"targetname" "mine3c" // b#1: added this
+"classname" "info_player_coop"
+"angle" "360"
+}
+{
+"origin" "-776 856 -360"
+"targetname" "mine3c" // b#1: added this
+"classname" "info_player_coop"
+"angle" "360"
+}
+{
+"origin" "-712 800 -360"
+"targetname" "mine3c"
+"angle" "360"
+"classname" "info_player_coop"
+}
+{
+"origin" "384 -248 -528"
+"targetname" "mine3a" // b#1: added this
+"classname" "info_player_coop"
+"angle" "270"
+}
+{
+"origin" "320 -248 -528"
+"targetname" "mine3a" // b#1: added this
+"classname" "info_player_coop"
+"angle" "270"
+}
+{
+"origin" "352 -184 -528"
+"targetname" "mine3a"
+"angle" "270"
+"classname" "info_player_coop"
+}
+{
+"origin" "-272 -552 -328"
+"angle" "270"
+"targetname" "mine3b" // b#1: added this
+"classname" "info_player_coop"
+}
+{
+"origin" "-264 -384 -328"
+"targetname" "mine3b" // b#1: added this
+"classname" "info_player_coop"
+"angle" "270"
+}
+{
+"origin" "-272 -672 -328"
+"angle" "360"
+"targetname" "mine3b"
+"classname" "info_player_coop"
+}
+{
+"origin" "768 -704 -80"
+"classname" "info_player_coop"
+"targetname" "mine1" // b#1: added this
+"angle" "360"
+}
+{
+"origin" "768 -640 -80"
+"targetname" "mine1"
+"classname" "info_player_coop"
+"angle" "360"
+}
+{
+"origin" "968 -968 -80"
+"targetname" "mine1"
+"angle" "90"
+"classname" "info_player_coop"
+}
+{
+"model" "*11"
+"classname" "trigger_once"
+"targetname" "t157"
+"target" "t156"
+"spawnflags" "2048"
+}
+{
+"targetname" "t16"
+"spawnflags" "2"
+"noise" "world/drill1.wav"
+"classname" "target_speaker"
+"origin" "100 800 -392"
+}
+{
+"spawnflags" "2048"
+"origin" "920 -808 -64"
+"targetname" "t155"
+"classname" "trigger_relay"
+"target" "t157"
+}
+{
+"origin" "-64 -600 -316"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*12"
+"spawnflags" "2048"
+"targetname" "k9"
+"classname" "func_wall"
+}
+{
+"classname" "item_health"
+"spawnflags" "2048"
+"origin" "428 988 -352"
+}
+{
+"origin" "744 1608 -664"
+"angles" "-25 328 0"
+"classname" "info_player_intermission"
+}
+{
+"classname" "light"
+"origin" "1184 1308 -612"
+"light" "130"
+}
+{
+"classname" "misc_teleporter_dest"
+"angle" "90"
+"spawnflags" "1792"
+"origin" "1344 -420 112"
+"targetname" "t154"
+}
+{
+"model" "*13"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "misc_teleporter"
+"spawnflags" "1792"
+"angle" "90"
+"origin" "1184 1304 -648"
+"target" "t154"
+}
+{
+"model" "*14"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "952 -780 -80"
+}
+{
+"origin" "1820 1120 -160"
+"targetname" "t153"
+"angle" "270"
+"spawnflags" "1792"
+"classname" "misc_teleporter_dest"
+}
+{
+"origin" "528 656 -344"
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+}
+{
+"origin" "568 656 -344"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "2232 728 -328"
+"spawnflags" "1792"
+"light" "140"
+"classname" "light"
+}
+{
+"origin" "1676 956 -168"
+"classname" "item_health"
+"spawnflags" "1792"
+}
+{
+"origin" "1676 916 -168"
+"spawnflags" "1792"
+"classname" "item_health"
+}
+{
+"origin" "876 1432 -340"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "920 1412 -340"
+"spawnflags" "1792"
+"classname" "weapon_grenadelauncher"
+}
+{
+"origin" "1348 1812 -632"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "1304 1772 -632"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "1264 1728 -632"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "1400 1860 -632"
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+}
+{
+"origin" "872 1332 -644"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "916 1320 -660"
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "1552 2088 -672"
+"spawnflags" "1792"
+"classname" "item_armor_combat"
+}
+{
+"origin" "1916 1204 -168"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "1960 1204 -168"
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "1612 696 -376"
+"spawnflags" "1792"
+"classname" "ammo_rockets"
+}
+{
+"origin" "1628 732 -376"
+"spawnflags" "1792"
+"classname" "weapon_rocketlauncher"
+}
+{
+"origin" "1944 476 -168"
+"classname" "ammo_grenades"
+"spawnflags" "1792"
+}
+{
+"origin" "1768 476 -168"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "1952 232 -168"
+"classname" "item_health"
+"spawnflags" "1792"
+}
+{
+"origin" "1952 152 -168"
+"spawnflags" "1792"
+"classname" "item_health"
+}
+{
+"origin" "-144 -632 -336"
+"spawnflags" "1792"
+"classname" "ammo_cells"
+}
+{
+"origin" "-96 -672 -336"
+"spawnflags" "1792"
+"classname" "weapon_bfg"
+}
+{
+"origin" "1608 344 -168"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "1576 304 -168"
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+}
+{
+"origin" "1344 -400 -88"
+"spawnflags" "1792"
+"classname" "item_health_small"
+}
+{
+"origin" "1304 -400 -88"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "1384 -400 -88"
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+}
+{
+"origin" "1304 -40 104"
+"spawnflags" "1792"
+"classname" "ammo_grenades"
+}
+{
+"origin" "1344 -68 104"
+"spawnflags" "1792"
+"classname" "weapon_grenadelauncher"
+}
+{
+"origin" "1220 296 -504"
+"classname" "ammo_bullets"
+"spawnflags" "1792"
+}
+{
+"origin" "1180 296 -504"
+"spawnflags" "1792"
+"classname" "ammo_rockets"
+}
+{
+"origin" "1484 936 -552"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "1512 896 -552"
+"spawnflags" "1792"
+"classname" "weapon_machinegun"
+}
+{
+"origin" "1640 1104 -784"
+"spawnflags" "1792"
+"classname" "item_health_mega"
+}
+{
+"origin" "1640 1304 -564"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "1640 1344 -564"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "1640 1264 -564"
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+}
+{
+"origin" "1880 1456 -572"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "1928 1472 -572"
+"spawnflags" "1792"
+"classname" "weapon_supershotgun"
+}
+{
+"origin" "2180 2132 -344"
+"spawnflags" "1792"
+"classname" "ammo_shells"
+}
+{
+"origin" "1408 2128 -340"
+"spawnflags" "1792"
+"classname" "ammo_bullets"
+}
+{
+"origin" "1792 2092 -340"
+"spawnflags" "1792"
+"classname" "weapon_chaingun"
+}
+{
+"origin" "-148 800 -412"
+"spawnflags" "1792"
+"classname" "weapon_hyperblaster"
+}
+{
+"target" "t153"
+"origin" "792 532 -336"
+"spawnflags" "1792"
+"classname" "misc_teleporter"
+}
+{
+"origin" "-352 728 -648"
+"spawnflags" "1792"
+"team" "mine"
+"classname" "item_health_mega"
+}
+{
+"origin" "-352 728 -648"
+"spawnflags" "1792"
+"team" "mine"
+"classname" "item_quad"
+}
+{
+"origin" "-352 584 -424"
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-392 576 -424"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "-312 584 -424"
+"classname" "item_armor_shard"
+"spawnflags" "1792"
+}
+{
+"origin" "-432 576 -424"
+"spawnflags" "1792"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-384 680 -624"
+"spawnflags" "1792"
+"classname" "ammo_cells"
+}
+{
+"angle" "90"
+"classname" "info_player_deathmatch"
+"origin" "1472 312 -500"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "360"
+"origin" "1432 2072 -568"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "0"
+"origin" "624 1544 -636"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "270"
+"origin" "796 856 -336"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "1448 1408 -336"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "180"
+"origin" "2224 1192 -336"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "2128 824 -352"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"origin" "1688 672 -160"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "360"
+"origin" "1140 168 -160"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "1344 -336 -92"
+}
+{
+"classname" "trigger_always"
+"spawnflags" "1792"
+"target" "t152"
+"origin" "564 1120 -352"
+}
+{
+"classname" "trigger_always"
+"spawnflags" "1792"
+"target" "t16"
+"origin" "792 640 -324"
+}
+{
+"model" "*15"
+"spawnflags" "1792"
+"classname" "func_wall"
+}
+{
+"model" "*16"
+"classname" "func_wall"
+"spawnflags" "1792"
+}
+{
+"origin" "-428 832 -412"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "-428 1064 -412"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "-100 1184 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "44 1184 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "-428 624 -412"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "-236 1184 -316"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "172 1184 -316"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "612 1088 -316"
+}
+{
+"origin" "-196 800 -432"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-196 672 -432"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-196 928 -432"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-358 1128 -456"
+"classname" "item_armor_shard"
+"spawnflags" "2048"
+}
+{
+"origin" "-392 1128 -456"
+"classname" "item_armor_shard"
+"spawnflags" "2048"
+}
+{
+"origin" "-324 1128 -456"
+"classname" "item_armor_shard"
+"spawnflags" "2048"
+}
+{
+"origin" "-488 1192 -456"
+"classname" "item_adrenaline"
+"spawnflags" "2048"
+}
+{
+"origin" "-424 744 -592"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-432 904 -592"
+"light" "150"
+"classname" "light"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-344 752 -592"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-352 912 -592"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-272 1024 -392"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-304 776 -392"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-416 712 -392"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-424 1088 -416"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-424 1176 -416"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-440 1184 -340"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-184 1184 -244"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-188 1120 -244"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-312 1120 -244"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-312 1184 -244"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-440 1184 -244"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-440 1120 -244"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-56 1120 -244"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-56 1184 -244"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-440 1120 -340"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-312 1120 -340"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-312 1184 -340"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-184 1184 -340"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-188 1120 -340"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-56 1120 -340"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-56 1184 -340"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "72 1184 -244"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "200 1184 -244"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "196 1120 -244"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "280 1120 -244"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "344 1120 -244"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "384 1120 -244"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-428 980 -416"
+}
+{
+"model" "*17"
+"classname" "func_door"
+"angle" "-1"
+"wait" "-1"
+"health" "10"
+"targetname" "t152"
+}
+{
+"origin" "792 668 -352"
+"targetname" "t151"
+"classname" "point_combat"
+}
+{
+"target" "t151"
+"origin" "792 552 -336" // b#7: -312 -> -336
+"targetname" "t16"
+"spawnflags" "2"
+"angle" "90"
+"classname" "monster_gunner"
+}
+{
+"origin" "792 504 -344"
+"classname" "ammo_grenades"
+"spawnflags" "2048"
+}
+{
+"model" "*18"
+"wait" "-1"
+"speed" "200"
+"targetname" "t16"
+"spawnflags" "8"
+"angle" "-1"
+"classname" "func_door"
+}
+{
+"classname" "target_secret"
+"targetname" "t109"
+"message" "You have found a secret."
+"origin" "1608 1152 -808"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_rockets"
+"origin" "876 768 -340"
+"spawnflags" "0"
+}
+{
+"classname" "ammo_bullets"
+"origin" "876 804 -340"
+"spawnflags" "0"
+}
+{
+"classname" "monster_gunner"
+"angle" "0"
+"spawnflags" "2"
+"targetname" "t83"
+"target" "t150"
+"origin" "448 1120 -336" // b#7: -304 -> -336
+}
+{
+"classname" "point_combat"
+"targetname" "t150"
+"origin" "688 1124 -320"
+}
+{
+"classname" "ammo_rockets"
+"origin" "2212 736 -356"
+"spawnflags" "2048"
+}
+{
+"model" "*19"
+"targetname" "t157"
+"delay" ".1"
+"classname" "trigger_once"
+"target" "t115"
+"spawnflags" "2048"
+}
+{
+"origin" "636 652 -324"
+"target" "t148"
+"targetname" "t143"
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "564 652 -324"
+"target" "t148"
+"targetname" "t144"
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"classname" "item_health_large"
+"origin" "-576 840 -360"
+"spawnflags" "2048"
+}
+{
+"classname" "item_health_large"
+"origin" "-576 760 -360"
+"spawnflags" "2048"
+}
+{
+"model" "*20"
+"classname" "trigger_once"
+"target" "t147"
+"spawnflags" "2048"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+"noise" "world/lite_on3.wav"
+"targetname" "t16"
+"origin" "404 820 -312"
+}
+{
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+"noise" "world/lite_on3.wav"
+"targetname" "t16"
+"origin" "404 760 -312"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t143"
+"target" "t145"
+"origin" "656 656 -312"
+}
+{
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t144"
+"target" "t146"
+"origin" "544 656 -312"
+}
+{
+"classname" "light"
+"light" "160"
+"origin" "544 628 -312"
+}
+{
+"classname" "light"
+"light" "160"
+"origin" "656 628 -312"
+}
+{
+"model" "*21"
+"speed" "200"
+"wait" "-1"
+"angle" "270"
+"classname" "func_button"
+"target" "t143"
+"spawnflags" "2048"
+}
+{
+"model" "*22"
+"speed" "200"
+"wait" "-1"
+"classname" "func_button"
+"angle" "270"
+"target" "t144"
+"spawnflags" "2048"
+}
+{
+"origin" "504 1108 -268"
+"targetname" "t16"
+"wait" "6"
+"random" "4"
+"target" "t142"
+"classname" "func_timer"
+}
+{
+"origin" "488 1116 -248"
+"targetname" "t142"
+"angle" "-2"
+"sounds" "1"
+"classname" "target_splash"
+}
+{
+"origin" "920 -688 -88"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"origin" "520 1104 -276"
+"delay" ".5"
+"targetname" "t141"
+"classname" "target_explosion"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "340 1120 -336"
+"classname" "item_health_large"
+"spawnflags" "2048"
+}
+{
+"model" "*23"
+"dmg" "5"
+"target" "t141"
+"mass" "500"
+"targetname" "t16"
+"classname" "func_explosive"
+}
+{
+"origin" "1556 364 -160"
+"classname" "monster_soldier_ss"
+"angle" "270"
+"spawnflags" "1"
+}
+{
+"origin" "1172 168 -160"
+"spawnflags" "1"
+"angle" "0"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "1336 1020 -556"
+"spawnflags" "1"
+"angle" "90"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "1928 2080 -556"
+"spawnflags" "1"
+"angle" "225"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "1224 1556 -680"
+"target" "t140"
+"targetname" "t139"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "1408 1460 -680"
+"target" "t139"
+"targetname" "t140"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "1224 1556 -640"
+"angle" "315"
+"target" "t139"
+"classname" "monster_mutant"
+"spawnflags" "1"
+}
+{
+"origin" "744 1568 -648"
+"target" "t138"
+"targetname" "t137"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "820 1392 -648"
+"target" "t137"
+"targetname" "t138"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "744 1568 -632"
+"spawnflags" "1"
+"target" "t137"
+"angle" "0"
+"classname" "monster_mutant"
+}
+{
+"origin" "816 1100 -320"
+"targetname" "t136"
+"classname" "monster_berserk"
+"angle" "0"
+"spawnflags" "1"
+}
+{
+"origin" "816 1060 -320"
+"targetname" "t136"
+"angle" "0"
+"classname" "monster_berserk"
+"spawnflags" "1"
+}
+{
+"model" "*24"
+"target" "t136"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "2184 1340 -344"
+"target" "t135"
+"targetname" "t134"
+"delay" "5"
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "1844 2096 -336"
+"targetname" "t135"
+"angle" "360"
+"classname" "monster_gladiator"
+"target" "t162"
+}
+{
+"origin" "1952 2084 -336"
+"targetname" "t134"
+"classname" "monster_soldier_ss"
+"angle" "360"
+"target" "t160"
+}
+{
+"origin" "1992 2116 -336"
+"targetname" "t134"
+"classname" "monster_soldier_ss"
+"angle" "360"
+"target" "t159"
+}
+{
+"origin" "1904 2116 -336"
+"targetname" "t134"
+"angle" "360"
+"classname" "monster_soldier_ss"
+"target" "t161"
+}
+{
+"origin" "1924 1700 -580"
+"targetname" "t133"
+"classname" "point_combat"
+"spawnflags" "1"
+}
+{
+"origin" "1780 1464 -580"
+"targetname" "t132"
+"spawnflags" "1"
+"classname" "point_combat"
+}
+{
+"origin" "1924 1888 -556"
+"targetname" "t134"
+"target" "t133"
+"classname" "monster_soldier_ss"
+"angle" "270"
+}
+{
+"origin" "1632 1464 -556"
+"targetname" "t134"
+"target" "t132"
+"angle" "0"
+"classname" "monster_soldier_ss"
+}
+{
+"model" "*25"
+"target" "t134"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2"
+"origin" "2112 1480 -324"
+"targetname" "t131"
+"angle" "270"
+"classname" "monster_berserk"
+}
+{
+"spawnflags" "2"
+"origin" "2168 1480 -324"
+"targetname" "t131"
+"angle" "270"
+"classname" "monster_berserk"
+}
+{
+"model" "*26"
+"target" "t131"
+"delay" "5"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "2240 648 -344"
+"angle" "180"
+"spawnflags" "1"
+"classname" "monster_berserk"
+}
+{
+"model" "*27"
+"target" "t127"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "1768 656 -168"
+"target" "t126"
+"targetname" "t125"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "2216 656 -252"
+"target" "t125"
+"targetname" "t126"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"spawnflags" "2"
+"origin" "1724 656 -152"
+"targetname" "t127"
+"target" "t125"
+"angle" "0"
+"classname" "monster_gladiator"
+}
+{
+"origin" "1344 116 -176"
+"targetname" "t124"
+"spawnflags" "1"
+"classname" "point_combat"
+}
+{
+"origin" "1124 208 -168"
+"classname" "item_health_large"
+"spawnflags" "2048"
+}
+{
+"origin" "1500 164 -160"
+"target" "t124"
+"item" "ammo_bullets"
+"targetname" "t91"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"spawnflags" "2048"
+"attenuation" "-1"
+"targetname" "t156"
+"classname" "target_speaker"
+"noise" "gladiator/railgun.wav"
+"origin" "952 -736 -24"
+}
+{
+"origin" "1464 360 -484"
+"classname" "monster_berserk"
+"angle" "90"
+"spawnflags" "3"
+"targetname" "t147"
+}
+{
+"origin" "1232 360 -492"
+"spawnflags" "3"
+"angle" "90"
+"classname" "monster_berserk"
+"targetname" "t147"
+}
+{
+"origin" "940 -604 -104"
+"spawnflags" "2050"
+"angle" "135"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "924 -624 -88"
+"classname" "weapon_grenadelauncher"
+"spawnflags" "2048"
+}
+{
+"volume" "1"
+"origin" "948 -696 -32"
+"targetname" "t115"
+"noise" "world/flesh1.wav"
+"classname" "target_speaker"
+}
+{
+"volume" "1"
+"origin" "956 -724 -52"
+"targetname" "t115"
+"noise" "player/death4.wav"
+"classname" "target_speaker"
+}
+{
+"angle" "270"
+"origin" "976 -700 -16"
+"targetname" "t115"
+"target" "misc_gib_arm"
+"speed" "90"
+"classname" "target_spawner"
+"spawnflags" "2048"
+}
+{
+"origin" "928 -700 -32"
+"targetname" "t115"
+"angle" "270"
+"target" "misc_gib_arm"
+"speed" "90"
+"classname" "target_spawner"
+"spawnflags" "2048"
+}
+{
+"origin" "928 -712 -60"
+"targetname" "t115"
+"speed" "60"
+"angle" "270"
+"target" "misc_gib_leg"
+"classname" "target_spawner"
+"spawnflags" "2048"
+}
+{
+"origin" "952 -708 -8"
+"targetname" "t115"
+"speed" "100"
+"angle" "270"
+"target" "misc_gib_head"
+"classname" "target_spawner"
+"spawnflags" "2048"
+}
+{
+"angle" "270"
+"origin" "976 -712 -72"
+"targetname" "t115"
+"speed" "60"
+"target" "misc_gib_leg"
+"classname" "target_spawner"
+"spawnflags" "2048"
+}
+{
+"origin" "1340 -264 -76"
+"targetname" "t122"
+"spawnflags" "1"
+"classname" "point_combat"
+}
+{
+"origin" "932 -264 -60"
+"target" "t122"
+"spawnflags" "1"
+"angle" "270"
+"classname" "monster_gladiator"
+}
+{
+"classname" "target_help"
+"targetname" "t115"
+"message" "Activate mine machinery to\ngain access to\nDrilling Area."
+"origin" "936 -940 -64"
+"spawnflags" "2048"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2049"
+"angle" "225"
+"origin" "1148 140 -184"
+}
+{
+"classname" "item_health_small"
+"origin" "1404 -236 -96"
+"spawnflags" "2048"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1372 284 -256"
+}
+{
+"origin" "1312 284 -256"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1372 284 0"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1440 328 -432"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1312 284 0"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1248 328 -432"
+}
+{
+"classname" "weapon_hyperblaster"
+"origin" "1620 748 -376"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_cells"
+"origin" "1644 720 -376"
+"spawnflags" "2048"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2052"
+"angle" "180"
+"origin" "628 1528 -660"
+}
+{
+"classname" "item_health"
+"origin" "1308 64 104"
+"spawnflags" "2048"
+}
+{
+"classname" "item_health"
+"origin" "1376 64 104"
+"spawnflags" "2048"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t111"
+"target" "t112"
+"origin" "980 1420 -352"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t112"
+"target" "t111"
+"origin" "1408 1420 -352"
+}
+{
+"classname" "monster_gladiator"
+"target" "t111"
+"spawnflags" "1"
+"angle" "0"
+"origin" "928 1420 -336"
+}
+{
+"origin" "1940 476 -132"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "1940 356 -132"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "1772 356 -132"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "1772 476 -132"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "812 872 -344"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "776 872 -344"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "684 1196 -344"
+"classname" "item_health"
+"spawnflags" "2048"
+}
+{
+"origin" "540 1196 -344"
+"classname" "item_health"
+"spawnflags" "0"
+}
+{
+"origin" "1468 1428 -344"
+"classname" "ammo_cells"
+"spawnflags" "2048"
+}
+{
+"origin" "1468 1388 -344"
+"classname" "ammo_bullets"
+"spawnflags" "2048"
+}
+{
+"origin" "1744 2116 -320"
+"targetname" "t110"
+"target" "misc_gib_head"
+"speed" "30"
+"angle" "180"
+"classname" "target_spawner"
+}
+{
+"model" "*28"
+"target" "t110"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "1588 2092 -344"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "1664 2084 -344"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "1704 2096 -344"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "1480 2112 -344"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "1792 2096 -264"
+"_style" "10"
+"_color" "1.000000 0.034884 0.011628"
+"light" "250"
+"classname" "light"
+}
+{
+"origin" "1756 2092 -344"
+"classname" "weapon_machinegun"
+"spawnflags" "2048"
+}
+{
+"origin" "1768 2112 -360"
+"angle" "45"
+"spawnflags" "2048"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "1348 2120 -628"
+"classname" "item_health_large"
+"spawnflags" "0"
+}
+{
+"target" "t109"
+"origin" "1572 1176 -800"
+"classname" "item_adrenaline"
+"spawnflags" "2048"
+}
+{
+"origin" "1488 300 -508"
+"classname" "ammo_shells"
+"spawnflags" "2048"
+}
+{
+"origin" "1180 336 -504"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "1180 296 -504"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "1180 376 -504"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "1620 704 -392"
+"classname" "misc_deadsoldier"
+}
+{
+"classname" "misc_explobox"
+"origin" "1636 668 -368"
+"spawnflags" "2048"
+}
+{
+"origin" "2200 684 -316"
+"targetname" "t108"
+"classname" "target_secret"
+"message" "You have found a secret."
+"spawnflags" "2048"
+}
+{
+"model" "*29"
+"target" "t108"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "2192 696 -360"
+"classname" "misc_explobox"
+"spawnflags" "2048"
+}
+{
+"origin" "2236 688 -360"
+"classname" "misc_explobox"
+"spawnflags" "2048"
+}
+{
+"origin" "2252 736 -352"
+"classname" "item_armor_combat"
+"spawnflags" "0"
+}
+{
+"origin" "1868 1196 -168"
+"classname" "ammo_shells"
+"spawnflags" "2048"
+}
+{
+"origin" "1844 1184 -184"
+"angle" "135"
+"spawnflags" "2048"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "1944 356 -168"
+"classname" "item_health_small"
+}
+{
+"origin" "1768 356 -168"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "1768 476 -168"
+"classname" "item_health_small"
+}
+{
+"spawnflags" "2048"
+"origin" "1944 476 -168"
+"classname" "item_health_small"
+}
+{
+"origin" "1708 412 -160"
+"classname" "item_health"
+"spawnflags" "0"
+}
+{
+"origin" "1124 120 -168"
+"classname" "ammo_grenades"
+"spawnflags" "2048"
+}
+{
+"origin" "1160 208 -168"
+"classname" "ammo_shells"
+"spawnflags" "2048"
+}
+{
+"origin" "1388 -264 -96"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "1340 -188 -96"
+"classname" "item_health_small"
+"spawnflags" "2048"
+}
+{
+"origin" "1380 -224 -116"
+"angle" "90"
+"spawnflags" "2048"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "16 884 -392"
+"targetname" "t16"
+"classname" "target_speaker"
+"noise" "world/drill1.wav"
+"spawnflags" "2"
+}
+{
+"origin" "-68 800 -392"
+"targetname" "t16"
+"classname" "target_speaker"
+"noise" "world/drill1.wav"
+"spawnflags" "2"
+}
+{
+"origin" "204 800 -392"
+"targetname" "t16"
+"classname" "target_speaker"
+"noise" "world/drill1.wav"
+"spawnflags" "2"
+}
+{
+"origin" "16 716 -392"
+"targetname" "t16"
+"spawnflags" "2"
+"noise" "world/drill1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "596 684 -320"
+"targetname" "t16"
+"noise" "world/lite_on1.wav"
+"attenuation" "-1"
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"volume" "1"
+"origin" "544 652 -284"
+"attenuation" "-1"
+"noise" "world/lite_on1.wav"
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t146"
+}
+{
+"volume" "1"
+"origin" "656 652 -284"
+"attenuation" "-1"
+"noise" "world/lite_on1.wav"
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t145"
+}
+{
+"origin" "600 578 -249"
+"light" "96"
+"classname" "light"
+}
+{
+"origin" "600 650 -296"
+"spawnflags" "2"
+"targetname" "t16"
+"noise" "world/pump3.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t16"
+"spawnflags" "0"
+"noise" "world/electro.wav"
+"origin" "600 650 -318"
+"classname" "target_speaker"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"style" "32"
+"_color" "1.000000 0.012000 0.012000"
+"spawnflags" "1"
+"origin" "656 630 -160"
+"light" "220"
+"classname" "light"
+"targetname" "t145"
+}
+{
+"origin" "544 608 -312"
+"light" "160"
+"classname" "light"
+}
+{
+"style" "33"
+"_color" "1.000000 0.012000 0.012000"
+"spawnflags" "1"
+"origin" "544 630 -160"
+"classname" "light"
+"light" "220"
+"targetname" "t146"
+}
+{
+"origin" "656 608 -312"
+"light" "160"
+"classname" "light"
+}
+{
+"model" "*30"
+"targetname" "t148"
+"target" "t16"
+"killtarget" "k9" // b#5: moved here
+"classname" "trigger_counter"
+"spawnflags" "2048"
+}
+{
+"model" "*31"
+"origin" "600 592 -233"
+"targetname" "t16"
+"_minlight" ".3"
+"speed" "750"
+"classname" "func_rotating"
+"spawnflags" "2048"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "-720 664 -312"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-720 936 -312"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "-680 800 -348"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "-680 800 -176"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-104 808 -356"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "168 808 -356"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-512 796 -620"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-520 872 -620"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-520 728 -620"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-456 900 -692"
+"spawnflags" "1"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+}
+{
+"origin" "-480 720 -692"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-56 676 -264"
+"classname" "target_speaker"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-60 920 -264"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "200 680 -264"
+"classname" "target_speaker"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+}
+{
+"origin" "196 924 -264"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-184 916 -356"
+"classname" "target_speaker"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+}
+{
+"origin" "404 796 -264"
+"classname" "target_speaker"
+"noise" "world/amb6.wav"
+"spawnflags" "1"
+}
+{
+"origin" "-180 672 -356"
+"spawnflags" "1"
+"noise" "world/amb6.wav"
+"classname" "target_speaker"
+}
+{
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "824 824 -284"
+}
+{
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "728 824 -284"
+}
+{
+"volume" ".6"
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "728 824 -296"
+}
+{
+"origin" "812 684 -284"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"volume" ".6"
+"origin" "824 824 -296"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+}
+{
+"volume" ".6"
+"origin" "812 684 -264"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+}
+{
+"volume" ".6"
+"origin" "480 648 -264"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+}
+{
+"origin" "536 992 -264"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+}
+{
+"origin" "536 1120 -264"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb10.wav"
+}
+{
+"origin" "-316 1152 -412"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "784 1088 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "900 1148 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "900 1332 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1444 1828 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1328 1512 -276"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+}
+{
+"origin" "1360 1760 -276"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+}
+{
+"origin" "1048 1500 -276"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1668 2096 -276"
+}
+{
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1948 2096 -276"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "2088 2096 -316"
+}
+{
+"origin" "1444 1964 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1488 2096 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1688 2096 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1904 2096 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "2140 1904 -276"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "2140 1964 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "2140 1780 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1984 1328 -312"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "2068 1488 -256"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+}
+{
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "2212 1608 -256"
+}
+{
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "2164 1540 -528"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "2144 1568 -316"
+}
+{
+"origin" "2144 1340 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "2204 1184 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1992 1184 -316"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1856 1184 -356"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "2232 1020 -356"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1640 1108 -216"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1640 1108 -356"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1640 1108 -52"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1952 1020 -356"
+}
+{
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "688 864 -296"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "2232 836 -292"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "2228 656 -216"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "2068 656 -168"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1856 656 -124"
+}
+{
+"noise" "world/amb10.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1856 448 -40"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "608 1196 -280"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1408 1384 -280"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1476 1408 -616"
+}
+{
+"origin" "720 1416 -468"
+"classname" "target_speaker"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+}
+{
+"origin" "584 1536 -596"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1428 1456 -688"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1212 1552 -688"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "968 1540 -688"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "720 660 -296"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "1036 1356 -688"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "1288 1824 -596"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1432 2072 -540"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "1232 2140 -688"
+}
+{
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"origin" "1532 2104 -656"
+}
+{
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+"classname" "target_speaker"
+"origin" "764 1560 -496"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+"origin" "1596 2072 -540"
+}
+{
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+"origin" "1764 2072 -540"
+}
+{
+"origin" "1924 2040 -540"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1924 1892 -540"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1924 1716 -540"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1816 1464 -540"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1332 1104 -540"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1516 1108 -540"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1316 2140 -504"
+"classname" "target_speaker"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1632 1464 -540"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1636 1280 -540"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1332 932 -540"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "2084 1392 -604"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"spawnflags" "1" // b#4: added this
+}
+{
+"origin" "1880 1384 -604"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"spawnflags" "1" // b#4: added this
+}
+{
+"origin" "1888 1580 -604"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"spawnflags" "1" // b#4: added this
+}
+{
+"origin" "1720 1164 -604"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"spawnflags" "1" // b#4: added this
+}
+{
+"origin" "2096 1556 -604"
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1" // b#4: added this
+}
+{
+"origin" "1628 1028 -604"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+"spawnflags" "1" // b#4: added this
+}
+{
+"origin" "1344 328 -200"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1344 328 -348"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1344 328 -500"
+"classname" "target_speaker"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1344 328 24"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1332 872 -608"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1348 612 -432"
+"wait" "4"
+"random" "3"
+"spawnflags" "1"
+"target" "t100"
+"classname" "func_timer"
+}
+{
+"origin" "1272 604 -432"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/drip_amb.wav"
+}
+{
+"origin" "1448 504 -432"
+"targetname" "t100"
+"noise" "world/drip_amb.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/water1.wav"
+"spawnflags" "1"
+"origin" "1412 800 -608"
+}
+{
+"origin" "1192 796 -608"
+"spawnflags" "1"
+"noise" "world/water1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1300 780 -324"
+"classname" "target_speaker"
+"noise" "world/fan1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1352 780 -420"
+"classname" "target_speaker"
+"noise" "world/fan1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1300 780 -420"
+"spawnflags" "1"
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1352 780 -324"
+"classname" "target_speaker"
+"noise" "world/fan1.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1440 284 -480"
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+}
+{
+"origin" "1246 284 -480"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1488 752 -504"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "2144 1768 -264"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "2144 1152 -280"
+}
+{
+"origin" "1568 928 -312"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "1856 1232 -312"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1856 624 -312"
+}
+{
+"origin" "1112 736 -504"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "1840 744 -356"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1856 540 -124"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1860 352 -124"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1856 164 -124"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1700 164 -124"
+}
+{
+"noise" "world/comp_hum1.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1700 308 -124"
+}
+{
+"origin" "1700 308 -108"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "1572 376 -124"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum1.wav"
+}
+{
+"origin" "1640 424 -88"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1496 164 -124"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1344 164 -124"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1204 164 -124"
+}
+{
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1572 376 -108"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1344 -24 -88"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1340 -160 -52"
+}
+{
+"origin" "1344 128 136"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1344 -56 136"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1248 -264 -52"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1344 284 136"
+}
+{
+"origin" "1156 164 -124"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "1344 -436 164"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1284 104 164"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1404 -8 164"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1508 -264 164"
+}
+{
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1180 -264 164"
+}
+{
+"noise" "world/pump3.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1340 -264 16"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "1104 -264 -52"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "956 -344 -52"
+}
+{
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+"origin" "956 -528 -52"
+}
+{
+"spawnflags" "1"
+"origin" "464 -816 -252"
+"classname" "target_speaker"
+"noise" "world/amb14.wav"
+}
+{
+"spawnflags" "1"
+"origin" "240 -816 -252"
+"noise" "world/amb14.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "160 -688 -52"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "352 -488 -52"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "512 -668 -52"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "352 -488 -296"
+"volume" ".7"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "512 -668 -296"
+"volume" ".7"
+"noise" "world/amb9.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "644 -668 -52"
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "352 -456 -448"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "160 -688 -296"
+"volume" ".7"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb9.wav"
+}
+{
+"origin" "800 -668 -52"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb4.wav"
+}
+{
+"origin" "1404 216 164"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+}
+{
+"origin" "956 -744 -52"
+"classname" "target_speaker"
+"noise" "world/amb4.wav"
+"spawnflags" "1" // b#4: added this
+}
+{
+"origin" "24 -664 -276"
+"noise" "world/amb4.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "356 -668 -620"
+"target" "t99"
+"random" "4"
+"wait" "5"
+"spawnflags" "1"
+"classname" "func_timer"
+}
+{
+"origin" "520 -796 -632"
+"volume" ".8"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/lava1.wav"
+}
+{
+"origin" "180 -796 -632"
+"targetname" "t99"
+"volume" ".8"
+"classname" "target_speaker"
+"spawnflags" "0"
+"noise" "world/lava1.wav"
+}
+{
+"origin" "180 -568 -632"
+"volume" ".8"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/lava1.wav"
+}
+{
+"origin" "520 -568 -632"
+"targetname" "t99"
+"volume" ".8"
+"noise" "world/lava1.wav"
+"spawnflags" "0"
+"classname" "target_speaker"
+}
+{
+"origin" "-992 800 -264"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"classname" "target_speaker"
+"noise" "world/amb7.wav"
+"spawnflags" "1"
+"origin" "-248 -352 -236"
+}
+{
+"origin" "352 -224 -428"
+"spawnflags" "1"
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "948 -984 24"
+"spawnflags" "1" // b#4: added this
+"noise" "world/amb7.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "712 724 -280"
+"targetname" "t16"
+"classname" "target_goal"
+}
+{
+"origin" "272 1116 -320"
+"targetname" "t98"
+"classname" "target_secret"
+"message" "You have found a secret area."
+"spawnflags" "2048"
+}
+{
+"model" "*32"
+"target" "t98"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"origin" "1964 1336 -312"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "2004 1336 -312"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "1876 632 -312"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "1836 632 -312"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "1620 416 -88"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "1660 416 -88"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "1296 84 168"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "1296 124 168"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "1392 -28 168"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "1392 12 168"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "1364 -424 168"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "1324 -424 168"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "1192 -244 168"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "1192 -284 168"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "1496 -244 168"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "1496 -284 168"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "1392 196 168"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "1392 236 168"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "-720 656 -312"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "720 656 -296"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "608 1200 -280"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1408 1384 -280"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1104 736 -504"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"classname" "light"
+"_color" "1.000000 1.000000 0.207843"
+"origin" "-720 944 -312"
+}
+{
+"origin" "2144 1144 -280"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1496 752 -504"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1856 1240 -312"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1560 928 -312"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1856 616 -312"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1640 432 -88"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1408 216 168"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1280 104 168"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1408 -8 168"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1176 -264 168"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1512 -264 168"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"origin" "1344 -440 168"
+"_color" "1.000000 1.000000 0.207843"
+"classname" "light"
+}
+{
+"classname" "light"
+"_color" "1.000000 1.000000 0.207843"
+"origin" "1984 1320 -312"
+}
+{
+"classname" "target_help"
+"targetname" "t16"
+"message" "Return to elevator shaft.\nProceed to Drilling Area."
+"origin" "744 728 -304"
+}
+{
+"model" "*33"
+"target" "t91"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"style" "2"
+"targetname" "t89"
+"classname" "func_areaportal"
+}
+{
+"style" "3"
+"targetname" "t88"
+"classname" "func_areaportal"
+}
+{
+"model" "*34"
+"target" "t86"
+"angle" "270"
+"classname" "trigger_once"
+"spawnflags" "3840" // b#5: added this
+}
+{
+"origin" "676 708 -300"
+"target" "t83"
+"targetname" "t16"
+"delay" "1"
+"classname" "trigger_relay"
+"spawnflags" "2048" // b#6: added this
+}
+{
+"origin" "624 1104 -320"
+"targetname" "t84"
+"spawnflags" "769" // b#5: 1 -> 769
+"classname" "point_combat"
+}
+{
+"item" "ammo_grenades"
+"origin" "412 1120 -336" // b#7: -304 -> -336
+"target" "t84"
+"targetname" "t83"
+"spawnflags" "770"
+"angle" "0"
+"classname" "monster_gunner"
+}
+{
+"classname" "ammo_cells"
+"origin" "608 1508 -636"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_rockets"
+"origin" "604 1544 -636"
+"spawnflags" "2048"
+}
+{
+"classname" "item_health_large"
+"origin" "600 1584 -636"
+"spawnflags" "2048"
+}
+{
+"model" "*35"
+"classname" "trigger_once"
+"target" "t77"
+"spawnflags" "3840" // b#5: 2048 -> 3840
+}
+{
+"classname" "point_combat"
+"targetname" "t61"
+"spawnflags" "1"
+"origin" "1300 -72 104"
+}
+{
+"classname" "point_combat"
+"targetname" "t62"
+"spawnflags" "1"
+"origin" "1388 -88 104"
+}
+{
+"origin" "1308 -20 120"
+"classname" "monster_gunner"
+"angle" "270"
+"target" "t61"
+"spawnflags" "256"
+}
+{
+"classname" "point_combat"
+"spawnflags" "1"
+"targetname" "t59"
+"origin" "1496 900 -556"
+}
+{
+"item" "ammo_grenades"
+"classname" "monster_gunner"
+"angle" "180"
+"spawnflags" "1"
+"target" "t59"
+"origin" "1496 944 -540"
+}
+{
+"origin" "1640 840 -368"
+"classname" "misc_explobox"
+"spawnflags" "2048"
+}
+{
+"origin" "1756 692 -368"
+"classname" "misc_explobox"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "256"
+"angle" "270"
+"classname" "monster_gunner"
+"origin" "1376 -20 120"
+"target" "t62"
+"item" "ammo_bullets"
+}
+{
+"model" "*36"
+"classname" "trigger_once"
+"delay" "2"
+"target" "t21"
+"spawnflags" "3840" // b#5: 2048 -> 3840
+}
+{
+"wait" "3"
+"classname" "func_timer"
+"random" "2"
+"target" "t19"
+"targetname" "t16"
+"origin" "-56 840 -224"
+}
+{
+"classname" "target_splash"
+"sounds" "1"
+"targetname" "t19"
+"origin" "-32 840 -208"
+}
+{
+"wait" "4"
+"classname" "func_timer"
+"random" "3"
+"target" "t18"
+"targetname" "t16"
+"origin" "88 760 -216"
+}
+{
+"classname" "target_splash"
+"sounds" "1"
+"targetname" "t18"
+"origin" "64 760 -216"
+}
+{
+"classname" "target_lightramp"
+"speed" "2"
+"message" "az"
+"targetname" "t16"
+"target" "t17"
+"origin" "160 800 -232"
+}
+{
+"style" "34"
+"spawnflags" "1"
+"light" "180"
+"classname" "light"
+"targetname" "t17"
+"origin" "-56 728 -232"
+}
+{
+"style" "34"
+"spawnflags" "1"
+"light" "180"
+"classname" "light"
+"targetname" "t17"
+"origin" "88 728 -232"
+}
+{
+"style" "34"
+"spawnflags" "1"
+"light" "180"
+"classname" "light"
+"targetname" "t17"
+"origin" "88 872 -232"
+}
+{
+"style" "34"
+"classname" "light"
+"light" "180"
+"spawnflags" "1"
+"targetname" "t17"
+"origin" "-56 872 -232"
+}
+{
+"classname" "item_health_small"
+"origin" "-576 800 -368"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_shells"
+"origin" "-592 664 -360"
+"spawnflags" "2048"
+}
+{
+"classname" "ammo_cells"
+"origin" "-592 936 -360"
+"spawnflags" "2048"
+}
+{
+"origin" "1552 2088 -672"
+"classname" "item_quad"
+//"target" "t68" // never used
+"spawnflags" "2048"
+}
+{
+"origin" "868 816 -284"
+"classname" "light"
+"light" "80"
+}
+{
+"model" "*37"
+"targetname" "k9"
+"message" "Mine machinery inoperative."
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+"wait" "3"
+}
+{
+"origin" "852 800 -340"
+"killtarget" "k9" // b#5: moved to trigger_counter
+"targetname" "t16"
+"classname" "trigger_relay"
+"spawnflags" "3840" // b#5: added this
+}
+{
+"model" "*38"
+"targetname" "t158"
+"classname" "func_button"
+"target" "t15"
+"angle" "90"
+"pathtarget" "p2"
+}
+{
+"origin" "1480 2040 -576"
+"light" "70"
+"classname" "light"
+}
+{
+"light" "70"
+"classname" "light"
+"origin" "1480 2112 -576"
+}
+{
+"origin" "1448 1976 -576"
+"light" "64"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "1376 2040 -576"
+}
+{
+"classname" "light"
+"light" "72"
+"origin" "584 1500 -544"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "588 1536 -588"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "576 1584 -544"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "576 1584 -644"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "584 1500 -644"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "380 -392 -308"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "320 -392 -308"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "352 -392 -52"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "684 -704 -508"
+"light" "110"
+"classname" "light"
+}
+{
+"model" "*39"
+"target" "t15"
+"pathtarget" "p2"
+"angle" "0"
+"classname" "func_button"
+}
+{
+"targetname" "t15"
+"target" "t14"
+"classname" "trigger_elevator"
+"origin" "0 0 0"
+}
+{
+"model" "*40"
+"angle" "90"
+"target" "t15"
+"pathtarget" "p2"
+"classname" "func_button"
+}
+{
+"model" "*41"
+"angle" "90"
+"target" "t15"
+"pathtarget" "p3"
+"classname" "func_button"
+}
+{
+"model" "*42"
+"angle" "90"
+"target" "t15"
+"pathtarget" "p1"
+"classname" "func_button"
+}
+{
+"pathtarget" "stop1"
+"wait" "-1"
+"targetname" "p3"
+"origin" "0 -896 -584"
+"classname" "path_corner"
+}
+{
+"pathtarget" "stop2"
+"wait" "-1"
+"targetname" "p2"
+"origin" "0 -896 -388"
+"classname" "path_corner"
+}
+{
+"pathtarget" "stop3"
+"wait" "-1"
+"origin" "0 -896 -140"
+"targetname" "p1"
+"classname" "path_corner"
+}
+{
+"model" "*43"
+"classname" "trigger_multiple"
+"target" "t13"
+"angle" "180"
+}
+{
+"classname" "target_changelevel"
+"map" "mine3$mine2c"
+"targetname" "t13"
+"origin" "-1072 840 -304"
+}
+{
+"model" "*44"
+"classname" "trigger_multiple"
+"target" "t12"
+"angle" "90"
+}
+{
+"classname" "target_changelevel"
+"map" "mine3$mine2a"
+"targetname" "t12"
+"origin" "312 -152 -440"
+}
+{
+"model" "*45"
+"classname" "trigger_multiple"
+"target" "t11"
+"angle" "90"
+}
+{
+"classname" "target_changelevel"
+"map" "mine3$mine2b"
+"targetname" "t11"
+"origin" "-280 -280 -288"
+}
+{
+"model" "*46"
+"classname" "trigger_multiple"
+"target" "t10"
+"angle" "270"
+}
+{
+"classname" "target_changelevel"
+"map" "mine1$mine2"
+"targetname" "t10"
+"origin" "976 -1040 -48"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "1640 1104 -344"
+}
+{
+"light" "200"
+"classname" "light"
+"origin" "2128 1088 -72"
+}
+{
+"origin" "812 680 -252"
+"classname" "light"
+"light" "100"
+}
+{
+"classname" "light"
+"light" "200"
+"origin" "-680 808 -208"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-696 936 -320"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-744 936 -320"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "-744 672 -320"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "-696 672 -320"
+}
+{ // b#2: swapped with mine3c's spot
+"origin" "954 -898 -64"
+"angle" "90"
+"classname" "info_player_start"
+"targetname" "mine1"
+}
+{
+"classname" "info_player_start"
+"angle" "270"
+"targetname" "mine3b"
+"origin" "-248 -448 -336"
+}
+{
+"classname" "info_player_start"
+"angle" "270"
+"targetname" "mine3a"
+"origin" "352 -312 -528"
+}
+{
+"origin" "1287 1818 -588"
+"light" "125"
+"classname" "light"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "2144 1568 -640"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "2096 1432 -672"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1920 1432 -672"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1920 1608 -672"
+}
+{
+"model" "*47"
+"target" "t89"
+"team" "d4"
+"angle" "180"
+"classname" "func_door"
+"_minlight" ".18"
+}
+{
+"origin" "-248 -260 -280"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-248 -552 -280"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-252 -444 -280"
+"light" "100"
+"classname" "light"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "176 872 -172"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "176 944 -172"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "172 732 -160"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "172 660 -160"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-796 800 -12"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "16 664 -272"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "16 976 -216"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "16 632 -216"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "200 800 -216"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-96 800 -272"
+}
+{
+"model" "*48"
+"origin" "16 800 -324"
+"dmg" "10"
+"targetname" "t16"
+"classname" "func_rotating"
+"spawnflags" "2064"
+"speed" "400"
+"_minlight" ".05"
+}
+{
+"origin" "584 1160 -296"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "888 1096 -272"
+"classname" "light"
+"light" "100"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "904 1448 -312"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1016 1472 -312"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1904 1208 -312"
+}
+{
+"origin" "1860 548 -16"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "1860 404 -16"
+}
+{
+"origin" "1568 360 -88"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1096 1352 -312"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1096 1352 -248"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "792 1392 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "1256 1392 -272"
+"classname" "light"
+"light" "80"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "1072 1440 -464"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "1304 1440 -464"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1288 1648 -432"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1280 1672 -272"
+}
+{
+"origin" "1400 1536 -464"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "896 1432 -464"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1224 1320 -600"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1224 1320 -496"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "864 1416 -608"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "864 1504 -608"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "984 1376 -608"
+"light" "120"
+"classname" "light"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "792 1336 -320"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "992 1336 -320"
+}
+{
+"origin" "1376 2112 -576"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "1448 1880 -576"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "1480 2040 -624"
+"classname" "light"
+"light" "48"
+}
+{
+"origin" "1480 2112 -624"
+"light" "48"
+"classname" "light"
+}
+{
+"origin" "1251 1814 -644"
+"classname" "light"
+"light" "32"
+}
+{
+"origin" "1251 1822 -544"
+"light" "32"
+"classname" "light"
+}
+{
+"origin" "1335 1830 -544"
+"classname" "light"
+"light" "48"
+}
+{
+"origin" "1335 1830 -644"
+"light" "48"
+"classname" "light"
+}
+{
+"origin" "1352 1504 -280"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1440 1576 -280"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "1264 1536 -272"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1104 1496 -432"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1360 1784 -272"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "1440 1704 -280"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1272 1488 -280"
+"light" "120"
+"classname" "light"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "1520 1784 -272"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1120 1536 -272"
+}
+{
+"origin" "792 1416 -272"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "808 1336 -464"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "992 1336 -464"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "1440 1408 -272"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1368 1408 -272"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "1440 2096 -320"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1800 2096 -320"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "2144 2096 -320"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "2144 1768 -320"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1440 1912 -320"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "2096 1624 -344"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "2184 1624 -344"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "2184 1512 -344"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "2096 1512 -344"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "2096 1384 -344"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "2184 1384 -344"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "2096 1384 -392"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "2184 1384 -392"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "2184 1512 -392"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "2184 1624 -392"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "2096 1624 -392"
+"classname" "light"
+"light" "64"
+}
+{
+"origin" "2096 1512 -392"
+"light" "64"
+"classname" "light"
+}
+{
+"origin" "2048 1352 -344"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "2232 1352 -344"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "1416 456 -432"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1440 284 -480"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1248 284 -480"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1272 456 -432"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "1336 712 -496"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "1432 536 -448"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "1240 544 -448"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "1248 856 -448"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1440 848 -448"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "1472 720 -496"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1472 776 -496"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "1160 760 -496"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1160 704 -496"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "1640 1112 -240"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "1328 776 -240"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1328 776 -80"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1328 776 72"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "1328 776 -376"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "175"
+"origin" "2004 888 -268"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "2032 1204 -240"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "2204 1200 -240"
+}
+{
+"origin" "1872 1112 -312"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "1824 1208 -312"
+"light" "80"
+"classname" "light"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "1760 1112 -344"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "1640 1216 -344"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "1528 1104 -344"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "1640 992 -344"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1800 752 -248"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1752 864 -248"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1752 992 -248"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1776 1208 -248"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1808 1112 -248"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1568 928 -40"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1568 928 -184"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1768 648 -248"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "2172 1180 -296"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "2092 1180 -296"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1920 1136 -112"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "1840 1136 -112"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1584 896 -312"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1584 976 -312"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "1792 928 -72"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1704 928 -104"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1904 656 -104"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1776 656 -104"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1952 640 -296"
+}
+{
+"classname" "light"
+"light" "64"
+"origin" "2064 640 -296"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "2224 664 -160"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "2200 808 -248"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "2176 968 -304"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "2064 656 -112"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "1896 216 -96"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1860 548 -144"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "1648 352 -88"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1688 296 -88"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "1632 368 32"
+}
+{
+"origin" "-240 -664 -304"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "88 -488 -440"
+"light" "125"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "356 -310 -472"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "352 -418 -472"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-240 -664 -232"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-104 -664 -280"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "352 -126 -472"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "608 -480 -440"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "24 -664 -240"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "608 -480 -216"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "88 -488 -216"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "352 -456 -536"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "192 -884 -404"
+}
+{
+"origin" "72 -884 -404"
+"classname" "light"
+"light" "125"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "536 -892 -404"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "120 -876 -84"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "352 -832 0"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "352 -832 -232"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "352 -832 -456"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "352 -832 -584"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "352 -832 -344"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "696 -744 -256"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "696 -672 -256"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "696 -608 -256"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "696 -544 -256"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "8 -672 -512"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "416 -392 -256"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "352 -392 -256"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "288 -392 -256"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "8 -608 -512"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "8 -544 -512"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "8 -744 -512"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "260 -452 -612"
+}
+{
+"origin" "1352 328 216"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "952 -888 -12"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "948 -1084 -12"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "948 -804 -12"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "720 664 -312"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "816 864 -284"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "680 864 -284"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "812 680 -328"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "708 680 -292"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "732 816 -284"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t6"
+"target" "t7"
+"origin" "-1200 768 -456"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t7"
+"target" "t8"
+"origin" "-672 764 -444"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t5"
+"target" "t6"
+"origin" "-1200 768 248"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t4"
+"target" "t5"
+"origin" "-952 764 248"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t3"
+"target" "t4"
+"origin" "-952 764 -104"
+}
+{
+"pathtarget" "backit2"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t2"
+"target" "t3"
+"origin" "-516 768 -104"
+}
+{
+"pathtarget" "backit1"
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"targetname" "t1"
+"target" "t2"
+"origin" "-516 768 -676"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048" // b#6: added this
+"target" "t1"
+"targetname" "t8"
+"origin" "-672 764 -676"
+}
+{
+"origin" "608 936 -296"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "432 664 -296"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "448 872 -296"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "272 648 -344"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "272 968 -344"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "16 808 -392"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-128 1000 -392"
+"classname" "light"
+"light" "150"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-128 640 -392"
+}
+{
+"light" "64"
+"classname" "light"
+"origin" "648 1160 -296"
+}
+{
+"origin" "-664 704 0"
+"light" "130"
+"classname" "light"
+}
+{
+"origin" "-656 896 0"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-736 872 -224"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-456 904 0"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-448 744 -240"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-456 904 -240"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-424 736 -480"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-432 896 -480"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-744 680 -224"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-288 864 -392"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-360 936 -392"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "-448 744 0"
+"light" "150"
+"classname" "light"
+}
+{ // b#2: swapped with mine1's spot
+"classname" "info_player_start"
+"angle" "0"
+"targetname" "mine3c"
+"origin" "-896 800 -360"
+}
+{
+"model" "*49"
+"team" "d5"
+"spawnflags" "8"
+"classname" "func_door"
+"angle" "0"
+"target" "t149"
+"_minlight" ".18"
+}
+{
+"model" "*50"
+"origin" "1326 779 207"
+"_minlight" ".3"
+"speed" "400"
+"spawnflags" "1"
+"classname" "func_rotating"
+}
+{
+"model" "*51"
+"angle" "270"
+"classname" "func_door"
+"team" "td13"
+"_minlight" ".18"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "952 -600 -16"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "968 1536 -576"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "896 1216 -272"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "896 1360 -248"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1176 1400 -272"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "2072 1008 -296"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "1872 808 -296"
+}
+{
+"light" "175"
+"classname" "light"
+"origin" "1872 1016 -296"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "2064 856 -296"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1852 196 -16"
+}
+{
+"origin" "792 1080 -272"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1448 1800 -240"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "1424 1752 -576"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "1200 1704 -576"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "1328 1528 -576"
+"classname" "light"
+"light" "200"
+}
+{
+"origin" "1080 1360 -576"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "720 1448 -576"
+"classname" "light"
+"light" "100"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "968 1512 -272"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1340 328 128"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1336 120 216"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1344 -88 216"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1344 -256 216"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "1344 -256 -16"
+}
+{
+"origin" "944 -432 -16"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "960 -264 -16"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "1104 -256 -16"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "1344 -88 -16"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "1224 184 -16"
+"classname" "light"
+"light" "175"
+}
+{
+"origin" "1448 184 -16"
+"classname" "light"
+"light" "175"
+}
+{
+"origin" "1624 184 -16"
+"classname" "light"
+"light" "175"
+}
+{
+"origin" "1860 404 -144"
+"classname" "light"
+"light" "80"
+}
+{
+"model" "*52"
+"spawnflags" "1"
+"classname" "func_plat"
+"_minlight" ".18"
+}
+{
+"origin" "584 -856 -84"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "656 -892 -404"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "636 -816 20"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "628 -520 20"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "256 -452 20"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "60 -812 20"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "60 -576 20"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "632 -520 -612"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "440 -444 20"
+"classname" "light"
+"light" "150"
+}
+{
+"origin" "460 -460 -612"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "64 -576 -612"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "64 -812 -612"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "640 -816 -612"
+"classname" "light"
+"light" "125"
+}
+{
+"model" "*53"
+"target" "t88"
+"spawnflags" "8"
+"team" "d3"
+"classname" "func_door"
+"angle" "180"
+"_minlight" ".18"
+}
+{
+"origin" "1928 920 -208"
+"classname" "light"
+"light" "150"
+}
+{
+"classname" "light"
+"origin" "1632 1112 -684"
+"light" "125"
+}
+{
+"light" "175"
+"origin" "1560 1104 -616"
+"classname" "light"
+}
+{
+"origin" "2120 920 -72"
+"classname" "light"
+"light" "250"
+}
+{
+"classname" "light"
+"origin" "1936 1488 -216"
+"light" "150"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "2136 1624 -208"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "2136 1352 -208"
+}
+{
+"classname" "light"
+"origin" "1640 1104 0"
+"light" "150"
+}


### PR DESCRIPTION
Here are some more mapfixes for mine1 (Upper Mines), mine2 (Lower Mines) and jail2 (Detention Center).

Fixes for mine1:
* Added missing target names to `info_player_coop` entities
  This fixes one of the spawnpoints that is too far away from the info_player_start
  for the code hack to work
* Swapped `info_player_start` entities to fix wrong spawn location from console
* Added spawnflag 1 to 4x ambient `target_speaker`
* Removed unused entities/fields and optimized some trigger chains
* Moved secret message from trigger to `target_secret`
* Added spawnflag 2048 to SP/co-op entities
* Added difficulty spawnflags to monster-related entities
* Fix `target_splash` near quad secret appearing in DM
* Moved triggered monster_mutant down a bit

Fixes for mine2:
* Added missing target names to info_player_coop
* Swapped info_player_start entities for correct console start location
* Added missing targetname to target_speaker for func_train pathtarget
* Added missing spawnflag 1 to ambient target_speaker entities
* Removed unused entities and optimized some trigger chains
* Added missing 256-2048 spawnflags to some entities
* Moved triggered monster_gunner down a bit to avoid thud sound

Fixes for jail2:
* Fixed incorrect targetname for 3x info_player_coop
* Added missing targetname to info_player_start
* Added spawnflag 1 to target_speaker
* Fixed silent elevator at level start
* Added missing spawnflag 256-2048 to some entities
* Removed unused fields/entities

I have tested these and they seem to work, but more playtests from others would be good, and if you know of any other bugs with these maps I didn't cover I can add them.