### PR TITLE
server: cache per-client leaf data across SV_Multicast fanout

### DIFF
--- a/src/server/header/server.h
+++ b/src/server/header/server.h
@@ -147,6 +147,13 @@ typedef struct client_s
 	int challenge;                      /* challenge of this user, randomly generated */
 
 	netchan_t netchan;
+
+	/* per-frame caches for SV_Multicast fanout */
+	vec3_t cached_origin;
+	int cached_leafnum;
+	int cached_area;
+	int cached_cluster;
+	int cached_framenum;
 } client_t;
 
 typedef struct

--- a/src/server/sv_send.c
+++ b/src/server/sv_send.c
@@ -142,30 +142,25 @@ SV_BroadcastCommand(const char *fmt, ...)
  * MULTICAST_PHS	send to clients potentially hearable from org
  */
 static qboolean
-SV_WereConnected(const vec3_t origin, const byte *mask, int area1)
+SV_WereConnected(int cluster, int area2, vec3_t origin,
+		 const byte *mask, int area1)
 {
-	vec3_t origin2;
-	int leafnum;
-	int cluster;
-
-	VectorCopy(origin, origin2);
-
-	leafnum = CM_PointLeafnum(origin2);
-	cluster = CM_LeafCluster(leafnum);
-
 	// cluster can be -1 if we're in the void (or sometimes just at a wall)
 	// and using a negative index into mask[] would be invalid
 	if (cluster >= 0 && (mask[cluster >> 3] & (1 << (cluster & 7))))
 	{
-		if (CM_AreasConnected(area1, CM_LeafArea(leafnum)))
+		if (CM_AreasConnected(area1, area2))
 		{
 			return true;
 		}
 	}
 
 	// if the client is currently in water, do a second check
-	if (CM_PointContents(origin2, 0) & MASK_WATER)
+	if (CM_PointContents(origin, 0) & MASK_WATER)
 	{
+		vec3_t origin2;
+		int leafnum2, cluster2;
+
 		// if the client is half-submerged in opaque water so its origin
 		// is below the water, but the head/camera is still above the water
 		// and thus should be able to see/hear explosions or similar
@@ -173,14 +168,15 @@ SV_WereConnected(const vec3_t origin, const byte *mask, int area1)
 		// so try again at a slightly higher position
 		// FIXME: OTOH, we have a similar problem if we're over water and shoot under water (near water level) => can't see explosion
 
+		VectorCopy(origin, origin2);
 		origin2[2] += 32.0f;
 
-		leafnum = CM_PointLeafnum(origin2);
-		cluster = CM_LeafCluster(leafnum);
+		leafnum2 = CM_PointLeafnum(origin2);
+		cluster2 = CM_LeafCluster(leafnum2);
 
-		if (cluster >= 0 && (mask[cluster >> 3] & (1 << (cluster & 7))))
+		if (cluster2 >= 0 && (mask[cluster2 >> 3] & (1 << (cluster2 & 7))))
 		{
-			if (CM_AreasConnected(area1, CM_LeafArea(leafnum)))
+			if (CM_AreasConnected(area1, CM_LeafArea(leafnum2)))
 			{
 				return true;
 			}
@@ -188,6 +184,25 @@ SV_WereConnected(const vec3_t origin, const byte *mask, int area1)
 	}
 
 	return false;
+}
+
+static void
+SV_GetClientLeafCache(client_t *client, int *area, int *cluster)
+{
+	edict_t *e = CL_EDICT(client);
+
+	if (client->cached_framenum != sv.framenum ||
+	    !VectorCompare(client->cached_origin, e->s.origin))
+	{
+		VectorCopy(e->s.origin, client->cached_origin);
+		client->cached_leafnum = CM_PointLeafnum(e->s.origin);
+		client->cached_area = CM_LeafArea(client->cached_leafnum);
+		client->cached_cluster = CM_LeafCluster(client->cached_leafnum);
+		client->cached_framenum = sv.framenum;
+	}
+
+	*area = client->cached_area;
+	*cluster = client->cached_cluster;
 }
 
 void
@@ -256,7 +271,10 @@ SV_Multicast(vec3_t origin, multicast_t to)
 
 		if (mask)
 		{
-			if (!SV_WereConnected(CL_EDICT(client)->s.origin, mask, area1))
+			int area2, cluster2;
+			SV_GetClientLeafCache(client, &area2, &cluster2);
+
+			if (!SV_WereConnected(cluster2, area2, CL_EDICT(client)->s.origin, mask, area1))
 			{
 				continue;
 			}


### PR DESCRIPTION
SV_Multicast iterates every connected client and previously recomputed CM_PointLeafnum + CM_LeafArea + CM_LeafCluster on the receiver's origin for each event. With many multicast events per server frame (sounds, temp entities, weapon/explosion effects), the same BSP descent and area lookup ran repeatedly per client even though the client origin only changes once per frame.

Cache the leaf/area/cluster trio on client_t, keyed by sv.framenum and origin. The first SV_Multicast of a frame populates the cache; subsequent events in the same frame reuse it, collapsing per-client lookup cost from O(events_per_frame) BSP walks to one. The origin compare keeps the cache correct if a client teleports or is moved mid-frame, and the underwater retry path stays dynamic since it probes a different point.