### PR TITLE
Revert GL1 big lightmaps (#1108) + fixes

### DIFF
--- a/.github/workflows/win32.yml
+++ b/.github/workflows/win32.yml
@@ -66,8 +66,8 @@ jobs:
         cp doc/080_contributing.md publish/quake2-win32-${{github.sha}}/misc/docs/080_contributing.txt
         cp doc/090_filelists.md publish/quake2-win32-${{github.sha}}/misc/docs/090_filelists.md
         # SDL2
-        wget -c https://github.com/libsdl-org/SDL/releases/download/release-2.32.0/SDL2-2.32.0-win32-x86.zip
-        unzip -o SDL2-2.32.0-win32-x86.zip
+        wget -c https://github.com/libsdl-org/SDL/releases/download/release-2.32.8/SDL2-2.32.8-win32-x86.zip
+        unzip -o SDL2-2.32.8-win32-x86.zip
         cp SDL2.dll publish/quake2-win32-${{github.sha}}/
         # openal-soft
         wget -c https://github.com/kcat/openal-soft/releases/download/1.23.1/openal-soft-1.23.1-bin.zip

--- a/.github/workflows/win64.yml
+++ b/.github/workflows/win64.yml
@@ -68,8 +68,8 @@ jobs:
         cp doc/080_contributing.md publish/quake2-win64-${{github.sha}}/misc/docs/080_contributing.txt
         cp doc/090_filelists.md publish/quake2-win64-${{github.sha}}/misc/docs/090_filelists.md
         # SDL3
-        wget -c https://github.com/libsdl-org/SDL/releases/download/release-3.2.4/SDL3-3.2.4-win32-x64.zip
-        unzip -o SDL3-3.2.4-win32-x64.zip
+        wget -c https://github.com/libsdl-org/SDL/releases/download/release-3.2.16/SDL3-3.2.16-win32-x64.zip
+        unzip -o SDL3-3.2.16-win32-x64.zip
         cp SDL3.dll publish/quake2-win64-${{github.sha}}/
         # openal-soft
         wget -c https://github.com/kcat/openal-soft/releases/download/1.23.1/openal-soft-1.23.1-bin.zip

--- a/src/client/refresh/gl1/gl1_buffer.c
+++ b/src/client/refresh/gl1/gl1_buffer.c
@@ -183,7 +183,7 @@ R_ApplyGLBuffer(void)
 			if (gl_config.lightmapcopies)
 			{
 				// Bind appropiate lightmap copy for this frame
-				lmtexture += gl_state.max_lightmaps * cur_lm_copy;
+				lmtexture += MAX_LIGHTMAPS * cur_lm_copy;
 			}
 			R_MBind(GL_TEXTURE1, lmtexture);
 

--- a/src/client/refresh/gl1/gl1_image.c
+++ b/src/client/refresh/gl1/gl1_image.c
@@ -31,7 +31,7 @@ int numgltextures;
 static int image_max = 0;
 int base_textureid; /* gltextures[i] = base_textureid+i */
 extern qboolean scrap_dirty;
-extern byte *scrap_texels[MAX_SCRAPS];
+extern byte scrap_texels[MAX_SCRAPS][SCRAP_WIDTH * SCRAP_HEIGHT];
 
 static byte intensitytable[256];
 static unsigned char gammatable[256];
@@ -1028,17 +1028,17 @@ R_LoadPic(const char *name, byte *pic, int width, int realwidth,
 
 			for (j = 0; j < image->width; j++, k++)
 			{
-				scrap_texels[texnum][(y + i) * gl_state.scrap_width + x + j] = pic[k];
+				scrap_texels[texnum][(y + i) * SCRAP_WIDTH + x + j] = pic[k];
 			}
 		}
 
 		image->texnum = TEXNUM_SCRAPS + texnum;
 		image->scrap = true;
 		image->has_alpha = true;
-		image->sl = (float)x / gl_state.scrap_width;
-		image->sh = (float)(x + image->width) / gl_state.scrap_width;
-		image->tl = (float)y / gl_state.scrap_height;
-		image->th = (float)(y + image->height) / gl_state.scrap_height;
+		image->sl = (float)x / SCRAP_WIDTH;
+		image->sh = (float)(x + image->width) / SCRAP_WIDTH;
+		image->tl = (float)y / SCRAP_HEIGHT;
+		image->th = (float)(y + image->height) / SCRAP_HEIGHT;
 	}
 	else
 	{

--- a/src/client/refresh/gl1/gl1_image.c
+++ b/src/client/refresh/gl1/gl1_image.c
@@ -29,14 +29,13 @@
 image_t gltextures[MAX_GLTEXTURES];
 int numgltextures;
 static int image_max = 0;
-int base_textureid; /* gltextures[i] = base_textureid+i */
 extern qboolean scrap_dirty;
 extern byte scrap_texels[MAX_SCRAPS][SCRAP_WIDTH * SCRAP_HEIGHT];
 
 static byte intensitytable[256];
 static unsigned char gammatable[256];
 
-cvar_t *intensity;
+static cvar_t *intensity;
 
 unsigned d_8to24table[256];
 
@@ -44,8 +43,8 @@ qboolean R_Upload8(byte *data, int width, int height,
 		qboolean mipmap, qboolean is_sky);
 qboolean R_Upload32(unsigned *data, int width, int height, qboolean mipmap);
 
-int gl_solid_format = GL_RGB;
-int gl_alpha_format = GL_RGBA;
+#define Q2_GL_SOLID_FORMAT GL_RGB
+#define Q2_GL_ALPHA_FORMAT GL_RGBA
 
 #ifdef YQ2_GL1_GLES
 #define DEFAULT_SOLID_FORMAT GL_RGBA
@@ -144,8 +143,8 @@ typedef struct
 		} \
 	}
 
