### PR TITLE
Added `-fno-common` for Clang, avoid linker warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,9 @@ endif
 ifeq ($(COMPILER), clang)
 	# -Wno-missing-braces because otherwise clang complains
 	#  about totally valid 'vec3_t bla = {0}' constructs.
-	override CFLAGS += -Wno-missing-braces
+	# -fno-common avoids linker warnings due
+	#  uninitialized global variables treated as "common".
+	override CFLAGS += -Wno-missing-braces -fno-common
 else ifeq ($(COMPILER), gcc)
 	# GCC 8.0 or higher.
 	ifeq ($(shell test $(COMPILERVER) -ge 80000; echo $$?),0)


### PR DESCRIPTION
Got a warning:

```
===> LD release/quake2
ld: warning: reducing alignment of section __DATA,__common from 0x8000 to 0x4000 because it exceeds segment maximum alignment
```

How to reproduce:

- macOS with latest installed clang from homebrew ([llvm](https://formulae.brew.sh/formula/llvm), [lld](https://formulae.brew.sh/formula/lld)).
- run `make`

These changes fix that, also I've found the same issue in [FFmpeg@f4e72eb](https://github.com/FFmpeg/FFmpeg/commit/f4e72eb5a3dbd25ed3ab6c9f89c42adcfc0b5e3d).