### PR TITLE
server: OPTIMIZE_CSBASE flag for sv_optimize_sp/mp_loadtime cvars

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -63,9 +63,9 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   enable/disable optimizations that speed up level load times (or more
   accurately, client connection).  
   sp stands for singleplayer and mp for multiplayer, respectively.  
-  The sp version is enabled by default (value 15) while multiplayer
+  The sp version is enabled by default (value 31) while multiplayer
   is 0.  
-  The cvar value is a bitmask for 4 optimization features:
+  The cvar value is a bitmask for 5 optimization features:
 
   - **1: Message utilization**: When the server sends the client
     configstrings and other data during the connection process, the
@@ -92,10 +92,17 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
     configstring packets by 1. The saving would be bigger in
     multiplayer due to the added networking latency, and mods with
     longer HUD code would also benefit more from this.
+  - **16: Baselines head-start**: When the server is sending the
+    last configstrings data packet, it adds the first baselines
+    command at the end and leaves any remaining space
+    in the packet unused. When this optimization is enabled,
+    the server will try to use that space for the first few
+    entity baselines. In some levels this can avoid an extra
+    roundtrip of client-server packets.
 
   Simply add these flag values together to get the cvar value you want.
   For example, sendrate + reconnect = 2 + 4 = 6.
-  Set to 15 for all optimizations, or 0 to disable them entirely.
+  Set to 31 for all optimizations, or 0 to disable them entirely.
 
 * **cl_maxfps**: The approximate framerate for client/server ("packet")
   frames if *cl_async* is `1`. If set to `-1` (the default), the engine

--- a/src/server/header/server.h
+++ b/src/server/header/server.h
@@ -297,6 +297,8 @@ trace_t SV_Trace(vec3_t start, vec3_t mins, vec3_t maxs,
 #define OPTIMIZE_SENDRATE 2
 #define OPTIMIZE_RECONNECT 4
 #define OPTIMIZE_HUDSEND 8
+#define OPTIMIZE_CSBASE 16
+#define OPTIMIZE_MASK_ALL 31
 
 int SV_Optimizations(void);
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -381,7 +381,7 @@ SV_Optimizations(void)
 	cv = (svs.gamemode == GAMEMODE_SP) ?
 		sv_optimize_sp_loadtime : sv_optimize_mp_loadtime;
 
-	return cv ? cv->value : 0;
+	return cv ? ((int)cv->value & OPTIMIZE_MASK_ALL) : 0;
 }
 
 void
@@ -603,7 +603,7 @@ SV_Init(void)
 {
 	SV_InitOperatorCommands();
 
-	sv_optimize_sp_loadtime = Cvar_Get("sv_optimize_sp_loadtime", "15", 0);
+	sv_optimize_sp_loadtime = Cvar_Get("sv_optimize_sp_loadtime", "31", 0);
 	sv_optimize_mp_loadtime = Cvar_Get("sv_optimize_mp_loadtime", "0", 0);
 
 	rcon_password = Cvar_Get("rcon_password", "", 0);

--- a/src/server/sv_user.c
+++ b/src/server/sv_user.c
@@ -166,6 +166,60 @@ _NumIndexSkips(int start, int end)
 }
 
 static void