-int upload_width, upload_height;
-qboolean uploaded_paletted;
+static int upload_width, upload_height;
+static qboolean uploaded_paletted;
 
 void
 R_SetTexturePalette(const unsigned palette[256])
@@ -635,7 +634,7 @@ R_Upload32Native(unsigned *data, int width, int height, qboolean mipmap)
 
 	c = width * height;
 	scan = ((byte *)data) + 3;
-	samples = gl_solid_format;
+	samples = Q2_GL_SOLID_FORMAT;
 	comp = gl_tex_solid_format;
 	upload_width = width;
 	upload_height = height;
@@ -646,7 +645,7 @@ R_Upload32Native(unsigned *data, int width, int height, qboolean mipmap)
 	{
 		if (*scan != 255)
 		{
-			samples = gl_alpha_format;
+			samples = Q2_GL_ALPHA_FORMAT;
 			comp = gl_tex_alpha_format;
 			break;
 		}
@@ -656,7 +655,7 @@ R_Upload32Native(unsigned *data, int width, int height, qboolean mipmap)
 			height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
 			data);
 	glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, false);
-	return samples == gl_alpha_format;
+	return samples == Q2_GL_ALPHA_FORMAT;
 }
 
 
@@ -725,20 +724,20 @@ R_Upload32Soft(unsigned *data, int width, int height, qboolean mipmap)
 	if (scaled_width * scaled_height > sizeof(scaled) / 4)
 	{
 		// this can't really happen (because they're clamped to 256 above), but whatever
-		ri.Sys_Error(ERR_DROP, "R_Upload32: too big");
+		ri.Sys_Error(ERR_DROP, "%s: too big", __func__);
 	}
 
 	/* scan the texture for any non-255 alpha */
 	c = width * height;
 	scan = ((byte *)data) + 3;
