### PR TITLE
Minimum light level for GL1

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -553,6 +553,11 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   value, at least `1.0` - default is `2.0`. Applied when textures are
   loaded, so it needs a `vid_restart`.
 
+* **gl1_minlight**: Sets the minimum light level on screen. Increasing
+  this illuminates darker scenes, at the expense of the atmosphere.
+  Posible values go from `0` (default, show the full spectrum of light
+  & dark) to `255` (equal to `r_fullbright 1`). Requires `vid_restart`.
+
 * **gl1_multitexture**: Enables (`1`, default) the blending of color and
   light textures on a single drawing pass; disabling this (`0`) does one
   pass for color and another for light. Requires a `vid_restart` when
@@ -744,10 +749,10 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   Default `2.5`.
 
 * **gyro_tightening**: Threshold of rotation, in degrees per second,
-  below which gyro input is reduced to stabilize aiming. Default `3.0`.
+  below which gyro input is reduced to stabilize aiming. Default `3.5`.
 
 * **gyro_smoothing**: Threshold of rotation, in degrees per second,
-  below which gyro input is averaged to reduce jitter. Default `2.0`.
+  below which gyro input is averaged to reduce jitter. Default `2.5`.
 
 * **gyro_smoothing_window**: The smoothing window size, in seconds.
   Default `0.125`.

--- a/src/client/input/sdl2.c
+++ b/src/client/input/sdl2.c
@@ -2872,8 +2872,8 @@ IN_Init(void)
 	gyro_local_roll = Cvar_Get("gyro_local_roll", "1", CVAR_ARCHIVE);
 	gyro_yawsensitivity = Cvar_Get("gyro_yawsensitivity", "2.5", CVAR_ARCHIVE);
 	gyro_pitchsensitivity = Cvar_Get("gyro_pitchsensitivity", "2.5", CVAR_ARCHIVE);
-	gyro_tightening = Cvar_Get("gyro_tightening", "3.0", CVAR_ARCHIVE);
-	gyro_smoothing = Cvar_Get("gyro_smoothing", "2.0", CVAR_ARCHIVE);
+	gyro_tightening = Cvar_Get("gyro_tightening", "3.5", CVAR_ARCHIVE);
+	gyro_smoothing = Cvar_Get("gyro_smoothing", "2.5", CVAR_ARCHIVE);
 	gyro_smoothing_window = Cvar_Get("gyro_smoothing_window", "0.125", CVAR_ARCHIVE);
 	gyro_acceleration = Cvar_Get("gyro_acceleration", "0", CVAR_ARCHIVE);
 	gyro_accel_multiplier = Cvar_Get("gyro_accel_multiplier", "2.0", CVAR_ARCHIVE);

--- a/src/client/input/sdl3.c
+++ b/src/client/input/sdl3.c
@@ -2849,8 +2849,8 @@ IN_Init(void)
 	gyro_local_roll = Cvar_Get("gyro_local_roll", "1", CVAR_ARCHIVE);
 	gyro_yawsensitivity = Cvar_Get("gyro_yawsensitivity", "2.5", CVAR_ARCHIVE);
 	gyro_pitchsensitivity = Cvar_Get("gyro_pitchsensitivity", "2.5", CVAR_ARCHIVE);
-	gyro_tightening = Cvar_Get("gyro_tightening", "3.0", CVAR_ARCHIVE);
-	gyro_smoothing = Cvar_Get("gyro_smoothing", "2.0", CVAR_ARCHIVE);
+	gyro_tightening = Cvar_Get("gyro_tightening", "3.5", CVAR_ARCHIVE);
+	gyro_smoothing = Cvar_Get("gyro_smoothing", "2.5", CVAR_ARCHIVE);
 	gyro_smoothing_window = Cvar_Get("gyro_smoothing_window", "0.125", CVAR_ARCHIVE);
 	gyro_acceleration = Cvar_Get("gyro_acceleration", "0", CVAR_ARCHIVE);
 	gyro_accel_multiplier = Cvar_Get("gyro_accel_multiplier", "2.0", CVAR_ARCHIVE);

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -62,6 +62,7 @@ static menuslider_s s_gl1_overbrightbits_slider;
 static menuslider_s s_gl3_overbrightbits_slider;
 static menuslider_s s_gl4_overbrightbits_slider;
 static menuslider_s s_vk_overbrightbits_slider;
