### PR TITLE
sound: Random music playback

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -348,9 +348,7 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   - `0`: Loop the current track (the default).
   - `1`: Play the current track once, then stop.
   - `2`: Play all available tracks in a linear sequence.
-  - `3`: Shuffle through the available tracks, never play the same track
-         twice in a row.
-  - `4`: Shuffle through the available tracks, may play the same track
+  - `3`: Shuffle through the available tracks, may play the same track
          multiple times in a row.
 
 * **s_doppler**: If set to `1` doppler effects are enabled. This is only

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2706,7 +2706,6 @@ Options_MenuInit(void)
 		"play once",
 		"sequential",
 		"random",
-		"truly random",
 		0
 	};
 

--- a/src/client/sound/ogg.c
+++ b/src/client/sound/ogg.c
@@ -531,7 +531,6 @@ OGG_PlayTrack(const char *track, qboolean cdtrack, qboolean immediate)
 		newtrack = (curtrack + 1) % (ogg_maxfileindex + 1) != 0 ? (curtrack + 1) : 2;
 	} break;
 	case 3:			// random
-	case 4:			// random with true randomness
 	{
 		int retries = 100;
 		newtrack = 0;
@@ -539,14 +538,6 @@ OGG_PlayTrack(const char *track, qboolean cdtrack, qboolean immediate)
 		while (retries-- > 0 && newtrack < 2)
 		{
 			newtrack = randk() % (ogg_maxfileindex + 1);
-
-			if (playback == 3)
-			{
-				if (newtrack == curtrack)
-				{
-					newtrack = 0;
-				}
-			}
 		}
 	} break;
 	}


### PR DESCRIPTION
This is to fix a mistake on the initial commit, true randomness can playback the same track twice. To keep things simple I have removed the "truly random" option, keeping "random", as a skip or reshuffle key-bind would be more appropriate.