-	samples = gl_solid_format;
+	samples = Q2_GL_SOLID_FORMAT;
 	comp = gl_tex_solid_format;
 
 	for (i = 0; i < c; i++, scan += 4)
 	{
 		if (*scan != 255)
 		{
-			samples = gl_alpha_format;
+			samples = Q2_GL_ALPHA_FORMAT;
 			comp = gl_tex_alpha_format;
 			break;
 		}
@@ -749,7 +748,7 @@ R_Upload32Soft(unsigned *data, int width, int height, qboolean mipmap)
 		if (!mipmap)
 		{
 			if (qglColorTableEXT && gl1_palettedtexture->value &&
-				(samples == gl_solid_format))
+				(samples == Q2_GL_SOLID_FORMAT))
 			{
 				uploaded_paletted = true;
 				R_BuildPalettedTexture(paletted_texture, (unsigned char *)data,
@@ -779,7 +778,7 @@ R_Upload32Soft(unsigned *data, int width, int height, qboolean mipmap)
 	R_LightScaleTexture(scaled, scaled_width, scaled_height, !mipmap);
 
 	if (qglColorTableEXT && gl1_palettedtexture->value &&
-		(samples == gl_solid_format))
+		(samples == Q2_GL_SOLID_FORMAT))
 	{
 		uploaded_paletted = true;
 		R_BuildPalettedTexture(paletted_texture, (unsigned char *)scaled,
@@ -820,7 +819,7 @@ R_Upload32Soft(unsigned *data, int width, int height, qboolean mipmap)
 			miplevel++;
 
 			if (qglColorTableEXT && gl1_palettedtexture->value &&
-				(samples == gl_solid_format))
+				(samples == Q2_GL_SOLID_FORMAT))
 			{
 				uploaded_paletted = true;
 				R_BuildPalettedTexture(paletted_texture, (unsigned char *)scaled,
@@ -839,7 +838,7 @@ R_Upload32Soft(unsigned *data, int width, int height, qboolean mipmap)
 
 done:
 
-	return samples == gl_alpha_format;
+	return samples == Q2_GL_ALPHA_FORMAT;
 }
 
 qboolean
@@ -977,7 +976,7 @@ R_LoadPic(const char *name, byte *pic, int width, int realwidth,
 	{
 		if (numgltextures == MAX_GLTEXTURES)
 		{
-			ri.Sys_Error(ERR_DROP, "MAX_GLTEXTURES");
+			ri.Sys_Error(ERR_DROP, "%s: MAX_GLTEXTURES", __func__);
 		}
 
 		numgltextures++;

--- a/src/client/refresh/gl1/gl1_lightmap.c
+++ b/src/client/refresh/gl1/gl1_lightmap.c
@@ -56,8 +56,8 @@ LM_AllocLightmapBuffer(int buffer, qboolean clean)
 	}
 	if (!gl_lms.lightmap_buffer[buffer])
 	{
-		ri.Sys_Error(ERR_FATAL, "Could not allocate lightmap buffer %d\n",
-			buffer);
+		ri.Sys_Error(ERR_FATAL, "%s: Could not allocate lightmap buffer %d\n",
+			__func__, buffer);
 	}
 	if (clean)
 	{
@@ -126,7 +126,7 @@ LM_UploadBlock(qboolean dynamic)
 		if (++gl_lms.current_lightmap_texture == MAX_LIGHTMAPS)
 		{
 			ri.Sys_Error(ERR_DROP,
-					"LM_UploadBlock() - MAX_LIGHTMAPS exceeded\n");
+					"%s: MAX_LIGHTMAPS exceeded\n", __func__);
 		}
 	}
 }
@@ -269,8 +269,8 @@ LM_CreateSurfaceLightmap(msurface_t *surf)
 
 		if (!LM_AllocBlock(smax, tmax, &surf->light_s, &surf->light_t))
 		{
-			ri.Sys_Error(ERR_FATAL, "Consecutive calls to LM_AllocBlock(%d,%d) failed\n",
-					smax, tmax);
+			ri.Sys_Error(ERR_FATAL, "%s: Consecutive calls to LM_AllocBlock(%d,%d) failed\n",
+					__func__, smax, tmax);
 		}
 	}
 

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -148,7 +148,6 @@ static cvar_t *gl1_waterwarp;
 refimport_t ri;
 
 void LM_FreeLightmapBuffers(void);
-void Scrap_Free(void);
 void Scrap_Init(void);
 
 extern void R_SetDefaultState(void);
@@ -1759,20 +1758,6 @@ RI_Init(void)
 
 	// ----
 
-	/* Big lightmaps: this used to be fast, but after the implementation of the "GL Buffer", it
-	 * became too evident that the bigger the texture, the slower the call to glTexSubImage2D() is.
-	 * Original logic remains, but it's preferable not to make it visible to the user.
-	 * Let's see if something changes in the future.
-	 */
-
-	gl_state.block_width = BLOCK_WIDTH;
-	gl_state.block_height = BLOCK_HEIGHT;
-	gl_state.max_lightmaps = MAX_LIGHTMAPS;
-	gl_state.scrap_width = BLOCK_WIDTH * 2;
-	gl_state.scrap_height = BLOCK_HEIGHT * 2;
-
-	// ----
-
 	R_ResetClearColor();
 	R_SetDefaultState();
 
@@ -1795,7 +1780,6 @@ RI_Shutdown(void)
 	ri.Cmd_RemoveCommand("gl_strings");
 
 	LM_FreeLightmapBuffers();
-	Scrap_Free();
 	Mod_FreeAll();
 
 	R_ShutdownImages();

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -730,7 +730,7 @@ void
 R_SetPerspective(GLdouble fovy)
 {
 	// gluPerspective style parameters
-	static const GLdouble zNear = 4;
+	static const GLdouble zNear = 2;
 	const GLdouble zFar = (r_farsee->value) ? 8192.0f : 4096.0f;
 	const GLdouble aspectratio = (GLdouble)r_newrefdef.width / r_newrefdef.height;
 

--- a/src/client/refresh/gl1/gl1_scrap.c
+++ b/src/client/refresh/gl1/gl1_scrap.c
@@ -27,8 +27,8 @@
 
 #include "header/local.h"
 
-int *scrap_allocated[MAX_SCRAPS];
-byte *scrap_texels[MAX_SCRAPS];
+static int scrap_allocated[MAX_SCRAPS][SCRAP_WIDTH];
+byte scrap_texels[MAX_SCRAPS][SCRAP_WIDTH * SCRAP_HEIGHT];
 qboolean scrap_dirty;
 
 qboolean R_Upload8(byte *data,
@@ -49,9 +49,9 @@ Scrap_AllocBlock(int w, int h, int *x, int *y)
 
 	for (texnum = 0; texnum < MAX_SCRAPS; texnum++)
 	{
-		best = gl_state.scrap_height;
+		best = SCRAP_HEIGHT;
 
-		for (i = 0; i < gl_state.scrap_width - w; i++)
+		for (i = 0; i < SCRAP_WIDTH - w; i++)
 		{
 			best2 = 0;
 
@@ -75,7 +75,7 @@ Scrap_AllocBlock(int w, int h, int *x, int *y)
 			}
 		}
 
-		if (best + h > gl_state.scrap_height)
+		if (best + h > SCRAP_HEIGHT)
 		{
 			continue;
 		}
@@ -97,57 +97,14 @@ void
 Scrap_Upload(void)
 {
 	R_Bind(TEXNUM_SCRAPS);
-	R_Upload8(scrap_texels[0], gl_state.scrap_width,
-			gl_state.scrap_height, false, false);
+	R_Upload8(scrap_texels[0], SCRAP_WIDTH, SCRAP_HEIGHT, false, false);
 	scrap_dirty = false;
-}
-
-void
-Scrap_Free(void)
-{
-	for (int i = 0; i < MAX_SCRAPS; i++)
-	{
-		if (scrap_allocated[i])
-		{
-			free(scrap_allocated[i]);
-		}
-		scrap_allocated[i] = NULL;
-
-		if (scrap_texels[i])
-		{
-			free(scrap_texels[i]);
-		}
-		scrap_texels[i] = NULL;
-	}
 }
 
 void
 Scrap_Init(void)
 {
-	const unsigned int allocd_size = gl_state.scrap_width * sizeof(int);
-	const unsigned int texels_size = gl_state.scrap_width
-			* gl_state.scrap_height * sizeof(byte);
-	int i;
-
-	Scrap_Free();
-
-	for (i = 0; i < MAX_SCRAPS; i++)
-	{
-		if (!scrap_allocated[i])
-		{
-			scrap_allocated[i] = malloc (allocd_size) ;
-		}
-		if (!scrap_texels[i])
-		{
-			scrap_texels[i] = malloc (texels_size) ;
-		}
-
-		if (!scrap_allocated[i] || !scrap_texels[i])
-		{
-			ri.Sys_Error(ERR_FATAL, "Could not allocate scrap memory.\n");
-		}
-		memset (scrap_allocated[i], 0, allocd_size);	// empty
-		memset (scrap_texels[i], 255, texels_size);	// transparent
-	}
+	memset (scrap_allocated, 0, sizeof(scrap_allocated));	// empty
+	memset (scrap_texels, 255, sizeof(scrap_texels));	// transparent
 }
 

--- a/src/client/refresh/gl1/gl1_surf.c
+++ b/src/client/refresh/gl1/gl1_surf.c
@@ -95,7 +95,7 @@ R_DrawTriangleOutlines(void)
 	glDisable(GL_DEPTH_TEST);
 	glColor4f(1, 1, 1, 1);
 
-	for (i = 0; i < gl_state.max_lightmaps; i++)
+	for (i = 0; i < MAX_LIGHTMAPS; i++)
 	{
 		msurface_t *surf;
 
@@ -247,7 +247,7 @@ R_BlendLightmaps(const model_t *currentmodel)
 	}
 
 	/* render static lightmaps first */
-	for (i = 1; i < gl_state.max_lightmaps; i++)
+	for (i = 1; i < MAX_LIGHTMAPS; i++)
 	{
 		if (gl_lms.lightmap_surfaces[i])
 		{
@@ -304,10 +304,10 @@ R_BlendLightmaps(const model_t *currentmodel)
 			if (LM_AllocBlock(smax, tmax, &surf->dlight_s, &surf->dlight_t))
 			{
 				base = gl_lms.lightmap_buffer[0];
-				base += (surf->dlight_t * gl_state.block_width +
+				base += (surf->dlight_t * BLOCK_WIDTH +
 						surf->dlight_s) * LIGHTMAP_BYTES;
 
-				R_BuildLightMap(surf, base, gl_state.block_width * LIGHTMAP_BYTES);
+				R_BuildLightMap(surf, base, BLOCK_WIDTH * LIGHTMAP_BYTES);
 			}
 			else
 			{
@@ -331,8 +331,8 @@ R_BlendLightmaps(const model_t *currentmodel)
 						}
 
 						R_DrawGLPolyChain(drawsurf->polys,
-								(drawsurf->light_s - drawsurf->dlight_s) * (1.0 / (float)gl_state.block_width),
-								(drawsurf->light_t - drawsurf->dlight_t) * (1.0 / (float)gl_state.block_height));
+								(drawsurf->light_s - drawsurf->dlight_s) * (float)(1.0 / BLOCK_WIDTH),
+								(drawsurf->light_t - drawsurf->dlight_t) * (float)(1.0 / BLOCK_HEIGHT));
 					}
 				}
 
@@ -350,10 +350,10 @@ R_BlendLightmaps(const model_t *currentmodel)
 				}
 
 				base = gl_lms.lightmap_buffer[0];
-				base += (surf->dlight_t * gl_state.block_width +
+				base += (surf->dlight_t * BLOCK_WIDTH +
 						surf->dlight_s) * LIGHTMAP_BYTES;
 
-				R_BuildLightMap(surf, base, gl_state.block_width * LIGHTMAP_BYTES);
+				R_BuildLightMap(surf, base, BLOCK_WIDTH * LIGHTMAP_BYTES);
 			}
 		}
 
@@ -375,8 +375,8 @@ R_BlendLightmaps(const model_t *currentmodel)
 				}
 
 				R_DrawGLPolyChain(surf->polys,
-						(surf->light_s - surf->dlight_s) * (1.0 / (float)gl_state.block_width),
-						(surf->light_t - surf->dlight_t) * (1.0 / (float)gl_state.block_height));
+						(surf->light_s - surf->dlight_s) * (float)(1.0 / BLOCK_WIDTH),
+						(surf->light_t - surf->dlight_t) * (float)(1.0 / BLOCK_HEIGHT));
 			}
 		}
 	}
