### PR TITLE
Improvements for Info_* functions and 2 new utility functions

### DIFF
--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -400,7 +400,7 @@ char *va(const char *format, ...)  PRINTF_ATTR(1, 2);
 #define MAX_INFO_KEYVAL ((MAX_INFO_KEY - 1) + (MAX_INFO_VALUE - 1) + 3) /* 3 for 2 backslashes and null char */
 #define MAX_INFO_STRING 512
 
-char *Info_ValueForKey(char *s, char *key);
+char *Info_ValueForKey(const char *s, const char *key);
 void Info_RemoveKey(char *s, const char *key);
 void Info_SetValueForKey(char *s, const char *key, const char *value);
 qboolean Info_Validate(const char *s);

--- a/src/game/savegame/tables/gamefunc_decs.h
+++ b/src/game/savegame/tables/gamefunc_decs.h
@@ -33,7 +33,7 @@ extern void InitGame ( void ) ;
 extern void Info_SetValueForKey ( char * s , const char * key , const char * value ) ;
 extern qboolean Info_Validate ( const char * s ) ;
 extern void Info_RemoveKey ( char * s , const char * key ) ;
-extern char * Info_ValueForKey ( char * s , char * key ) ;
+extern char * Info_ValueForKey ( const char * s , const char * key ) ;
 extern int Q_strlcat ( char * dst , const char * src , int size ) ;
 extern int Q_strlcpy ( char * dst , const char * src , int size ) ;
 extern char * Q_strlwr ( char * s ) ;


### PR DESCRIPTION
This PR cleans up and optimizes the Info_* functions in `shared.c` as well as adding 2 new `Q_strlcpy_ascii` and `Q_strchrs` utility function used by the new code.

`Info_ValueForKey` improvements:
* const `s` and `key` args
* Use `MAX_INFO_VALUE` instead of `512` for static value buffers. Since `Info_SetValueForKey` enforces that limit there is no need for more
* Always reset value buffer to null char at the start to avoid lingering values
* Optimized away the key buffer and copying to it
* Bounds checking when writing to value buffer

`Info_Validate` improvements:
* const `s` arg
* Use `Q_strchrs` to simplify code

`Info_RemoveKey` improvements:
* const `key` arg
* Optimized away the key and value buffers and copying to them

`Info_SetValueForKey` improvements:
* const `key` and `value` args
* More accurately determines if there is enough space left for a key/value pair, taking into account ASCII/non-ASCII characters in the key/value
* More detailed warning messages
* A little optimized with fewer `strlen` calls and `newi` buffer only as big as needed, `MAX_INFO_KEYVAL` instead of `MAX_INFO_STRING`
* Fixed value length validation using `MAX_INFO_KEY` instead of `MAX_INFO_VALUE`

New common/shared features:
* `Q_strlcpy_ascii` that only copies ASCII chars
* `Q_strchrs` that works like a `strchr` that can look for several chars at once
* `Q_strchr0` that works like `strchr` but instead of returning `NULL` it returns a pointer to the null char at the end of the string
* `MAX_INFO_KEYVAL` that defines maximum space a key/value pair can take in a buffer + null char
See `shared.h` definitions for details.

I tested each function individually so I'm mostly confident they work the same as before. There may still be some subtle side-effects so let me know if you find anything unusual.