### PR TITLE
OpenAL double free fix when unloading the library.

### DIFF
--- a/src/backends/unix/system.c
+++ b/src/backends/unix/system.c
@@ -690,6 +690,43 @@ Sys_LoadLibrary(const char *path, const char *sym, void **handle)
 	return entry;
 }
 
+void *
+Sys_LoadLibraryNoUnLoad(const char *path, const char *sym, void **handle)
+{
+	void *module, *entry;
+
+	*handle = NULL;
+	module = dlopen(path, RTLD_LAZY | RTLD_NODELETE);
+
+	if (!module)
+	{
+		Com_Printf("%s failed: %s\n", __func__, dlerror());
+		return NULL;
+	}
+
+	if (sym)
+	{
+		entry = dlsym(module, sym);
+
+		if (!entry)
+		{
+			Com_Printf("%s failed: %s\n", __func__, dlerror());
+			dlclose(module);
+			return NULL;
+		}
+	}
+	else
+	{
+		entry = NULL;
+	}
+
+	Com_DPrintf("%s succeeded: %s\n", __func__, path);
+
+	*handle = module;
+
+	return entry;
+}
+
 /* ================================================================ */
 
 void

--- a/src/backends/windows/system.c
+++ b/src/backends/windows/system.c
@@ -698,6 +698,12 @@ Sys_LoadLibrary(const char *path, const char *sym, void **handle)
 	return entry;
 }
 
+void *
+Sys_LoadLibraryNoUnLoad(const char *path, const char *sym, void **handle)
+{
+	return Sys_LoadLibrary(path, sym, handle);
+}
+
 /* ======================================================================= */
 
 void

--- a/src/client/sound/qal.c
+++ b/src/client/sound/qal.c
@@ -388,7 +388,10 @@ QAL_Shutdown()
 
 	if (handle)
 	{
-		/* Unload the shared lib */
+		/**
+		 * To avoid a double free with OpenAL already unloading its symbols via __cxa_finalize,
+		 * we don't unload the library here due to Sys_LoadLibraryNoUnLoad
+		 */
 		Sys_FreeLibrary(handle);
 		handle = NULL;
 	}
@@ -414,7 +417,7 @@ QAL_Init()
 
 	/* Load the library */
 	Com_Printf("Loading library: %s\n", al_driver->string);
-	Sys_LoadLibrary(al_driver->string, NULL, &handle);
+	Sys_LoadLibraryNoUnLoad(al_driver->string, NULL, &handle);
 
 	if (!handle)
 	{

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -855,6 +855,7 @@ void Sys_Nanosleep(int);
 void *Sys_GetProcAddress(void *handle, const char *sym);
 void Sys_FreeLibrary(void *handle);
 void *Sys_LoadLibrary(const char *path, const char *sym, void **handle);
+void *Sys_LoadLibraryNoUnLoad(const char *path, const char *sym, void **handle);
 void *Sys_GetGameAPI(void *parms);
 void Sys_UnloadGame(void);
 void Sys_GetWorkDir(char *buffer, size_t len);


### PR DESCRIPTION
Since it is preferable not to touch legacy YQ2 api, creating a separate call just for OpenAL alone, making sense only on unixes though.

```c
Block was alloc'd at
==16821==    at 0x4844F93: operator new(unsigned long) (vg_replace_malloc.c:487)
==16821==    by 0x5FAAE0A: ??? (in /usr/lib/x86_64-linux-gnu/libopenal.so.1.24.2)
==16821==    by 0x6CDA78E: ??? (in /usr/lib/x86_64-linux-gnu/pipewire-0.3/libpipewire-module-protocol-native.so)
==16821==    by 0x6CCB670: ??? (in /usr/lib/x86_64-linux-gnu/pipewire-0.3/libpipewire-module-protocol-native.so)
==16821==    by 0x6CCBE07: ??? (in /usr/lib/x86_64-linux-gnu/pipewire-0.3/libpipewire-module-protocol-native.so)
==16821==    by 0x6491C45: ??? (in /usr/lib/x86_64-linux-gnu/spa-0.2/support/libspa-support.so)
==16821==    by 0x644AB54: ??? (in /usr/lib/x86_64-linux-gnu/libpipewire-0.3.so.0.1402.0)
==16821==    by 0x4BE5B7A: start_thread (pthread_create.c:448)
==16821==    by 0x4C635EF: clone (clone.S:100)
...
Address 0x5db1f90 is 0 bytes inside a block of size 384 free'd
==16821==    at 0x484886D: operator delete(void*, unsigned long) (vg_replace_malloc.c:1181)
==16821==    by 0x4B94D50: __cxa_finalize (cxa_finalize.c:97)
==16821==    by 0x5F3ADB6: ??? (in /usr/lib/x86_64-linux-gnu/libopenal.so.1.24.2)
==16821==    by 0x4001FC1: _dl_call_fini (dl-call_fini.c:43)
==16821==    by 0x4002425: _dl_catch_exception (dl-catch.c:215)
==16821==    by 0x4002B1C: _dl_close_worker (dl-close.c:264)
==16821==    by 0x4003405: _dl_close (dl-close.c:795)
==16821==    by 0x4002398: _dl_catch_exception (dl-catch.c:241)
==16821==    by 0x40024BE: _dl_catch_error (dl-catch.c:260)
==16821==    by 0x4BE1D66: _dlerror_run (dlerror.c:138)
==16821==    by 0x4BE1A95: dlclose@@GLIBC_2.34 (dlclose.c:31)
==16821==    by 0x1C87F2: Sys_FreeLibrary (system.c:645)
```