@@ -605,14 +605,14 @@ R_RegenAllLightmaps()
 	if (gl_config.lightmapcopies)
 	{
 		cur_lm_copy = (cur_lm_copy + 1) % MAX_LIGHTMAP_COPIES;	// select the next lightmap copy
-		lmtex = gl_state.max_lightmaps * cur_lm_copy;	// ...and its corresponding texture
+		lmtex = MAX_LIGHTMAPS * cur_lm_copy;	// ...and its corresponding texture
 	}
 	else
 	{
 		lmtex = 0;
 	}
 
-	for (i = 1; i < gl_state.max_lightmaps; i++)
+	for (i = 1; i < MAX_LIGHTMAPS; i++)
 	{
 		if (!gl_lms.lightmap_surfaces[i] || !gl_lms.lightmap_buffer[i])
 		{
@@ -620,8 +620,8 @@ R_RegenAllLightmaps()
 		}
 
 		affected_lightmap = false;
-		best.top = gl_state.block_height;
-		best.left = gl_state.block_width;
+		best.top = BLOCK_HEIGHT;
+		best.left = BLOCK_WIDTH;
 		best.bottom = best.right = 0;
 
 		for (surf = gl_lms.lightmap_surfaces[i];
@@ -661,9 +661,9 @@ dynamic_surf:
 			current.bottom = surf->light_t + tmax;
 
 			base = gl_lms.lightmap_buffer[i];
-			base += (current.top * gl_state.block_width + current.left) * LIGHTMAP_BYTES;
+			base += (current.top * BLOCK_WIDTH + current.left) * LIGHTMAP_BYTES;
 
-			R_BuildLightMap(surf, base, gl_state.block_width * LIGHTMAP_BYTES);
+			R_BuildLightMap(surf, base, BLOCK_WIDTH * LIGHTMAP_BYTES);
 
 			if ( ((surf->styles[map] >= 32) || (surf->styles[map] == 0))
 				&& (surf->dlightframe != r_framecount) )
@@ -711,7 +711,7 @@ dynamic_surf:
 #ifndef YQ2_GL1_GLES
 		if (!pixelstore_set)
 		{
-			glPixelStorei(GL_UNPACK_ROW_LENGTH, gl_state.block_width);
+			glPixelStorei(GL_UNPACK_ROW_LENGTH, BLOCK_WIDTH);
 			pixelstore_set = true;
 		}
 #endif
@@ -720,15 +720,15 @@ dynamic_surf:
 		base = gl_lms.lightmap_buffer[i];
 
 #ifdef YQ2_GL1_GLES
-		base += (best.top * gl_state.block_width) * LIGHTMAP_BYTES;
+		base += (best.top * BLOCK_WIDTH) * LIGHTMAP_BYTES;
 
 		R_Bind(gl_state.lightmap_textures + i + lmtex);
 
 		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, best.top,
-			gl_state.block_width, best.bottom - best.top,
+			BLOCK_WIDTH, best.bottom - best.top,
 			GL_LIGHTMAP_FORMAT, GL_UNSIGNED_BYTE, base);
 #else
-		base += (best.top * gl_state.block_width + best.left) * LIGHTMAP_BYTES;
+		base += (best.top * BLOCK_WIDTH + best.left) * LIGHTMAP_BYTES;
 
 		R_Bind(gl_state.lightmap_textures + i + lmtex);
 

--- a/src/client/refresh/gl1/gl1_surf.c
+++ b/src/client/refresh/gl1/gl1_surf.c
@@ -345,8 +345,8 @@ R_BlendLightmaps(const model_t *currentmodel)
 				if (!LM_AllocBlock(smax, tmax, &surf->dlight_s, &surf->dlight_t))
 				{
 					ri.Sys_Error(ERR_FATAL,
-							"Consecutive calls to LM_AllocBlock(%d,%d) failed (dynamic)\n",
-							smax, tmax);
+							"%s: Consecutive calls to LM_AllocBlock(%d,%d) failed (dynamic)\n",
+							__func__, smax, tmax);
 				}
 
 				base = gl_lms.lightmap_buffer[0];

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -246,10 +246,6 @@ extern cvar_t *gl_msaa_samples;
 extern cvar_t *vid_fullscreen;
 extern cvar_t *vid_gamma;
 
