### PR TITLE
ref_soft: Fix particle clipping and improve translucent depth sorting

### DIFF
--- a/src/client/refresh/soft/sw_main.c
+++ b/src/client/refresh/soft/sw_main.c
@@ -820,9 +820,8 @@ R_DrawEntitiesOnList
 =============
 */
 static void
-R_DrawEntitiesOnList (void)
+R_DrawEntitiesOnList (qboolean translucent)
 {
-	qboolean translucent_entities = false;
 	int i;
 
 	if (!r_drawentities->value)
@@ -830,107 +829,106 @@ R_DrawEntitiesOnList (void)
 		return;
 	}
 
-	// all bmodels have already been drawn by the edge list
-	for (i = 0; i < r_newrefdef.num_entities; i++)
+	if (!translucent)
 	{
-		entity_t *currententity = &r_newrefdef.entities[i];
+		// all bmodels have already been drawn by the edge list
+		for (i = 0; i < r_newrefdef.num_entities; i++)
+		{
+			entity_t *currententity = &r_newrefdef.entities[i];
 
-		if (currententity->flags & RF_TRANSLUCENT)
-		{
-			translucent_entities = true;
-			continue; /* not solid */
-		}
-
-		if ( currententity->flags & RF_BEAM )
-		{
-			modelorg[0] = -r_origin[0];
-			modelorg[1] = -r_origin[1];
-			modelorg[2] = -r_origin[2];
-			VectorCopy(vec3_origin, r_entorigin);
-			R_DrawBeam(currententity);
-		}
-		else
-		{
-			const model_t *currentmodel = currententity->model;
-			if (!currentmodel)
+			if (currententity->flags & RF_TRANSLUCENT)
 			{
-				R_DrawNullModel();
-				continue;
+				continue; /* not solid */
 			}
-			VectorCopy (currententity->origin, r_entorigin);
-			VectorSubtract (r_origin, r_entorigin, modelorg);
 
-			switch (currentmodel->type)
+			if ( currententity->flags & RF_BEAM )
 			{
-			case mod_sprite:
-				R_DrawSprite(currententity, currentmodel);
-				break;
+				modelorg[0] = -r_origin[0];
+				modelorg[1] = -r_origin[1];
+				modelorg[2] = -r_origin[2];
+				VectorCopy(vec3_origin, r_entorigin);
+				R_DrawBeam(currententity);
+			}
+			else
+			{
+				const model_t *currentmodel = currententity->model;
+				if (!currentmodel)
+				{
+					R_DrawNullModel();
+					continue;
+				}
+				VectorCopy (currententity->origin, r_entorigin);
+				VectorSubtract (r_origin, r_entorigin, modelorg);
 
-			case mod_alias:
-				R_DrawAliasModel(currententity, currentmodel);
-				break;
+				switch (currentmodel->type)
+				{
+				case mod_sprite:
+					R_DrawSprite(currententity, currentmodel);
+					break;
 
-			case mod_brush:
-				break;
+				case mod_alias:
+					R_DrawAliasModel(currententity, currentmodel);
+					break;
 
-			default:
-				Com_Printf("%s: Bad modeltype %d\n",
-					__func__, currentmodel->type);
-				return;
+				case mod_brush:
+					break;
+
+				default:
+					Com_Printf("%s: Bad modeltype %d\n",
+						__func__, currentmodel->type);
+					return;
+				}
 			}
 		}
 	}
-
-	if (!translucent_entities)
+	else
 	{
-		return;
-	}
-
-	for (i = 0; i < r_newrefdef.num_entities; i++)
-	{
-		entity_t *currententity = &r_newrefdef.entities[i];
-
-		if (!(currententity->flags & RF_TRANSLUCENT))
+		for (i = 0; i < r_newrefdef.num_entities; i++)
 		{
-			continue; /* solid */
-		}
+			entity_t *currententity = &r_newrefdef.entities[i];
 
-		if (currententity->flags & RF_BEAM)
-		{
-			modelorg[0] = -r_origin[0];
-			modelorg[1] = -r_origin[1];
-			modelorg[2] = -r_origin[2];
-			VectorCopy(vec3_origin, r_entorigin);
-			R_DrawBeam(currententity);
-		}
-		else
-		{
-			const model_t *currentmodel = currententity->model;
-			if (!currentmodel)
+			if (!(currententity->flags & RF_TRANSLUCENT))
 			{
-				R_DrawNullModel();
-				continue;
+				continue; /* solid */
 			}
-			VectorCopy (currententity->origin, r_entorigin);
-			VectorSubtract (r_origin, r_entorigin, modelorg);
 
-			switch (currentmodel->type)
+			if (currententity->flags & RF_BEAM)
 			{
-			case mod_sprite:
-				R_DrawSprite(currententity, currentmodel);
-				break;
+				modelorg[0] = -r_origin[0];
+				modelorg[1] = -r_origin[1];
+				modelorg[2] = -r_origin[2];
+				VectorCopy(vec3_origin, r_entorigin);
+				R_DrawBeam(currententity);
+			}
+			else
+			{
+				const model_t *currentmodel = currententity->model;
+				if (!currentmodel)
+				{
+					R_DrawNullModel();
+					continue;
+				}
+				VectorCopy (currententity->origin, r_entorigin);
+				VectorSubtract (r_origin, r_entorigin, modelorg);
 
-			case mod_alias:
-				R_DrawAliasModel(currententity, currentmodel);
-				break;
+				switch (currentmodel->type)
+				{
+				case mod_sprite:
+					R_DrawSprite(currententity, currentmodel);
+					break;
 
-			case mod_brush:
-				break;
+				case mod_alias:
+					R_DrawAliasModel(currententity, currentmodel);
+					break;
 
-			default:
-				Com_Printf("%s: Bad modeltype %d\n",
-					__func__, currentmodel->type);
-				return;
+				case mod_brush:
+					break;
+
+				default:
+					Com_Printf("%s: Bad modeltype %d\n",
+						__func__, currentmodel->type);
+					return;
+				}
 			}
 		}
 	}
@@ -1415,7 +1413,7 @@ RE_RenderFrame(refdef_t *fd)
 	}
 	// Draw enemies, barrel etc...
 	// Use Z-Buffer mostly in read mode only.
