### PR TITLE
Gamma correction for GL1 with SDL3

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -529,6 +529,11 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   "flash" you see when getting injured or picking up an item. In GL1 is
   also used for looking underwater. Default is `1` (enabled).
 
+* **gl_znear**: Sets the distance to the *near depth clipping plane* of
+  the player view. Reducing it may allow some weapon animations to not
+  get "clipped" by the player view (e.g. railgun firing), at the risk
+  of heavy glitches with some hardware configurations. Default is `4`.
+
 * **gl_texturemode**: How textures are filtered.
 
   - `GL_NEAREST`: No filtering (using value of *nearest* source pixel),

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -475,12 +475,12 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
 * **vid_gamma**: The value used for gamma correction. Higher values look
   brighter. The OpenGL 3.2 OpenGL ES3 and Vulkan renderers apply this to
   the window in realtime via shaders (on all platforms). When the game
-  is build against SDL2, the OpenGL 1.4 renderer uses "hardware gamma"
-  when available, increasing the brightness of the whole screen. On
-  MacOS the gamma is applied only at renderer start, so a `vid_restart`
-  is required. When the game is build against SDL3, the OpenGL 1.4
-  renderer doesn't support gamma. Have a look at `gl1_overbrightbits`
-  instead. This is also set by the brightness slider in the video menu.
+  is built against SDL2, the OpenGL 1.4 renderer uses "hardware gamma"
+  when available, increasing the brightness of the whole screen. When
+  the game is built using SDL3, the OpenGL 1.4 renderer requires a
+  `vid_restart` since gamma values are precomputed at renderer start
+  only. On MacOS the situation is similar; `vid_restart` is required.
+  This cvar is also set by the brightness slider in the video menu.
 
 * **vid_fullscreen**: Sets the fullscreen mode. When set to `0` (the
   default) the game runs in window mode. When set to `1` the games

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -447,6 +447,19 @@ ApplyChanges(void *unused)
 	M_ForceMenuOff();
 }
 
+static void
+RestartNeededMsg(void *unused)
+{
+	if (
+#ifdef USE_SDL3
+		Q_stricmp(vid_renderer->string, "gl1") == 0 ||
+#endif
+		Q_stricmp(vid_renderer->string, "gles1") == 0 )
+	{
+		Menu_SetStatusBar(&s_opengl_menu, "apply required");
+	}
+}
+
 void
 VID_MenuInit(void)
 {
@@ -611,6 +624,7 @@ VID_MenuInit(void)
 	s_brightness_slider.generic.name = "brightness";
 	s_brightness_slider.generic.x = 0;
 	s_brightness_slider.generic.y = (y += 10);
+	s_brightness_slider.generic.callback = RestartNeededMsg;
 	s_brightness_slider.cvar = "vid_gamma";
 	s_brightness_slider.minvalue = 0.1f;
 	s_brightness_slider.maxvalue = 2.0f;
@@ -909,6 +923,7 @@ VID_MenuInit(void)
 	Menu_AddItem(&s_opengl_menu, (void *)&s_defaults_action);
 	Menu_AddItem(&s_opengl_menu, (void *)&s_apply_action);
 
+	Menu_SetStatusBar(&s_opengl_menu, NULL);
 	Menu_Center(&s_opengl_menu);
 	s_opengl_menu.x -= 8;
 }

--- a/src/client/refresh/gl1/gl1_buffer.c
+++ b/src/client/refresh/gl1/gl1_buffer.c
@@ -211,7 +211,7 @@ R_ApplyGLBuffer(void)
 	if (color)
 	{
 		glEnableClientState(GL_COLOR_ARRAY);
-		glColorPointer(4, GL_FLOAT, 0, gl_buf.clr);
+		glColorPointer(4, GL_UNSIGNED_BYTE, 0, gl_buf.clr);
 	}
 
 	// All set, we can finally draw

--- a/src/client/refresh/gl1/gl1_light.c
+++ b/src/client/refresh/gl1/gl1_light.c
@@ -638,9 +638,9 @@ store:
 				a = a * t;
 			}
 
-			dest[0] = r;
-			dest[1] = g;
-			dest[2] = b;
+			dest[0] = gammatable[r];
+			dest[1] = gammatable[g];
+			dest[2] = gammatable[b];
 			dest[3] = a;
 
 			bl += 3;

--- a/src/client/refresh/gl1/gl1_light.c
+++ b/src/client/refresh/gl1/gl1_light.c
@@ -47,8 +47,8 @@ R_RenderDlight(dlight_t *light)
 	}
 
 	GLBUFFER_VERTEX( vtx[0], vtx[1], vtx[2] )
-	GLBUFFER_COLOR( light->color[0] * 0.2, light->color[1] * 0.2,
-		light->color[2] * 0.2, 1 )
+	GLBUFFER_COLOR( light->color[0] * 51, light->color[1] * 51,
+		light->color[2] * 51, 255 )	// 255 * 0.2 = 51
 
 	for ( i = 16; i >= 0; i-- )
 	{
@@ -61,7 +61,7 @@ R_RenderDlight(dlight_t *light)
 		}
 
 		GLBUFFER_VERTEX( vtx[0], vtx[1], vtx[2] )