-extern cvar_t *intensity;
-
-extern int gl_solid_format;
-extern int gl_alpha_format;
 extern int gl_tex_solid_format;
 extern int gl_tex_alpha_format;
 
@@ -258,7 +254,6 @@ extern int c_visible_textures;
 
 extern float r_world_matrix[16];
 
-void R_TranslatePlayerSkin(int playernum);
 qboolean R_Bind(int texnum);
 
 void R_TexEnv(GLenum value);
@@ -299,8 +294,6 @@ void R_MarkSurfaceLights(dlight_t *light, int bit, mnode_t *node,
 	int lightframecount);
 
 void COM_StripExtension(char *in, char *out);
-
-void R_SwapBuffers(int);
 
 image_t *R_LoadPic(const char *name, byte *pic, int width, int realwidth,
 		int height, int realheight, size_t data_size, imagetype_t type, int bits);

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -52,8 +52,10 @@
 #define TEXNUM_SCRAPS (TEXNUM_LIGHTMAPS + MAX_LIGHTMAPS * MAX_LIGHTMAP_COPIES)
 #define TEXNUM_IMAGES (TEXNUM_SCRAPS + MAX_SCRAPS)
 #define MAX_GLTEXTURES 1024
-#define BLOCK_WIDTH 128		// default values; now defined in glstate_t
+#define BLOCK_WIDTH 128
 #define BLOCK_HEIGHT 128