-	R_DrawEntitiesOnList();
+	R_DrawEntitiesOnList(false);
 
 	if (r_dspeeds->value)
 	{
@@ -1433,6 +1431,8 @@ RE_RenderFrame(refdef_t *fd)
 
 	// Perform pixel palette blending ia the pics/colormap.pcx lower part lookup table.
 	R_DrawAlphaSurfaces(&ent);
+
+	R_DrawEntitiesOnList(true);
 
 	// Save off light value for server to look at (BIG HACK!)
 	R_SetLightLevel(&ent);

--- a/src/client/refresh/soft/sw_main.c
+++ b/src/client/refresh/soft/sw_main.c
@@ -819,14 +819,15 @@ R_DrawNullModel(void)
 R_DrawEntitiesOnList
 =============
 */
-static void
+static qboolean
 R_DrawEntitiesOnList (qboolean translucent)
 {
 	int i;
+	qboolean anytranslucent = false;
 
 	if (!r_drawentities->value)
 	{
-		return;
+		return false;
 	}
 
 	if (!translucent)
@@ -838,6 +839,7 @@ R_DrawEntitiesOnList (qboolean translucent)
 
 			if (currententity->flags & RF_TRANSLUCENT)
 			{
+				anytranslucent = true;
 				continue; /* not solid */
 			}
 
@@ -876,7 +878,7 @@ R_DrawEntitiesOnList (qboolean translucent)
 				default:
 					Com_Printf("%s: Bad modeltype %d\n",
 						__func__, currentmodel->type);
-					return;
+					return false;
 				}
 			}
 		}
@@ -927,11 +929,13 @@ R_DrawEntitiesOnList (qboolean translucent)
 				default:
 					Com_Printf("%s: Bad modeltype %d\n",
 						__func__, currentmodel->type);