-		GLBUFFER_COLOR( 0, 0, 0, 1 )
+		GLBUFFER_COLOR( 0, 0, 0, 255 )
 	}
 }
 

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -1970,9 +1970,9 @@ RI_SetPalette(const unsigned char *palette)
 	{
 		for (i = 0; i < 256; i++)
 		{
-			rp[i * 4 + 0] = palette[i * 3 + 0];
-			rp[i * 4 + 1] = palette[i * 3 + 1];
-			rp[i * 4 + 2] = palette[i * 3 + 2];
+			rp[i * 4 + 0] = gammatable[palette[i * 3 + 0]];
+			rp[i * 4 + 1] = gammatable[palette[i * 3 + 1]];
+			rp[i * 4 + 2] = gammatable[palette[i * 3 + 2]];
 			rp[i * 4 + 3] = 0xff;
 		}
 	}

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -143,6 +143,7 @@ cvar_t *gl1_stereo_separation;
 cvar_t *gl1_stereo_anaglyph_colors;
 cvar_t *gl1_stereo_convergence;
 
+static cvar_t *gl_znear;
 static cvar_t *gl1_waterwarp;
 
 refimport_t ri;
@@ -731,7 +732,7 @@ void
 R_SetPerspective(GLdouble fovy)
 {
 	// gluPerspective style parameters
-	static const GLdouble zNear = 2;
+	const GLdouble zNear = Q_max(gl_znear->value, 0.1f);
 	const GLdouble zFar = (r_farsee->value) ? 8192.0f : 4096.0f;
 	const GLdouble aspectratio = (GLdouble)r_newrefdef.width / r_newrefdef.height;
 
@@ -1267,6 +1268,7 @@ R_Register(void)
 	gl_polyblend = ri.Cvar_Get("gl_polyblend", "1", 0);
 	gl1_flashblend = ri.Cvar_Get("gl1_flashblend", "0", 0);
 	r_fixsurfsky = ri.Cvar_Get("r_fixsurfsky", "0", CVAR_ARCHIVE);
+	gl_znear = ri.Cvar_Get("gl_znear", "4", CVAR_ARCHIVE);
 
 	gl_texturemode = ri.Cvar_Get("gl_texturemode", "GL_LINEAR_MIPMAP_NEAREST", CVAR_ARCHIVE);
 	gl1_texturealphamode = ri.Cvar_Get("gl1_texturealphamode", "default", CVAR_ARCHIVE);

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -704,10 +704,11 @@ R_SetupFrame(void)
 		}
 	}
 
-	for (i = 0; i < 4; i++)
+	for (i = 0; i < 3; i++)
 	{
-		v_blend[i] = r_newrefdef.blend[i];
+		v_blend[i] = r_newrefdef.blend[i] * gl_state.sw_gamma;
 	}
+	v_blend[3] = r_newrefdef.blend[3];
 
 	c_brush_polys = 0;
 	c_alias_polys = 0;

--- a/src/client/refresh/gl1/gl1_mesh.c
+++ b/src/client/refresh/gl1/gl1_mesh.c
@@ -143,6 +143,8 @@ R_DrawAliasFrameLerp(entity_t *currententity, dmdl_t *paliashdr, float backlerp)
 
 	while (1)
 	{
+		int idx[3];
+
 		/* get the vertex count and primitive type */
 		count = *order++;
 
@@ -172,8 +174,15 @@ R_DrawAliasFrameLerp(entity_t *currententity, dmdl_t *paliashdr, float backlerp)
 				GLBUFFER_VERTEX(s_lerped[index_xyz][0],
 					s_lerped[index_xyz][1], s_lerped[index_xyz][2])
 
-				GLBUFFER_COLOR(shadelight[0], shadelight[1],
-					shadelight[2], alpha)
+				for (i = 0; i < 3; i++)
+				{
+					idx[i] = shadelight[i] * 255;
+					idx[i] = Q_clamp(idx[i], 0, 255);
+				}
+
+				GLBUFFER_COLOR(gammatable[idx[0]],
+					gammatable[idx[1]],
+					gammatable[idx[2]], alpha * 255)
 			}
 			while (--count);
 		}
@@ -196,8 +205,15 @@ R_DrawAliasFrameLerp(entity_t *currententity, dmdl_t *paliashdr, float backlerp)
 
 				GLBUFFER_SINGLETEX(tex[0], tex[1])
 
-				GLBUFFER_COLOR(l * shadelight[0], l * shadelight[1],
-					l * shadelight[2], alpha)
+				for (i = 0; i < 3; i++)
+				{
+					idx[i] = l * shadelight[i] * 255;
+					idx[i] = Q_clamp(idx[i], 0, 255);
+				}
+
+				GLBUFFER_COLOR(gammatable[idx[0]],
+					gammatable[idx[1]],
+					gammatable[idx[2]], alpha * 255)
 			}
 			while (--count);
 		}