+#define SCRAP_WIDTH (BLOCK_WIDTH * 2)
+#define SCRAP_HEIGHT (BLOCK_HEIGHT * 2)
 #define BACKFACE_EPSILON 0.01
 #define LIGHTMAP_BYTES 4
 #define MAX_TEXTURE_UNITS 2
@@ -450,12 +452,6 @@ typedef struct
 	enum stereo_modes stereo_mode;
 
 	qboolean stencil;
-
-	int	block_width,	// replaces BLOCK_WIDTH
-		block_height,	// replaces BLOCK_HEIGHT
-		max_lightmaps,	// the larger the lightmaps, the fewer the max lightmaps
-		scrap_width,	// size for scrap (atlas of 2D elements)
-		scrap_height;
 } glstate_t;
 
 typedef struct
@@ -464,7 +460,7 @@ typedef struct
 
 	msurface_t *lightmap_surfaces[MAX_LIGHTMAPS];
 
-	int *allocated;		// formerly allocated[BLOCK_WIDTH];
+	int allocated[BLOCK_WIDTH];
 
 	/* the lightmap texture data needs to be kept in
 	   main memory so texsubimage can update properly */

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -1464,7 +1464,7 @@ SetupGL(void)
 	{
 		float screenaspect = (float)gl3_newrefdef.width / gl3_newrefdef.height;
 		float dist = (r_farsee->value == 0) ? 4096.0f : 8192.0f;
-		gl3state.projMat3D = GL3_MYgluPerspective(gl3_newrefdef.fov_y, screenaspect, 4, dist);
+		gl3state.projMat3D = GL3_MYgluPerspective(gl3_newrefdef.fov_y, screenaspect, 2, dist);
 	}
 
 	glCullFace(GL_FRONT);

