### PR TITLE
build: Fixed QUIET var from config.mk being ignored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@
 #   i686-w64-mingw32   -> indicates i386
 # QUIET
 #   If defined, "===> CC ..." lines are silenced.
+# SOURCE_DATE_EPOCH
+#   For reproduceable builds, look here for details:
+#   https://reproducible-builds.org/specs/source-date-epoch/
+#   If set, adds a BUILD_DATE define to CFLAGS.
 # UBSAN
 #   Builds with undefined behavior sanitizer.includes DEBUG.
 # VERBOSE
@@ -108,16 +112,16 @@ PKG_CONFIG ?= pkgconf
 
 # ----------
 
+# In case of a configuration file being present, we'll just use it
+ifeq ($(wildcard $(CONFIG_FILE)), $(CONFIG_FILE))
+include $(CONFIG_FILE)
+endif
+
 # Normalize QUIET value to either "x" or ""
 ifdef QUIET
 	override QUIET := "x"
 else
 	override QUIET := ""
-endif
-
-# In case a of a configuration file being present, we'll just use it
-ifeq ($(wildcard $(CONFIG_FILE)), $(CONFIG_FILE))
-include $(CONFIG_FILE)
 endif
 
 # Detect the OS
@@ -278,8 +282,6 @@ override CFLAGS += -DYQ2OSTYPE=\"$(YQ2_OSTYPE)\" -DYQ2ARCH=\"$(YQ2_ARCH)\"
 
 # ----------
 
-# For reproduceable builds, look here for details:
-# https://reproducible-builds.org/specs/source-date-epoch/
 ifdef SOURCE_DATE_EPOCH
 override CFLAGS += -DBUILD_DATE=\"$(shell date --utc --date="@${SOURCE_DATE_EPOCH}" +"%b %_d %Y" | sed -e 's/ /\\ /g')\"
 endif


### PR DESCRIPTION
A small hotfix PR to fix `QUIET` variable being ignored if defined in a config file. Accidentally put the variable check before the config file is read.