--- a/src/client/refresh/gl1/gl1_sdl.c
+++ b/src/client/refresh/gl1/gl1_sdl.c
@@ -216,15 +216,16 @@ void RI_SetVsync(void)
 }
 
 /*
- * Updates the gamma ramp.
+ * Updates the gamma ramp. Only used with SDL2.
  */
 void
 RI_UpdateGamma(void)
 {
-// TODO SDL3: Hardware gamma / gamma ramps are no longer supported with
-// SDL3. There's no replacement and sdl2-compat won't support it either.
+// Hardware gamma / gamma ramps are no longer supported with SDL3.
+// There's no replacement and sdl2-compat won't support it either.
 // See https://github.com/libsdl-org/SDL/pull/6617 for the rational.
-#ifndef USE_SDL3
+// Gamma works with a lookup table when using SDL3 (or GLES1).
+#ifndef GL1_GAMMATABLE
 	float gamma = (vid_gamma->value);
 
 	Uint16 ramp[256];

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -141,8 +141,9 @@ typedef struct	//	832k aprox.
 
 	GLfloat
 		vtx[MAX_VERTICES * 3],	// vertexes
-		tex[MAX_TEXTURE_UNITS][MAX_VERTICES * 2],	// texture coords
-		clr[MAX_VERTICES * 4];	// color components
+		tex[MAX_TEXTURE_UNITS][MAX_VERTICES * 2];	// texture coords
+
+	GLubyte	clr[MAX_VERTICES * 4];	// color components
 
 	GLushort idx[MAX_INDICES];	// indices for the draw call
 

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -74,6 +74,11 @@
 /* fall over */
 #define ROLL 2
 
+#if defined(USE_SDL3) || defined(YQ2_GL1_GLES)
+// Use internal lookup table instead of SDL2 hw gamma funcs for GL1/GLES1
+#define GL1_GAMMATABLE
+#endif
+
 extern viddef_t vid;
 
 
@@ -254,6 +259,8 @@ extern int c_visible_textures;
 
 extern float r_world_matrix[16];
 
+extern unsigned char gammatable[256];
+
 qboolean R_Bind(int texnum);
 
 void R_TexEnv(GLenum value);
@@ -429,6 +436,7 @@ typedef struct
 typedef struct
 {
 	float inverse_intensity;
+	float sw_gamma;	// always 1 if using SDL2 hw gamma
 	qboolean fullscreen;
 
 	int prev_mode;

--- a/src/client/refresh/gl3/gl3_mesh.c
+++ b/src/client/refresh/gl3/gl3_mesh.c
@@ -815,23 +815,13 @@ GL3_DrawAliasModel(entity_t *entity)
 
 	if (entity->flags & RF_WEAPONMODEL)
 	{
-		extern hmm_mat4 GL3_MYgluPerspective(GLdouble fovy, GLdouble aspect, GLdouble zNear, GLdouble zFar);
+		extern hmm_mat4 GL3_SetPerspective(GLdouble fovy);
 
 		origProjViewMat = gl3state.uni3DData.transProjViewMat4;
 
 		// render weapon with a different FOV (r_gunfov) so it's not distorted at high view FOV
-		float screenaspect = (float)gl3_newrefdef.width / gl3_newrefdef.height;
-		float dist = (r_farsee->value == 0) ? 4096.0f : 8192.0f;
-
-		hmm_mat4 projMat;
-		if (r_gunfov->value < 0)
-		{
-			projMat = GL3_MYgluPerspective(gl3_newrefdef.fov_y, screenaspect, 2, dist);
-		}
-		else
-		{
-			projMat = GL3_MYgluPerspective(r_gunfov->value, screenaspect, 2, dist);
-		}
+		hmm_mat4 projMat = GL3_SetPerspective( (r_gunfov->value < 0)?
+				gl3_newrefdef.fov_y : r_gunfov->value );
 
 		if(gl_lefthand->value == 1.0F)
 		{


### PR DESCRIPTION
Resurrected the Vanilla Q2 gamma table. Thanks to the fact that is still applied to textures today (with `gamma value == 1.0`), getting it back was easy. The difference with the old implementation is that _alpha surfaces_ and `gl_polyblend` effects take gamma into account for their color, and most importantly, the gamma table use is no longer limited to loading textures. Now it is used for picking color intensity in lightmaps, meshes, particles, beams, and even cinematics.

It's difficult to tell apart the end result from the SDL2 gamma functions IMHO. What's noticeable is the lack of color banding at extreme values, and of course, that gamma no longer affects the whole screen, just the game window :)

The great disadvantage this has is that requires `vid_restart` to apply the new `vid_gamma` value, with the problem described in #1236.
EDIT: #1238 solves the crashes, with it the game can re-apply gamma with no drawbacks.