--- a/src/client/refresh/gl3/gl3_mesh.c
+++ b/src/client/refresh/gl3/gl3_mesh.c
@@ -826,11 +826,11 @@ GL3_DrawAliasModel(entity_t *entity)
 		hmm_mat4 projMat;
 		if (r_gunfov->value < 0)
 		{
-			projMat = GL3_MYgluPerspective(gl3_newrefdef.fov_y, screenaspect, 4, dist);
+			projMat = GL3_MYgluPerspective(gl3_newrefdef.fov_y, screenaspect, 2, dist);
 		}
 		else
 		{
-			projMat = GL3_MYgluPerspective(r_gunfov->value, screenaspect, 4, dist);
+			projMat = GL3_MYgluPerspective(r_gunfov->value, screenaspect, 2, dist);
 		}
 
 		if(gl_lefthand->value == 1.0F)


### PR DESCRIPTION
Was mostly done in #1124, but this PR completes the cleaning job, restoring _classic Q2_ static handling of lightmaps and _scrap_ (atlas for HUD elements).
The work done by commit 4503333b should alleviate what big lightmaps used to do.
Note that the _scrap_ remains at its vanilla Q2 size (256x256), with an additional transparent border for each element inside it.

Additionally, _GL1 multitexturing_ now properly detects when a lightmap's cache reset is needed, fixes #1220 and every surface with more than 2 _static light styles_ (normal, flicker, strobe, pulse, etc.) applied to them.

Also, OpenGL's perspective projection (_frustum_) has been modified; `zNear` is down from `4` to `2` in all GL renderers, GL3 included. Fixes #1231, #1230, #1229, world hunger, and who knows what else.
It just might introduce other visual bugs; we will know soon enough. If it does, please only revert this individual commit: 56b7aa6.