### PR TITLE
client: Add 2 server frame delay on lerping newly created client lasers

### DIFF
--- a/src/client/cl_entities.c
+++ b/src/client/cl_entities.c
@@ -27,6 +27,13 @@
 #include <math.h>
 #include "header/client.h"
 
+/* skip lerping the first server frames after client receives it
+ * avoids lerping toggled lasers
+ * and fixes lerp-spamming with xatrix monster lasers
+ * they spawn short-lived lasers repeatedly
+ */
+#define LASERLERP_NSKIPS 2
+
 void
 CL_AddPacketEntities(frame_t *frame)
 {
@@ -122,7 +129,8 @@ CL_AddPacketEntities(frame_t *frame)
 		ent.oldframe = cent->prev.frame;
 		ent.backlerp = 1.0f - cl.lerpfrac;
 
-		if (renderfx & RF_BEAM)
+		if ((renderfx & RF_BEAM) &&
+			(cl.frame.serverframe - cent->serverframe_created) >= LASERLERP_NSKIPS)
 		{
 			for (i = 0; i < 3; i++)
 			{
@@ -132,7 +140,7 @@ CL_AddPacketEntities(frame_t *frame)
 						(cent->current.old_origin[i] - cent->prev.old_origin[i]));
 			}
 		}
-		else if (renderfx & RF_FRAMELERP)
+		else if (renderfx & (RF_BEAM | RF_FRAMELERP))
 		{
 			/* step origin discretely, because the
 			   frames do the animation properly */

--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -331,6 +331,8 @@ CL_DeltaEntity(frame_t *frame, int newnum, const entity_state_t *old, int bits)
 		   lerping doesn't hurt anything */
 		ent->prev = *state;
 
+		ent->serverframe_created = cl.frame.serverframe;
+
 		if (state->event == EV_OTHER_TELEPORT)
 		{
 			VectorCopy(state->origin, ent->prev.origin);

--- a/src/client/header/client.h
+++ b/src/client/header/client.h
@@ -80,6 +80,7 @@ typedef struct
 	entity_state_t	current;
 	entity_state_t	prev; /* will always be valid, but might just be a copy of current */
 
+	int			serverframe_created; /* set any time the client ent is initialized */
 	int			serverframe; /* if not current, this ent isn't in the frame */
 
 	int			trailcount;	 /* for diminishing grenade trails */


### PR DESCRIPTION
Fixes https://github.com/yquake2/yquake2/issues/1316

This fixes toggled lasers lerping every time they turn on and lerp-spamming xatrix monster lasers that are short-lived and spawned repeatedly.

Now there is a `serverframe_created` in `centity_t`, set when a client receives an entity that was previously absent in packet(s). Subtracting this value from `cl.frame.serverframe` gives the client lifetime of the entity relative to number of server frames that have passed.

**Known minor issue**: `sv.framenum` increases even while the game is paused. This means if the game is paused during one of the delay frames of the entity, it will appear lerped on the paused screen. This is a minor issue and so won't be fixed unless someone knows a better way to do this.

Thanks to @protocultor for reporting this issue, suggesting using server frames and testing the fix.