+SV_AddBaselines(int start, qboolean allow_zero)
+{
+	sizebuf_t *msg;
+	int i, is_opt;
+
+	if (start < 0)
+	{
+		start = 0;
+	}
+
+	msg = &sv_client->netchan.message;
+	is_opt = SV_Optimizations() & OPTIMIZE_MSGUTIL;
+
+	for (i = start; i < sv.numbaselines; i++)
+	{
+		const entity_state_t *base = &sv.baselines[i];
+
+		if (base->modelindex || base->sound || base->effects)
+		{
+			if (!_EnoughSpaceInBuffer(msg,
+				MSG_DeltaEntity_Size(NULL, base, true, true), is_opt))
+			{
+				break;
+			}
+
+			MSG_WriteByte(msg, svc_spawnbaseline);
+			MSG_WriteDeltaEntity(NULL, base, msg, true, true);
+		}
+	}
+
+	if (!allow_zero &&
+		(i == start) && (i < sv.numbaselines))
+	{
+		Com_Printf("%s: skipping index %i: too big to send\n",
+			__func__, i);
+		i++;
+	}
+
+	/* send next command */
+	if (i >= sv.numbaselines)
+	{
+		MSG_WriteByte(msg, svc_stufftext);
+		MSG_WriteString(msg,
+				va("precache %i\n", svs.spawncount));
+	}
+	else
+	{
+		MSG_WriteByte(msg, svc_stufftext);
+		MSG_WriteString(msg,
+				va("cmd baselines %i %i\n", svs.spawncount, i));
+	}
+}
+
+static void
 SV_Configstrings_f(void)
 {
 	const char *cs;
@@ -250,9 +304,16 @@ SV_Configstrings_f(void)
 	{
 		PrintOverflowConfigstrings();
 
-		MSG_WriteByte(msg, svc_stufftext);
-		MSG_WriteString(msg,
-				va("cmd baselines %i 0\n", svs.spawncount));
+		if (opt & OPTIMIZE_CSBASE)
+		{
+			/* try use remainder of packet for baselines */
+			SV_AddBaselines(0, true);
+		}
+		else
+		{
+			MSG_WriteByte(msg, svc_stufftext);
+			MSG_WriteString(msg, va("cmd baselines %i 0\n", svs.spawncount));
+		}
 	}
 	else
 	{
@@ -265,12 +326,7 @@ SV_Configstrings_f(void)
 static void
 SV_Baselines_f(void)
 {
-	sizebuf_t *msg;
-	int i, start;
-	int is_opt;
-	const entity_state_t *base;
-
-	start = (Cmd_Argc() > 2) ? (int)strtol(Cmd_Argv(2), (char **)NULL, 10) : 0;
+	int start = (Cmd_Argc() > 2) ? (int)strtol(Cmd_Argv(2), (char **)NULL, 10) : 0;
 
 	Com_DPrintf("Baselines(%i) from %s\n", start, sv_client->name);
 
@@ -289,51 +345,7 @@ SV_Baselines_f(void)
 		return;
 	}
 
-	if (start < 0)
-	{
-		start = 0;
-	}
-
-	msg = &sv_client->netchan.message;
-	is_opt = SV_Optimizations() & OPTIMIZE_MSGUTIL;
-
-	for (i = start; i < sv.numbaselines; i++)
-	{
-		base = &sv.baselines[i];
-
-		if (base->modelindex || base->sound || base->effects)
-		{
-			if (!_EnoughSpaceInBuffer(msg,
-				MSG_DeltaEntity_Size(NULL, base, true, true), is_opt))
-			{
-				break;
-			}
-
-			MSG_WriteByte(msg, svc_spawnbaseline);
-			MSG_WriteDeltaEntity(NULL, base, msg, true, true);
-		}
-	}
-
-	if ((i == start) && (i < sv.numbaselines))
-	{
-		Com_Printf("%s: skipping index %i: too big to send\n",
-			__func__, i);
-		i++;
-	}
-
-	/* send next command */
-	if (i >= sv.numbaselines)
-	{
-		MSG_WriteByte(msg, svc_stufftext);
-		MSG_WriteString(msg,
-				va("precache %i\n", svs.spawncount));
-	}
-	else
-	{
-		MSG_WriteByte(msg, svc_stufftext);
-		MSG_WriteString(msg,
-				va("cmd baselines %i %i\n", svs.spawncount, i));
-	}
+	SV_AddBaselines(start, false);
 }
 
 static void


### PR DESCRIPTION
This PR adds new `OPTIMIZE_CSBASE` flag (`16`) for the `sv_optimize_sp/mp_loadtime` cvars and sets the sp default value to `31`.

The last configstrings packet is usually only partially filled with data. With this optimization enabled, the server will, if possible, use that leftover space for a first batch of entity baselines. In some levels this will shave off one roundtrip of client-server packets. Only a trivial optimization for single-player but may be more noticeable in multiplayer due to the added networking latenncy.

I was also thinking, should I increase the default value of `sv_optimize_mp_loadtime` to 7? It's been a while now and I feel this should be safe. Does anyone here have experience with playing LAN or internet multiplayer with loadtime optimizations enabled?