### PR TITLE
Add cppcheck to static analysis checks

### DIFF
--- a/.github/workflows/linux_aarch64.yml
+++ b/.github/workflows/linux_aarch64.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +30,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install libgl1-mesa-dev libsdl2-dev libopenal-dev libcurl4-openssl-dev \
-            build-essential
+            build-essential snapd
     - name: Check out repository code
       uses: actions/checkout@v6
     - name: Build
@@ -63,3 +64,13 @@ jobs:
         name: quake2-linux_aarch64-${{github.sha}}
         path: publish/
         if-no-files-found: error
+    - name: Run Cppcheck
+      run: |
+        sudo snap install cppcheck --edge
+        /snap/bin/cppcheck -j 4 --enable=all --output-format=sarif \
+          --output-file=cppcheck_results.sarif --inconclusive --library=posix \
+          -DYQ2OSTYPE=\"Linux\" src
+    - name: Upload SARIF to GitHub Code Scanning
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        sarif_file: cppcheck_results.sarif

--- a/src/client/refresh/files/pcx.c
+++ b/src/client/refresh/files/pcx.c
@@ -483,7 +483,7 @@ LoadPCX(const char *origname, byte **pic, byte **palette, int *width, int *heigh
 	PCX_Decode(filename, raw, len, pic, palette, width, height, bitsPerPixel);
 
 	if(*pic && *bitsPerPixel == 8 && width && height
-		&& *width == 319 && *height == 239
+		&& *width == 320 && *height == 240
 		&& Q_strcasecmp(filename, "pics/quit.pcx") == 0
 		&& Com_BlockChecksum(raw, len) == 3329419434u)
 	{

--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -1538,7 +1538,6 @@ Info_ValueForKey(const char *s, const char *key)
 void
 Info_RemoveKey(char *s, const char *key)
 {
-	char *kstart;
 	size_t klen;
 
 	if (strchr(key, '\\'))
@@ -1550,6 +1549,7 @@ Info_RemoveKey(char *s, const char *key)
 
 	while (*s != '\0')
 	{
+		const char *kstart;
 		char *start;
 
 		start = s;

--- a/src/game/g_spawn.c
+++ b/src/game/g_spawn.c
@@ -25,6 +25,7 @@
  */
 
 #include "header/local.h"
+#include "savegame/tables/spawnfunc_decs.h"
 
 typedef struct
 {
@@ -32,242 +33,8 @@ typedef struct
 	void (*spawn)(edict_t *ent);
 } spawn_t;
 
-void SP_item_health(edict_t *self);
-void SP_item_health_small(edict_t *self);
-void SP_item_health_large(edict_t *self);
-void SP_item_health_mega(edict_t *self);
-
-void SP_info_player_start(edict_t *ent);
-void SP_info_player_deathmatch(edict_t *ent);
-void SP_info_player_coop(edict_t *ent);
-void SP_info_player_intermission(edict_t *ent);
-
-void SP_func_plat(edict_t *ent);
-void SP_func_rotating(edict_t *ent);
-void SP_func_button(edict_t *ent);
-void SP_func_door(edict_t *ent);
-void SP_func_door_secret(edict_t *ent);
-void SP_func_door_rotating(edict_t *ent);
-void SP_func_water(edict_t *ent);
-void SP_func_train(edict_t *ent);
-void SP_func_conveyor(edict_t *self);
-void SP_func_wall(edict_t *self);
-void SP_func_object(edict_t *self);
-void SP_func_explosive(edict_t *self);
-void SP_func_timer(edict_t *self);
-void SP_func_areaportal(edict_t *ent);
-void SP_func_clock(edict_t *ent);
-void SP_func_killbox(edict_t *ent);
-
-void SP_trigger_always(edict_t *ent);
-void SP_trigger_once(edict_t *ent);
-void SP_trigger_multiple(edict_t *ent);
-void SP_trigger_relay(edict_t *ent);
-void SP_trigger_push(edict_t *ent);
-void SP_trigger_hurt(edict_t *ent);
-void SP_trigger_key(edict_t *ent);
-void SP_trigger_counter(edict_t *ent);
-void SP_trigger_elevator(edict_t *ent);
-void SP_trigger_gravity(edict_t *ent);
-void SP_trigger_monsterjump(edict_t *ent);
-
-void SP_target_temp_entity(edict_t *ent);
-void SP_target_speaker(edict_t *ent);
-void SP_target_explosion(edict_t *ent);
-void SP_target_changelevel(edict_t *ent);
-void SP_target_secret(edict_t *ent);
-void SP_target_goal(edict_t *ent);
-void SP_target_splash(edict_t *ent);
-void SP_target_spawner(edict_t *ent);
-void SP_target_blaster(edict_t *ent);
-void SP_target_crosslevel_trigger(edict_t *ent);
-void SP_target_crosslevel_target(edict_t *ent);
-void SP_target_laser(edict_t *self);
-void SP_target_help(edict_t *ent);
-void SP_target_lightramp(edict_t *self);
-void SP_target_earthquake(edict_t *ent);
-void SP_target_character(edict_t *ent);
-void SP_target_string(edict_t *ent);
-
-void SP_worldspawn(edict_t *ent);
-void SP_viewthing(edict_t *ent);
-
-void SP_light(edict_t *self);
-void SP_light_mine1(edict_t *ent);
-void SP_light_mine2(edict_t *ent);
-void SP_info_null(edict_t *self);
-void SP_info_notnull(edict_t *self);
-void SP_path_corner(edict_t *self);
-void SP_point_combat(edict_t *self);
-
-void SP_misc_explobox(edict_t *self);
-void SP_misc_banner(edict_t *self);
-void SP_misc_satellite_dish(edict_t *self);
-void SP_misc_gib_arm(edict_t *self);
-void SP_misc_gib_leg(edict_t *self);
-void SP_misc_gib_head(edict_t *self);
-void SP_misc_insane(edict_t *self);
-void SP_misc_deadsoldier(edict_t *self);
-void SP_misc_viper(edict_t *self);
-void SP_misc_viper_bomb(edict_t *self);
-void SP_misc_bigviper(edict_t *self);
-void SP_misc_strogg_ship(edict_t *self);
-void SP_misc_teleporter(edict_t *self);
-void SP_misc_teleporter_dest(edict_t *self);
-void SP_misc_blackhole(edict_t *self);
-void SP_misc_eastertank(edict_t *self);
-void SP_misc_easterchick(edict_t *self);
-void SP_misc_easterchick2(edict_t *self);
-
-void SP_monster_berserk(edict_t *self);
-void SP_monster_gladiator(edict_t *self);
-void SP_monster_gunner(edict_t *self);
-void SP_monster_infantry(edict_t *self);
-void SP_monster_soldier_light(edict_t *self);
-void SP_monster_soldier(edict_t *self);
-void SP_monster_soldier_ss(edict_t *self);
-void SP_monster_tank(edict_t *self);
-void SP_monster_medic(edict_t *self);
-void SP_monster_flipper(edict_t *self);
-void SP_monster_chick(edict_t *self);
-void SP_monster_parasite(edict_t *self);
-void SP_monster_flyer(edict_t *self);
-void SP_monster_brain(edict_t *self);
-void SP_monster_floater(edict_t *self);
-void SP_monster_hover(edict_t *self);
-void SP_monster_mutant(edict_t *self);
-void SP_monster_supertank(edict_t *self);
-void SP_monster_boss2(edict_t *self);
-void SP_monster_jorg(edict_t *self);
-void SP_monster_makron(edict_t *self);
-void SP_monster_boss3_stand(edict_t *self);
-
-void SP_monster_commander_body(edict_t *self);
-
-void SP_turret_breach(edict_t *self);
-void SP_turret_base(edict_t *self);
-void SP_turret_driver(edict_t *self);
-
 static spawn_t spawns[] = {
-	{"item_health", SP_item_health},
-	{"item_health_small", SP_item_health_small},
-	{"item_health_large", SP_item_health_large},
-	{"item_health_mega", SP_item_health_mega},
-
-	{"info_player_start", SP_info_player_start},
-	{"info_player_deathmatch", SP_info_player_deathmatch},
-	{"info_player_coop", SP_info_player_coop},
-	{"info_player_intermission", SP_info_player_intermission},
-
-	{"func_plat", SP_func_plat},
-	{"func_button", SP_func_button},
-	{"func_door", SP_func_door},
-	{"func_door_secret", SP_func_door_secret},
-	{"func_door_rotating", SP_func_door_rotating},
-	{"func_rotating", SP_func_rotating},
-	{"func_train", SP_func_train},
-	{"func_water", SP_func_water},
-	{"func_conveyor", SP_func_conveyor},
-	{"func_areaportal", SP_func_areaportal},
-	{"func_clock", SP_func_clock},
-	{"func_wall", SP_func_wall},
-	{"func_object", SP_func_object},
-	{"func_timer", SP_func_timer},
-	{"func_explosive", SP_func_explosive},
-	{"func_killbox", SP_func_killbox},
-
-	{"trigger_always", SP_trigger_always},
-	{"trigger_once", SP_trigger_once},
-	{"trigger_multiple", SP_trigger_multiple},
-	{"trigger_relay", SP_trigger_relay},
-	{"trigger_push", SP_trigger_push},
-	{"trigger_hurt", SP_trigger_hurt},
-	{"trigger_key", SP_trigger_key},
-	{"trigger_counter", SP_trigger_counter},
-	{"trigger_elevator", SP_trigger_elevator},
-	{"trigger_gravity", SP_trigger_gravity},
-	{"trigger_monsterjump", SP_trigger_monsterjump},
-
-	{"target_temp_entity", SP_target_temp_entity},
-	{"target_speaker", SP_target_speaker},
-	{"target_explosion", SP_target_explosion},
-	{"target_changelevel", SP_target_changelevel},
-	{"target_secret", SP_target_secret},
-	{"target_goal", SP_target_goal},
-	{"target_splash", SP_target_splash},
-	{"target_spawner", SP_target_spawner},
-	{"target_blaster", SP_target_blaster},
-	{"target_crosslevel_trigger", SP_target_crosslevel_trigger},
-	{"target_crosslevel_target", SP_target_crosslevel_target},
-	{"target_laser", SP_target_laser},
-	{"target_help", SP_target_help},
-	{"target_lightramp", SP_target_lightramp},
-	{"target_earthquake", SP_target_earthquake},
-	{"target_character", SP_target_character},
-	{"target_string", SP_target_string},
-
-	{"worldspawn", SP_worldspawn},
-	{"viewthing", SP_viewthing},
-
-	{"light", SP_light},
-	{"light_mine1", SP_light_mine1},
-	{"light_mine2", SP_light_mine2},
-	{"info_null", SP_info_null},
-	{"func_group", SP_info_null},
-	{"info_notnull", SP_info_notnull},
-	{"path_corner", SP_path_corner},
-	{"point_combat", SP_point_combat},
-
-	{"misc_explobox", SP_misc_explobox},
-	{"misc_banner", SP_misc_banner},
-	{"misc_satellite_dish", SP_misc_satellite_dish},
-	{"misc_gib_arm", SP_misc_gib_arm},
-	{"misc_gib_leg", SP_misc_gib_leg},
-	{"misc_gib_head", SP_misc_gib_head},
-	{"misc_insane", SP_misc_insane},
-	{"misc_deadsoldier", SP_misc_deadsoldier},
-	{"misc_viper", SP_misc_viper},
-	{"misc_viper_bomb", SP_misc_viper_bomb},
-	{"misc_bigviper", SP_misc_bigviper},
-	{"misc_strogg_ship", SP_misc_strogg_ship},
-	{"misc_teleporter", SP_misc_teleporter},
-	{"misc_teleporter_dest", SP_misc_teleporter_dest},
-	{"misc_blackhole", SP_misc_blackhole},
-	{"misc_eastertank", SP_misc_eastertank},
-	{"misc_easterchick", SP_misc_easterchick},
-	{"misc_easterchick2", SP_misc_easterchick2},
-
-	{"monster_berserk", SP_monster_berserk},
-	{"monster_gladiator", SP_monster_gladiator},
-	{"monster_gunner", SP_monster_gunner},
-	{"monster_infantry", SP_monster_infantry},
-	{"monster_soldier_light", SP_monster_soldier_light},
-	{"monster_soldier", SP_monster_soldier},
-	{"monster_soldier_ss", SP_monster_soldier_ss},
-	{"monster_tank", SP_monster_tank},
-	{"monster_tank_commander", SP_monster_tank},
-	{"monster_medic", SP_monster_medic},
-	{"monster_flipper", SP_monster_flipper},
-	{"monster_chick", SP_monster_chick},
-	{"monster_parasite", SP_monster_parasite},
-	{"monster_flyer", SP_monster_flyer},
-	{"monster_brain", SP_monster_brain},
-	{"monster_floater", SP_monster_floater},
-	{"monster_hover", SP_monster_hover},
-	{"monster_mutant", SP_monster_mutant},
-	{"monster_supertank", SP_monster_supertank},
-	{"monster_boss2", SP_monster_boss2},
-	{"monster_boss3_stand", SP_monster_boss3_stand},
-	{"monster_makron", SP_monster_makron},
-	{"monster_jorg", SP_monster_jorg},
-
-	{"monster_commander_body", SP_monster_commander_body},
-
-	{"turret_breach", SP_turret_breach},
-	{"turret_base", SP_turret_base},
-	{"turret_driver", SP_turret_driver},
-
-	{NULL, NULL}
+#include "savegame/tables/spawnfunc_list.h"
 };
 
 /*
@@ -277,7 +44,7 @@ static spawn_t spawns[] = {
 void
 ED_CallSpawn(edict_t *ent)
 {
-	spawn_t *s;
+	const spawn_t *s;
 	gitem_t *item;
 	int i;
 
@@ -288,7 +55,7 @@ ED_CallSpawn(edict_t *ent)
 
 	if (!ent->classname)
 	{
-		gi.dprintf("ED_CallSpawn: NULL classname\n");
+		gi.dprintf("%s: NULL classname\n", __func__);
 		G_FreeEdict(ent);
 		return;
 	}
@@ -440,8 +207,6 @@ static char *
 ED_ParseEdict(char *data, edict_t *ent)
 {
 	qboolean init;
-	char keyname[256];
-	const char *com_token;
 
 	if (!ent)
 	{
@@ -454,6 +219,9 @@ ED_ParseEdict(char *data, edict_t *ent)
 	/* go through all the dictionary pairs */
 	while (1)
 	{
+		const char *com_token;
+		char keyname[256];
+
 		/* parse key */
 		com_token = COM_Parse(&data);
 
@@ -512,7 +280,7 @@ ED_ParseEdict(char *data, edict_t *ent)
  * All but the first will have the FL_TEAMSLAVE flag set.
  * All but the last will have the teamchain field set to the next one
  */
-void
+static void
 G_FindTeams(void)
 {
 	edict_t *e, *e2, *chain;
@@ -856,7 +624,7 @@ static char *dm_statusbar =
 /*QUAKED worldspawn (0 0 0) ?
  *
  * Only used for the world.
- *  "sky"		environment map name
+ *  "sky"       environment map name
  *  "skyaxis"	vector axis for rotating sky
  *  "skyrotate"	speed of rotation in degrees/second
  *  "sounds"	music cd track number

--- a/src/game/header/game.h
+++ b/src/game/header/game.h
@@ -69,7 +69,7 @@ struct gclient_s
 	player_state_t ps;      /* communicated by server to clients */
 	int ping;
 	/* the game dll can add anything it wants
-	   after  this point in the structure */
+	   after this point in the structure */
 };
 
 struct edict_s

--- a/src/game/savegame/tables/gamefunc_decs.h
+++ b/src/game/savegame/tables/gamefunc_decs.h
@@ -713,7 +713,6 @@ extern qboolean SV_FilterPacket ( char * from ) ;
 extern void Svcmd_Test_f ( void ) ;
 extern void SP_worldspawn ( edict_t * ent ) ;
 extern void SpawnEntities ( const char * mapname , char * entities , const char * spawnpoint ) ;
-extern void G_FindTeams ( void ) ;
 extern char * ED_NewString ( const char * string ) ;
 extern void ED_CallSpawn ( edict_t * ent ) ;
 extern void G_RunEntity ( edict_t * ent ) ;

--- a/src/game/savegame/tables/gamefunc_list.h
+++ b/src/game/savegame/tables/gamefunc_list.h
@@ -712,7 +712,6 @@
 {"Svcmd_Test_f", (byte *)Svcmd_Test_f},
 {"SP_worldspawn", (byte *)SP_worldspawn},
 {"SpawnEntities", (byte *)SpawnEntities},
-{"G_FindTeams", (byte *)G_FindTeams},
 {"ED_NewString", (byte *)ED_NewString},
 {"ED_CallSpawn", (byte *)ED_CallSpawn},
 {"G_RunEntity", (byte *)G_RunEntity},

--- a/src/game/savegame/tables/spawnfunc_decs.h
+++ b/src/game/savegame/tables/spawnfunc_decs.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 1997-2001 Id Software, Inc.
+ * Copyright (C) 2011 Yamagi Burmeister
+ * Copyright (c) ZeniMax Media Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * =======================================================================
+ *
+ * Prototypes for every spawn function in the game.so.
+ *
+ * =======================================================================
+ */
+
+void SP_item_health(edict_t *self);
+void SP_item_health_small(edict_t *self);
+void SP_item_health_large(edict_t *self);
+void SP_item_health_mega(edict_t *self);
+
+void SP_info_player_start(edict_t *ent);
+void SP_info_player_deathmatch(edict_t *ent);
+void SP_info_player_coop(edict_t *ent);
+void SP_info_player_intermission(edict_t *ent);
+
+void SP_func_plat(edict_t *ent);
+void SP_func_rotating(edict_t *ent);
+void SP_func_button(edict_t *ent);
+void SP_func_door(edict_t *ent);
+void SP_func_door_secret(edict_t *ent);
+void SP_func_door_rotating(edict_t *ent);
+void SP_func_water(edict_t *ent);
+void SP_func_train(edict_t *ent);
+void SP_func_conveyor(edict_t *self);
+void SP_func_wall(edict_t *self);
+void SP_func_object(edict_t *self);
+void SP_func_explosive(edict_t *self);
+void SP_func_timer(edict_t *self);
+void SP_func_areaportal(edict_t *ent);
+void SP_func_clock(edict_t *ent);
+void SP_func_killbox(edict_t *ent);
+
+void SP_trigger_always(edict_t *ent);
+void SP_trigger_once(edict_t *ent);
+void SP_trigger_multiple(edict_t *ent);
+void SP_trigger_relay(edict_t *ent);
+void SP_trigger_push(edict_t *ent);
+void SP_trigger_hurt(edict_t *ent);
+void SP_trigger_key(edict_t *ent);
+void SP_trigger_counter(edict_t *ent);
+void SP_trigger_elevator(edict_t *ent);
+void SP_trigger_gravity(edict_t *ent);
+void SP_trigger_monsterjump(edict_t *ent);
+
+void SP_target_temp_entity(edict_t *ent);
+void SP_target_speaker(edict_t *ent);
+void SP_target_explosion(edict_t *ent);
+void SP_target_changelevel(edict_t *ent);
+void SP_target_secret(edict_t *ent);
+void SP_target_goal(edict_t *ent);
+void SP_target_splash(edict_t *ent);
+void SP_target_spawner(edict_t *ent);
+void SP_target_blaster(edict_t *ent);
+void SP_target_crosslevel_trigger(edict_t *ent);
+void SP_target_crosslevel_target(edict_t *ent);
+void SP_target_laser(edict_t *self);
+void SP_target_help(edict_t *ent);
+void SP_target_lightramp(edict_t *self);
+void SP_target_earthquake(edict_t *ent);
+void SP_target_character(edict_t *ent);
+void SP_target_string(edict_t *ent);
+
+void SP_worldspawn(edict_t *ent);
+void SP_viewthing(edict_t *ent);
+
+void SP_light(edict_t *self);
+void SP_light_mine1(edict_t *ent);
+void SP_light_mine2(edict_t *ent);
+void SP_info_null(edict_t *self);
+void SP_info_notnull(edict_t *self);
+void SP_path_corner(edict_t *self);
+void SP_point_combat(edict_t *self);
+
+void SP_misc_explobox(edict_t *self);
+void SP_misc_banner(edict_t *self);
+void SP_misc_satellite_dish(edict_t *self);
+void SP_misc_gib_arm(edict_t *self);
+void SP_misc_gib_leg(edict_t *self);
+void SP_misc_gib_head(edict_t *self);
+void SP_misc_insane(edict_t *self);
+void SP_misc_deadsoldier(edict_t *self);
+void SP_misc_viper(edict_t *self);
+void SP_misc_viper_bomb(edict_t *self);
+void SP_misc_bigviper(edict_t *self);
+void SP_misc_strogg_ship(edict_t *self);
+void SP_misc_teleporter(edict_t *self);
+void SP_misc_teleporter_dest(edict_t *self);
+void SP_misc_blackhole(edict_t *self);
+void SP_misc_eastertank(edict_t *self);
+void SP_misc_easterchick(edict_t *self);
+void SP_misc_easterchick2(edict_t *self);
+
+void SP_monster_berserk(edict_t *self);
+void SP_monster_gladiator(edict_t *self);
+void SP_monster_gunner(edict_t *self);
+void SP_monster_infantry(edict_t *self);
+void SP_monster_soldier_light(edict_t *self);
+void SP_monster_soldier(edict_t *self);
+void SP_monster_soldier_ss(edict_t *self);
+void SP_monster_tank(edict_t *self);
+void SP_monster_medic(edict_t *self);
+void SP_monster_flipper(edict_t *self);
+void SP_monster_chick(edict_t *self);
+void SP_monster_parasite(edict_t *self);
+void SP_monster_flyer(edict_t *self);
+void SP_monster_brain(edict_t *self);
+void SP_monster_floater(edict_t *self);
+void SP_monster_hover(edict_t *self);
+void SP_monster_mutant(edict_t *self);
+void SP_monster_supertank(edict_t *self);
+void SP_monster_boss2(edict_t *self);
+void SP_monster_jorg(edict_t *self);
+void SP_monster_makron(edict_t *self);
+void SP_monster_boss3_stand(edict_t *self);
+
+void SP_monster_commander_body(edict_t *self);
+
+void SP_turret_breach(edict_t *self);
+void SP_turret_base(edict_t *self);
+void SP_turret_driver(edict_t *self);

--- a/src/game/savegame/tables/spawnfunc_list.h
+++ b/src/game/savegame/tables/spawnfunc_list.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 1997-2001 Id Software, Inc.
+ * Copyright (C) 2011 Yamagi Burmeister
+ * Copyright (c) ZeniMax Media Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * =======================================================================
+ *
+ * Functionpointers to every spawn function in the game.so.
+ *
+ * =======================================================================
+ */
+
+{"item_health", SP_item_health},
+{"item_health_small", SP_item_health_small},
+{"item_health_large", SP_item_health_large},
+{"item_health_mega", SP_item_health_mega},
+
+{"info_player_start", SP_info_player_start},
+{"info_player_deathmatch", SP_info_player_deathmatch},
+{"info_player_coop", SP_info_player_coop},
+{"info_player_intermission", SP_info_player_intermission},
+
+{"func_plat", SP_func_plat},
+{"func_button", SP_func_button},
+{"func_door", SP_func_door},
+{"func_door_secret", SP_func_door_secret},
+{"func_door_rotating", SP_func_door_rotating},
+{"func_rotating", SP_func_rotating},
+{"func_train", SP_func_train},
+{"func_water", SP_func_water},
+{"func_conveyor", SP_func_conveyor},
+{"func_areaportal", SP_func_areaportal},
+{"func_clock", SP_func_clock},
+{"func_wall", SP_func_wall},
+{"func_object", SP_func_object},
+{"func_timer", SP_func_timer},
+{"func_explosive", SP_func_explosive},
+{"func_killbox", SP_func_killbox},
+
+{"trigger_always", SP_trigger_always},
+{"trigger_once", SP_trigger_once},
+{"trigger_multiple", SP_trigger_multiple},
+{"trigger_relay", SP_trigger_relay},
+{"trigger_push", SP_trigger_push},
+{"trigger_hurt", SP_trigger_hurt},
+{"trigger_key", SP_trigger_key},
+{"trigger_counter", SP_trigger_counter},
+{"trigger_elevator", SP_trigger_elevator},
+{"trigger_gravity", SP_trigger_gravity},
+{"trigger_monsterjump", SP_trigger_monsterjump},
+
+{"target_temp_entity", SP_target_temp_entity},
+{"target_speaker", SP_target_speaker},
+{"target_explosion", SP_target_explosion},
+{"target_changelevel", SP_target_changelevel},
+{"target_secret", SP_target_secret},
+{"target_goal", SP_target_goal},
+{"target_splash", SP_target_splash},
+{"target_spawner", SP_target_spawner},
+{"target_blaster", SP_target_blaster},
+{"target_crosslevel_trigger", SP_target_crosslevel_trigger},
+{"target_crosslevel_target", SP_target_crosslevel_target},
+{"target_laser", SP_target_laser},
+{"target_help", SP_target_help},
+{"target_lightramp", SP_target_lightramp},
+{"target_earthquake", SP_target_earthquake},
+{"target_character", SP_target_character},
+{"target_string", SP_target_string},
+
+{"worldspawn", SP_worldspawn},
+{"viewthing", SP_viewthing},
+
+{"light", SP_light},
+{"light_mine1", SP_light_mine1},
+{"light_mine2", SP_light_mine2},
+{"info_null", SP_info_null},
+{"func_group", SP_info_null},
+{"info_notnull", SP_info_notnull},
+{"path_corner", SP_path_corner},
+{"point_combat", SP_point_combat},
+
+{"misc_explobox", SP_misc_explobox},
+{"misc_banner", SP_misc_banner},
+{"misc_satellite_dish", SP_misc_satellite_dish},
+{"misc_gib_arm", SP_misc_gib_arm},
+{"misc_gib_leg", SP_misc_gib_leg},
+{"misc_gib_head", SP_misc_gib_head},
+{"misc_insane", SP_misc_insane},
+{"misc_deadsoldier", SP_misc_deadsoldier},
+{"misc_viper", SP_misc_viper},
+{"misc_viper_bomb", SP_misc_viper_bomb},
+{"misc_bigviper", SP_misc_bigviper},
+{"misc_strogg_ship", SP_misc_strogg_ship},
+{"misc_teleporter", SP_misc_teleporter},
+{"misc_teleporter_dest", SP_misc_teleporter_dest},
+{"misc_blackhole", SP_misc_blackhole},
+{"misc_eastertank", SP_misc_eastertank},
+{"misc_easterchick", SP_misc_easterchick},
+{"misc_easterchick2", SP_misc_easterchick2},
+
+{"monster_berserk", SP_monster_berserk},
+{"monster_gladiator", SP_monster_gladiator},
+{"monster_gunner", SP_monster_gunner},
+{"monster_infantry", SP_monster_infantry},
+{"monster_soldier_light", SP_monster_soldier_light},
+{"monster_soldier", SP_monster_soldier},
+{"monster_soldier_ss", SP_monster_soldier_ss},
+{"monster_tank", SP_monster_tank},
+{"monster_tank_commander", SP_monster_tank},
+{"monster_medic", SP_monster_medic},
+{"monster_flipper", SP_monster_flipper},
+{"monster_chick", SP_monster_chick},
+{"monster_parasite", SP_monster_parasite},
+{"monster_flyer", SP_monster_flyer},
+{"monster_brain", SP_monster_brain},
+{"monster_floater", SP_monster_floater},
+{"monster_hover", SP_monster_hover},
+{"monster_mutant", SP_monster_mutant},
+{"monster_supertank", SP_monster_supertank},
+{"monster_boss2", SP_monster_boss2},
+{"monster_boss3_stand", SP_monster_boss3_stand},
+{"monster_makron", SP_monster_makron},
+{"monster_jorg", SP_monster_jorg},
+
+{"monster_commander_body", SP_monster_commander_body},
+
+{"turret_breach", SP_turret_breach},
+{"turret_base", SP_turret_base},
+{"turret_driver", SP_turret_driver},
+
+{NULL, NULL}


### PR DESCRIPTION
Add cppcheck validation and fix crashes with rerelease maps when command buffer is reinited inside execution command.