### PR TITLE
Linux: MUSL support

### DIFF
--- a/src/backends/unix/signalhandler.c
+++ b/src/backends/unix/signalhandler.c
@@ -32,11 +32,13 @@
 
 /* musl based distros do not have execinfo.h */
 #if defined(HAVE_EXECINFO)
+#ifndef __APPLE__
     #include <features.h>
     #ifndef __USE_GNU
         /* IS MUSL - no execinfo.h */
         #undef HAVE_EXECINFO
     #endif
+#endif
 #endif
 
 #if defined(HAVE_EXECINFO)


### PR DESCRIPTION
Linux distributions that use musl do not have any glib feature support, execinfo.h is unilaterally enabled for linux, which fails compilation on musl-based distros.

Since the musl developers do not provide compiler flags for identification, we can identify musl distros based on if they have GCC/GNU features or not.

This allows full compilation and support for musl systems (PostmarketOS, Alpine Linux).