+static menuslider_s s_gl1_minlight_slider;
 static menulist_s s_gl3_colorlight_list;
 static menulist_s s_gl4_colorlight_list;
 static menulist_s s_vk_dynamic_list;
@@ -448,7 +449,7 @@ ApplyChanges(void *unused)
 }
 
 static void
-RestartNeededMsg(void *unused)
+RestartNeededSDL3Msg(void *unused)
 {
 	if (
 #ifdef USE_SDL3
@@ -458,6 +459,12 @@ RestartNeededMsg(void *unused)
 	{
 		Menu_SetStatusBar(&s_opengl_menu, "apply required");
 	}
+}
+
+static void
+RestartNeededForAllMsg(void *unused)
+{
+	Menu_SetStatusBar(&s_opengl_menu, "apply required");
 }
 
 void
@@ -624,7 +631,7 @@ VID_MenuInit(void)
 	s_brightness_slider.generic.name = "brightness";
 	s_brightness_slider.generic.x = 0;
 	s_brightness_slider.generic.y = (y += 10);
-	s_brightness_slider.generic.callback = RestartNeededMsg;
+	s_brightness_slider.generic.callback = RestartNeededSDL3Msg;
 	s_brightness_slider.cvar = "vid_gamma";
 	s_brightness_slider.minvalue = 0.1f;
 	s_brightness_slider.maxvalue = 2.0f;
@@ -740,6 +747,17 @@ VID_MenuInit(void)
 			s_gl1_overbrightbits_slider.maxvalue = 2;
 			s_gl1_overbrightbits_slider.slidestep = 1;
 			s_gl1_overbrightbits_slider.printformat = "%.0f";
+
+			s_gl1_minlight_slider.generic.type = MTYPE_SLIDER;
+			s_gl1_minlight_slider.generic.name = "min. light level";
+			s_gl1_minlight_slider.generic.x = 0;
+			s_gl1_minlight_slider.generic.y = (y += 10);
+			s_gl1_minlight_slider.generic.callback = RestartNeededForAllMsg;
+			s_gl1_minlight_slider.cvar = "gl1_minlight";
+			s_gl1_minlight_slider.minvalue = 0;
+			s_gl1_minlight_slider.maxvalue = 32;
+			s_gl1_minlight_slider.slidestep = 4;
+			s_gl1_minlight_slider.printformat = "%.0f";
 			break;
 
 		default:
@@ -907,6 +925,7 @@ VID_MenuInit(void)
 		case ref_gl1:
 			Menu_AddItem(&s_opengl_menu, (void *)&s_gl1_intensity_slider);
 			Menu_AddItem(&s_opengl_menu, (void *)&s_gl1_overbrightbits_slider);
+			Menu_AddItem(&s_opengl_menu, (void *)&s_gl1_minlight_slider);
 			break;
 		default:
 			break;

--- a/src/client/refresh/gl1/gl1_light.c
+++ b/src/client/refresh/gl1/gl1_light.c
@@ -32,6 +32,8 @@ cplane_t *lightplane; /* used as shadow plane */
 vec3_t lightspot;
 static float s_blocklights[34 * 34 * 3];
 
+unsigned char minlight[256];
+
 void
 R_RenderDlight(dlight_t *light)
 {
@@ -636,6 +638,13 @@ store:
 				g = g * t;
 				b = b * t;
 				a = a * t;
+			}
+
+			if (gl_state.minlight_set)
+			{
+				r = minlight[r];
+				g = minlight[g];
+				b = minlight[b];
 			}
 
 			dest[0] = gammatable[r];

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -100,6 +100,7 @@ cvar_t *gl_shadows;
 cvar_t *gl1_stencilshadow;
 cvar_t *r_mode;
 cvar_t *r_fixsurfsky;
+cvar_t *gl1_minlight;
 
 cvar_t *r_customwidth;
 cvar_t *r_customheight;
@@ -1269,6 +1270,7 @@ R_Register(void)
 	gl1_flashblend = ri.Cvar_Get("gl1_flashblend", "0", 0);
 	r_fixsurfsky = ri.Cvar_Get("r_fixsurfsky", "0", CVAR_ARCHIVE);
 	gl_znear = ri.Cvar_Get("gl_znear", "4", CVAR_ARCHIVE);
+	gl1_minlight = ri.Cvar_Get("gl1_minlight", "0", CVAR_ARCHIVE);
 
 	gl_texturemode = ri.Cvar_Get("gl_texturemode", "GL_LINEAR_MIPMAP_NEAREST", CVAR_ARCHIVE);
 	gl1_texturealphamode = ri.Cvar_Get("gl1_texturealphamode", "default", CVAR_ARCHIVE);

--- a/src/client/refresh/gl1/gl1_mesh.c
+++ b/src/client/refresh/gl1/gl1_mesh.c
@@ -45,6 +45,8 @@ float shadelight[3];
 float *shadedots = r_avertexnormal_dots[0];
 extern vec3_t lightspot;
 
+extern unsigned char minlight[256];
+
 static void
 R_LerpVerts(entity_t *currententity, int nverts, dtrivertx_t *v, dtrivertx_t *ov,
 		dtrivertx_t *verts, float *lerp, float move[3],
@@ -180,6 +182,14 @@ R_DrawAliasFrameLerp(entity_t *currententity, dmdl_t *paliashdr, float backlerp)
 					idx[i] = Q_clamp(idx[i], 0, 255);
 				}
 
+				if (gl_state.minlight_set)
+				{
+					for (i = 0; i < 3; i++)
+					{
+						idx[i] = minlight[idx[i]];
+					}
+				}
+
 				GLBUFFER_COLOR(gammatable[idx[0]],
 					gammatable[idx[1]],
 					gammatable[idx[2]], alpha * 255)
@@ -209,6 +219,14 @@ R_DrawAliasFrameLerp(entity_t *currententity, dmdl_t *paliashdr, float backlerp)
 				{
 					idx[i] = l * shadelight[i] * 255;
 					idx[i] = Q_clamp(idx[i], 0, 255);
+				}
+
+				if (gl_state.minlight_set)
+				{
+					for (i = 0; i < 3; i++)
+					{
+						idx[i] = minlight[idx[i]];
+					}
 				}
 
 				GLBUFFER_COLOR(gammatable[idx[0]],

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -438,6 +438,7 @@ typedef struct
 {
 	float inverse_intensity;
 	float sw_gamma;	// always 1 if using SDL2 hw gamma
+	qboolean minlight_set;	// is gl1_minlight > 0 ?
 	qboolean fullscreen;
 
 	int prev_mode;


### PR DESCRIPTION
Closes #953.
After having done _gamma for SDL3_, I found this issue to be very simple to solve :)
The new `gl1_minlight` cvar sets the minimum light level the rendered scene presents. Meaning, every lightmap is scaled from `0-255` to the new `threshold-255`, with the threshold being "the new 0", the new absolute minimum.
Q2, being the dark game it is, kinda loses atmosphere if you set this too high. When increased, this cvar reduces the scope of "intensities" the game is allowed to show; the higher it's set, the more it looks like `r_fullbright 1`. So, this is more useful as a visual impairment aid.
Included is a new slider in video options. As this changes presently loaded lightmaps, `vid_restart` is required.
Extra: some default values for gamepad's gyro settings have been changed.