### PR TITLE
Makefile QUIET and WERR variables and separate folders for release and debug binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build/
+/debug/
 /release/
 *.mk
 *.user

--- a/Makefile
+++ b/Makefile
@@ -187,8 +187,13 @@ endif
 override BINROOT :=
 override BUILDROOT := build
 
-override BINDIR := $(BINROOT)release
-override BUILDDIR := $(BUILDROOT)
+ifdef DEBUG
+	override BINDIR := $(BINROOT)debug
+	override BUILDDIR := $(BUILDROOT)/debug
+else
+	override BINDIR := $(BINROOT)release
+	override BUILDDIR := $(BUILDROOT)/release
+endif
 
 # ----------
 
@@ -502,11 +507,11 @@ endif
 # Cleanup
 clean:
 	@echo "===> CLEAN"
-	${Q}rm -Rf build release/*
+	${Q}rm -Rf build debug/* release/*
 
 cleanall:
 	@echo "===> CLEAN"
-	${Q}rm -Rf build release
+	${Q}rm -Rf build debug release
 
 # ----------
 


### PR DESCRIPTION
This PR adds the following features to the build system:
* Some improvements to variable docs at the top of the file
* An optional `QUIET` variable that, when defined, silences the `===> CC ...` output lines.
* An optional `WERR` variable that, when defined, adds `-Werror` to `CFLAGS` to treat warnings as errors.
* Build and bin directories no longer hard-coded:
- `BINROOT`: The root dir for binaries (none by default)
- `BINDIR`: Root + build type. Example: `release` or `debug`
- `BUILDROOT`: Root dir for build objects (`build/` by default)
- `BUILDDIR`: Build root + build type. Example: `build/release` or `build/debug`
These variables can't be customized right now but we could maybe allow that in the future.
* Debug and release builds are now put in separate folders
- Release: `release/*` and `build/release/*`
- Debug: `debug/*` and `build/debug/*`

Let me know what you think of the debug/release dir stuff. If this is not wanted I can undo that commit and maybe do a separate PR for it with more customization.