### PR TITLE
Temp ent refactoring and temp ent model state cleared on renderer restarts

### DIFF
--- a/src/client/cl_effects.c
+++ b/src/client/cl_effects.c
@@ -1987,8 +1987,6 @@ CL_TeleportParticles(vec3_t org)
  * event value. the female events are there for
  * backwards compatability
  */
-extern struct sfx_s *cl_sfx_footsteps[4];
-
 void
 CL_EntityEvent(entity_state_t *ent)
 {
@@ -2009,7 +2007,7 @@ CL_EntityEvent(entity_state_t *ent)
 			if (cl_footsteps->value)
 			{
 				S_StartSound(NULL, ent->number, CHAN_BODY,
-						cl_sfx_footsteps[randk() & 3], 1, ATTN_NORM, 0);
+						CL_RandomFootstepSfx(), 1, ATTN_NORM, 0);
 			}
 
 			break;

--- a/src/client/cl_entities.c
+++ b/src/client/cl_entities.c
@@ -27,8 +27,6 @@
 #include <math.h>
 #include "header/client.h"
 
-extern struct model_s *cl_mod_powerscreen;
-
 void
 CL_AddPacketEntities(frame_t *frame)
 {
@@ -440,7 +438,7 @@ CL_AddPacketEntities(frame_t *frame)
 
 		if (effects & EF_POWERSCREEN)
 		{
-			ent.model = cl_mod_powerscreen;
+			ent.model = CL_PowerScreenModel();
 			ent.oldframe = 0;
 			ent.frame = 0;
 			ent.flags |= (RF_TRANSLUCENT | RF_SHELL_GREEN);

--- a/src/client/cl_tempentities.c
+++ b/src/client/cl_tempentities.c
@@ -1559,6 +1559,23 @@ CL_AddHeatBeams(void)
 			CL_MonsterPlasma_Shell(org);
 		}
 
+		/* hack for left-handed weapon
+		   RF_WEAPONMODEL will mirror the beam start pos
+		   so put the start pos to the right
+		   that way the renderer mirrors it to the left
+		*/
+		if (by_us && hand_mul == -1.0f)
+		{
+			AdjustToWeapon(b->offset, 1.0f, org);
+			VectorSubtract(b->end, org, dist);
+
+			len = VectorLength(dist);
+			VectorScale(cl.v_forward, len, dist);
+			ApplyBeamOffset(b->offset, 1.0f, dist);
+
+			CalculatePitchYaw(dist, &pitch, &yaw);
+		}
+
 		/* add new entities for the beams */
 		d = VectorNormalize(dist);
 
@@ -1569,7 +1586,13 @@ CL_AddHeatBeams(void)
 		memset(&ent, 0, sizeof(ent));
 
 		ent.model = b->model;
-		ent.flags = RF_FULLBRIGHT|RF_WEAPONMODEL; // DG: fix rogue heatbeam high FOV rendering
+		ent.flags = RF_FULLBRIGHT;
+
+		// DG: fix rogue heatbeam high FOV rendering
+		if (by_us && hand_mul != 0.0f)
+		{
+			ent.flags |= RF_WEAPONMODEL;
+		}
 
 		ent.angles[0] = -pitch;
 		ent.angles[1] = yaw + 180.0f;

--- a/src/client/cl_tempentities.c
+++ b/src/client/cl_tempentities.c
@@ -48,7 +48,7 @@ typedef struct
 #define MAX_BEAMS 64
 #define MAX_LASERS 64
 
-explosion_t cl_explosions[MAX_EXPLOSIONS];
+static explosion_t cl_explosions[MAX_EXPLOSIONS];
 
 typedef struct
 {
@@ -60,17 +60,18 @@ typedef struct
 	vec3_t start, end;
 } beam_t;
 
-beam_t cl_beams[MAX_BEAMS];
-beam_t cl_playerbeams[MAX_BEAMS];
+static beam_t cl_beams[MAX_BEAMS];
+static beam_t cl_playerbeams[MAX_BEAMS];
 
 typedef struct
 {
 	entity_t ent;
 	int endtime;
 } laser_t;
-laser_t cl_lasers[MAX_LASERS];
 
-cl_sustain_t cl_sustains[MAX_SUSTAINS];
+static laser_t cl_lasers[MAX_LASERS];
+
+static cl_sustain_t cl_sustains[MAX_SUSTAINS];
 
 extern void CL_TeleportParticles(vec3_t org);
 void CL_BlasterParticles(vec3_t org, vec3_t dir);
@@ -85,39 +86,38 @@ void CL_Explosion_Particle(vec3_t org, float size,
 #define NUM_FOOTSTEP_SFX 4
 
 /* sounds */
-struct sfx_s *cl_sfx_ric1;
-struct sfx_s *cl_sfx_ric2;
-struct sfx_s *cl_sfx_ric3;
-struct sfx_s *cl_sfx_lashit;
-struct sfx_s *cl_sfx_spark5;
-struct sfx_s *cl_sfx_spark6;
-struct sfx_s *cl_sfx_spark7;
-struct sfx_s *cl_sfx_railg;
-struct sfx_s *cl_sfx_rockexp;
-struct sfx_s *cl_sfx_grenexp;
-struct sfx_s *cl_sfx_watrexp;
-struct sfx_s *cl_sfx_plasexp;
-struct sfx_s *cl_sfx_footsteps[NUM_FOOTSTEP_SFX];
+static struct sfx_s *cl_sfx_ric1;
+static struct sfx_s *cl_sfx_ric2;
+static struct sfx_s *cl_sfx_ric3;
+static struct sfx_s *cl_sfx_lashit;
+static struct sfx_s *cl_sfx_spark5;
+static struct sfx_s *cl_sfx_spark6;
+static struct sfx_s *cl_sfx_spark7;
+static struct sfx_s *cl_sfx_railg;
+static struct sfx_s *cl_sfx_rockexp;
+static struct sfx_s *cl_sfx_grenexp;
+static struct sfx_s *cl_sfx_watrexp;
+static struct sfx_s *cl_sfx_footsteps[NUM_FOOTSTEP_SFX];
 
-struct sfx_s *cl_sfx_lightning;
-struct sfx_s *cl_sfx_disrexp;
+static struct sfx_s *cl_sfx_lightning;
+static struct sfx_s *cl_sfx_disrexp;
 
 /* models */
-struct model_s *cl_mod_explode;
-struct model_s *cl_mod_smoke;
-struct model_s *cl_mod_flash;
-struct model_s *cl_mod_parasite_segment;
-struct model_s *cl_mod_grapple_cable;
-struct model_s *cl_mod_parasite_tip;
-struct model_s *cl_mod_explo4;
-struct model_s *cl_mod_bfg_explo;
-struct model_s *cl_mod_powerscreen;
-struct model_s *cl_mod_plasmaexplo;
+static struct model_s *cl_mod_explode;
+static struct model_s *cl_mod_smoke;
+static struct model_s *cl_mod_flash;
+static struct model_s *cl_mod_parasite_segment;
+static struct model_s *cl_mod_grapple_cable;
+static struct model_s *cl_mod_parasite_tip;
+static struct model_s *cl_mod_explo4;
+static struct model_s *cl_mod_bfg_explo;
+static struct model_s *cl_mod_powerscreen;
+static struct model_s *cl_mod_plasmaexplo;
 
-struct model_s *cl_mod_lightning;
-struct model_s *cl_mod_heatbeam;
-struct model_s *cl_mod_monster_heatbeam;
-struct model_s *cl_mod_explo4_big;
+static struct model_s *cl_mod_lightning;
+static struct model_s *cl_mod_heatbeam;
+static struct model_s *cl_mod_monster_heatbeam;
+static struct model_s *cl_mod_explo4_big;
 
 /*
  * Utility functions
@@ -1904,5 +1904,17 @@ CL_AddTEnts(void)
 	CL_AddExplosions();
 	CL_AddLasers();
 	CL_ProcessSustain();
+}
+
+struct sfx_s *
+CL_RandomFootstepSfx(void)
+{
+	return cl_sfx_footsteps[randk() % NUM_FOOTSTEP_SFX];
+}
+
+struct model_s *
+CL_PowerScreenModel(void)
+{
+	return cl_mod_powerscreen;
 }
 

--- a/src/client/header/client.h
+++ b/src/client/header/client.h
@@ -437,6 +437,8 @@ void CL_AddEntities (void);
 void CL_AddDLights (void);
 void CL_AddTEnts (void);
 void CL_AddLightStyles (void);
+struct sfx_s *CL_RandomFootstepSfx (void);
+struct model_s *CL_PowerScreenModel (void);
 
 void CL_PrepRefresh (void);
 void CL_RegisterSounds (void);

--- a/src/client/header/client.h
+++ b/src/client/header/client.h
@@ -389,6 +389,7 @@ typedef struct particle_s
 
 void CL_ClearEffects (void);
 void CL_ClearTEnts (void);
+void CL_ClearTEntModels (void);
 void CL_BlasterTrail (vec3_t start, vec3_t end);
 void CL_QuadTrail (vec3_t start, vec3_t end);
 void CL_RailTrail (vec3_t start, vec3_t end);

--- a/src/client/vid/vid.c
+++ b/src/client/vid/vid.c
@@ -376,6 +376,8 @@ VID_ShutdownRenderer(void)
 		Sys_FreeLibrary(reflib_handle);
 		reflib_handle = NULL;
 		memset(&re, 0, sizeof(re));
+
+		CL_ClearTEntModels();
 	}
 
 	// Declare the refresher as inactive


### PR DESCRIPTION
The following was done:
* Fixes issue https://github.com/yquake2/yquake2/issues/1236.
* Temp ent static state is now cleared on renderer restarts/changes
* Added `static` to a few private functions in the temp ent code file
* Created utility functions to simply the beams/sustains code (DRY principle)
* `CL_ClearTEnt` now also `NULL`-ifies the `cl_mod_` and `cl_sfx_` static vars
* Adds a `r < 0` check for indexing `splash_color` array since `MSG_ReadByte` can return `-1`
* Temp ent global variables now `static`
* `CL_RandomFootstepSfx` and `CL_PowerScreenModel` accessor  functions, since they were needed elsewhere (exposing these variables directly is a bad idea I think)
* Renamed `playerbeam` variables and functions to the more correct `heatbeam` and cleaned up `CL_ParseHeatBeam` and `CL_AddHeatBeams`
* Removed unused `cl_sfx_plasexpl` variable
* Removed unused `cl_mod_monster_heatbeam` variable. Was never actually being used, `CL_ParseHeatBeam` always set `model` to `cl_mod_heatbeam` if this model was passed to it
* Potential fix for heatbeam appearing in the wrong location for left/center weapon modes
* Replaced `return` with `continue` in `CL_AddBeams` loop `cl_mod_lightning` special case. I see no reason why it should stop adding beams if this happens

I don't know if this fixes the `vid_restart` crashes for others but it does for me.

Because of my refactoring, if others could test the temp entities (beams and steam namely) is a good idea.