### PR TITLE
client, server: Optionally use system copies of libminizip and Zlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ WITH_RPATH:=yes
 # When disabled SDL 2 is used instead of SDL 3.
 WITH_SDL3:=yes
 
+# WITH_SYSTEM_MINIZIP
+# When disabled, an included copy of minizip and miniz is used.
+WITH_SYSTEM_MINIZIP:=no
+
 # WITH_SYSTEMWIDE
 # Enable systemwide installation of game assets.
 WITH_SYSTEMWIDE:=no
@@ -1048,11 +1052,6 @@ CLIENT_OBJS_ := \
 	src/common/shared/flash.o \
 	src/common/shared/rand.o \
 	src/common/shared/shared.o \
-	src/common/unzip/ioapi.o \
-	src/common/unzip/unzip.o \
-	src/common/unzip/miniz/miniz.o \
-	src/common/unzip/miniz/miniz_tdef.o \
-	src/common/unzip/miniz/miniz_tinfl.o \
 	src/server/sv_cmd.o \
 	src/server/sv_conless.o \
 	src/server/sv_entities.o \
@@ -1063,6 +1062,18 @@ CLIENT_OBJS_ := \
 	src/server/sv_send.o \
 	src/server/sv_user.o \
 	src/server/sv_world.o
+
+ifeq ($(WITH_SYSTEM_MINIZIP),yes)
+$(BINDIR)/quake2 : CFLAGS += -DUSE_SYSTEM_MINIZIP
+$(BINDIR)/quake2 : LDLIBS += -lminizip -lz
+else
+CLIENT_OBJS_ += \
+	src/common/unzip/ioapi.o \
+	src/common/unzip/unzip.o \
+	src/common/unzip/miniz/miniz.o \
+	src/common/unzip/miniz/miniz_tdef.o \
+	src/common/unzip/miniz/miniz_tinfl.o
+endif
 
 ifeq ($(WITH_SDL3),yes)
 CLIENT_OBJS_ += \
@@ -1226,11 +1237,6 @@ SERVER_OBJS_ := \
 	src/common/zone.o \
 	src/common/shared/rand.o \
 	src/common/shared/shared.o \
-	src/common/unzip/ioapi.o \
-	src/common/unzip/unzip.o \
-	src/common/unzip/miniz/miniz.o \
-	src/common/unzip/miniz/miniz_tdef.o \
-	src/common/unzip/miniz/miniz_tinfl.o \
 	src/server/sv_cmd.o \
 	src/server/sv_conless.o \
 	src/server/sv_entities.o \
@@ -1241,6 +1247,18 @@ SERVER_OBJS_ := \
 	src/server/sv_send.o \
 	src/server/sv_user.o \
 	src/server/sv_world.o
+
+ifeq ($(WITH_SYSTEM_MINIZIP),yes)
+$(BINDIR)/q2ded : CFLAGS += -DUSE_SYSTEM_MINIZIP
+$(BINDIR)/q2ded : LDLIBS += -lminizip
+else
+SERVER_OBJS_ += \
+	src/common/unzip/ioapi.o \
+	src/common/unzip/unzip.o \
+	src/common/unzip/miniz/miniz.o \
+	src/common/unzip/miniz/miniz_tdef.o \
+	src/common/unzip/miniz/miniz_tinfl.o
+endif
 
 ifeq ($(YQ2_OSTYPE), Windows)
 SERVER_OBJS_ += \

--- a/doc/070_packaging.md
+++ b/doc/070_packaging.md
@@ -58,6 +58,21 @@ binaries. It allows several Quake2 source ports to share the same game
 data.
 
 
+## The `WITH_SYSTEM_MINIZIP` option
+
+The default is to use an included copy of the `minizip` library,
+which uses an included copy of the `miniz` library as a replacement
+for zlib.
+
+Integrated distribution vendors might prefer to link to a system copy of
+the `minizip` library. This can be done by building with
+`make WITH_SYSTEM_MINIZIP=yes`, or a similar command.
+In this mode, `libminizip` and `libz` headers and shared or static
+libraries are assumed to be available in the compiler's default
+search path, or by adding appropriate `-I` options in `CPPFLAGS`
+and appropriate `-L` options in `LDFLAGS`.
+
+
 ## Alternative startup config
 
 Yamagi Quake II has support for an alternative startup config. That

--- a/src/client/vid/vid.c
+++ b/src/client/vid/vid.c
@@ -35,7 +35,11 @@
 // Screenshots
 // -----------
 
+#ifdef USE_SYSTEM_MINIZIP
+#include <zlib.h>
+#else
 #include "../../common/unzip/miniz/miniz.h"
+#endif
 
 static unsigned char*
 compress_for_stbiw(unsigned char *data, int data_len, int *out_len, int quality)

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -31,7 +31,12 @@
 
 #include "header/common.h"
 #include "header/glob.h"
+
+#ifdef USE_SYSTEM_MINIZIP
+#include <minizip/unzip.h>
+#else
 #include "unzip/unzip.h"
+#endif
 
 #include "../client/sound/header/vorbis.h"
 
@@ -142,7 +147,12 @@ fsRawPath_t *fs_rawPath;
  */
 
 #include <windows.h>
+
+#ifdef USE_SYSTEM_MINIZIP
+#include <minizip/ioapi.h>
+#else
 #include "unzip/ioapi.h"
+#endif
 
 zlib_filefunc_def zlib_file_api;
 


### PR DESCRIPTION
Some Linux distributions have a system copy of the minizip library, either built from zlib's contrib directory or as a separate package. In such distributions, having a private copy in applications is generally discouraged, because it means more places that need to be updated every time a security issue is found.

---

For the moment this only works for the `Makefile` build system, and the CMake build system is still hard-coded to use the vendored minizip and miniz.