-					return;
+					return false;
 				}
 			}
 		}
 	}
+
+	return anytranslucent;
 }
 
 
@@ -1343,6 +1347,7 @@ RE_RenderFrame(refdef_t *fd)
 {
 	r_newrefdef = *fd;
 	entity_t	ent;
+	qboolean	anytranslucent = false;
 
 	if (!r_worldmodel && !( r_newrefdef.rdflags & RDF_NOWORLDMODEL ) )
 	{
@@ -1413,7 +1418,7 @@ RE_RenderFrame(refdef_t *fd)
 	}
 	// Draw enemies, barrel etc...
 	// Use Z-Buffer mostly in read mode only.
-	R_DrawEntitiesOnList(false);
+	anytranslucent = R_DrawEntitiesOnList(false);
 
 	if (r_dspeeds->value)
 	{
@@ -1432,7 +1437,10 @@ RE_RenderFrame(refdef_t *fd)
 	// Perform pixel palette blending ia the pics/colormap.pcx lower part lookup table.
 	R_DrawAlphaSurfaces(&ent);
 
-	R_DrawEntitiesOnList(true);
+	if (anytranslucent)
+	{
+		R_DrawEntitiesOnList(true);
+	}
 
 	// Save off light value for server to look at (BIG HACK!)
 	R_SetLightLevel(&ent);

--- a/src/client/refresh/soft/sw_part.c
+++ b/src/client/refresh/soft/sw_part.c
@@ -101,7 +101,10 @@ R_DrawParticle(particle_t *pparticle, int level)
 	** render the appropriate pixels
 	*/
 	count = pix;
-	if ((pz[(vid_buffer_width * count / 2) + (count / 2)]) > izi)
+
+	int half_count = count / 2;
+
+	if (pz[(vid_buffer_width * half_count) + half_count] > izi)
 	{
 		// looks like under some object
 		return;


### PR DESCRIPTION
Greetings, community.

This PR contains three small fixes to improve the Software Renderer (`ref_soft`), resolving particle disappearing issues and depth sorting bugs for translucent objects.

#### **Summary of Changes:**

* **Fix particle clipping at steep angles (`sw_part.c`):**
  * **Problem:** Particles of all types would suddenly disappear or flicker at certain camera angles (very noticeable at lower resolutions like 240p).
  * **Fix:** Corrected the depth-test calculation to ensure accurate particle culling regardless of the camera's angle.

* **Enable depth writing for translucent sprites (`sw_poly.c`):**
  * **Problem:** Translucent sprites were drawn without updating the Z-buffer, causing sorting issues when they overlapped.
  * **Fix:** Turned on depth writing for translucent sprites to ensure they overlap and occlusion works naturally.

* **Fix depth writing and screen tracking for 33% translucent models (`sw_polyset.c`):**
  * **Problem:** Translucent models had rendering artifacts and flickering.
  * **Fix:** Ensured 33% translucent models correctly write to the Z-buffer and trigger viewport damage tracking.

These fixes make the software renderer more stable and visually consistent. I can provide screenshots showing the before and after if needed!

I look forward to hearing your comments.

Before:
<img width="659" height="519" alt="bfg-antes" src="https://github.com/user-attachments/assets/0c8c54b8-a200-476e-8829-14906e6ce394" />

After:
<img width="671" height="519" alt="bgf-ahora" src="https://github.com/user-attachments/assets/d75270a6-36e1-4ddf-a09c-7fac23141a1e" />

Before:
<img width="657" height="518" alt="rail-antes" src="https://github.com/user-attachments/assets/d940a1cf-466a-4ba6-b779-b792f1ccbd14" />

After:
<img width="674" height="533" alt="rail-ahora" src="https://github.com/user-attachments/assets/d9746489-4687-43a9-8a40-5003ab7f8bcf" />


> **Note on AI Assistance:**
> *I prepared these fixes and code modifications with the assistance of an AI coding partner. All changes have been manually reviewed, compiled, and verified to ensure they meet Yamagi Quake II's standards.*
