### PR TITLE
game: Fixed chick, flipper, infantry and parasite not playing their search sounds

### DIFF
--- a/src/game/monster/brain/brain.c
+++ b/src/game/monster/brain/brain.c
@@ -194,13 +194,25 @@ mmove_t brain_move_idle =
 void
 brain_idle(edict_t *self)
 {
+	int n;
+
 	if (!self)
 	{
 		return;
 	}
 
-	gi.sound(self, CHAN_AUTO, sound_idle3, 1, ATTN_IDLE, 0);
-	self->monsterinfo.currentmove = &brain_move_idle;
+	n = randk() & 3;
+
+	if (n <= 1)
+	{
+		self->monsterinfo.currentmove = &brain_move_idle;
+		gi.sound(self, CHAN_AUTO, sound_idle3, 1, ATTN_IDLE, 0);
+	}
+	else
+	{
+		gi.sound(self, CHAN_VOICE,
+			(n == 2) ? sound_idle1 : sound_idle2, 1, ATTN_IDLE, 0);
+	}
 }
 
 static mframe_t brain_frames_walk1[] = {

--- a/src/game/monster/chick/chick.c
+++ b/src/game/monster/chick/chick.c
@@ -249,6 +249,17 @@ mmove_t chick_move_run =
    	NULL
 };
 
+void
+chick_search(edict_t *self)
+{
+	if (!self)
+	{
+		return;
+	}
+
+	gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
+}
+
 static mframe_t chick_frames_walk[] = {
 	{ai_walk, 6, NULL},
 	{ai_walk, 8, chick_footstep},
@@ -990,6 +1001,7 @@ SP_monster_chick(edict_t *self)
 	self->monsterinfo.attack = chick_attack;
 	self->monsterinfo.melee = chick_melee;
 	self->monsterinfo.sight = chick_sight;
+	self->monsterinfo.search = chick_search;
 
 	gi.linkentity(self);
 

--- a/src/game/monster/chick/chick.c
+++ b/src/game/monster/chick/chick.c
@@ -454,6 +454,18 @@ chick_dead(edict_t *self)
 	gi.linkentity(self);
 }
 
+static void
+chick_fall_down(edict_t *self)
+{
+	if (!self)
+	{
+		return;
+	}
+
+	/* CHAN_VOICE so gibbing the body cancels this sound */
+	gi.sound(self, CHAN_VOICE, sound_fall_down, 1, ATTN_NORM, 0);
+}
+
 static mframe_t chick_frames_death2[] = {
 	{ai_move, -6, NULL},
 	{ai_move, 0, NULL},
@@ -476,7 +488,7 @@ static mframe_t chick_frames_death2[] = {
 	{ai_move, -5, NULL},
 	{ai_move, 4, NULL},
 	{ai_move, 15, NULL},
-	{ai_move, 14, NULL},
+	{ai_move, 14, chick_fall_down},
 	{ai_move, 1, NULL}
 };
 

--- a/src/game/monster/flipper/flipper.c
+++ b/src/game/monster/flipper/flipper.c
@@ -40,6 +40,17 @@ static int sound_sight;
 
 void flipper_stand(edict_t *self);
 
+void
+flipper_idle(edict_t *self)
+{
+	if (!self)
+	{
+		return;
+	}
+
+	gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
+}
+
 static mframe_t flipper_frames_stand[] = {
 	{ai_stand, 0, NULL}
 };
@@ -564,6 +575,7 @@ SP_monster_flipper(edict_t *self)
 	self->monsterinfo.run = flipper_start_run;
 	self->monsterinfo.melee = flipper_melee;
 	self->monsterinfo.sight = flipper_sight;
+	self->monsterinfo.idle = flipper_idle;
 	self->monsterinfo.search = flipper_search;
 
 	gi.linkentity(self);

--- a/src/game/monster/flipper/flipper.c
+++ b/src/game/monster/flipper/flipper.c
@@ -139,6 +139,17 @@ flipper_run(edict_t *self)
 	self->monsterinfo.currentmove = &flipper_move_run_start;
 }
 
+void
+flipper_search(edict_t *self)
+{
+	if (!self)
+	{
+		return;
+	}
+
+	gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
+}
+
 /* Standard Swimming */
 static mframe_t flipper_frames_walk[] = {
 	{ai_walk, 4, NULL},
@@ -553,6 +564,7 @@ SP_monster_flipper(edict_t *self)
 	self->monsterinfo.run = flipper_start_run;
 	self->monsterinfo.melee = flipper_melee;
 	self->monsterinfo.sight = flipper_sight;
+	self->monsterinfo.search = flipper_search;
 
 	gi.linkentity(self);
 

--- a/src/game/monster/infantry/infantry.c
+++ b/src/game/monster/infantry/infantry.c
@@ -185,6 +185,17 @@ infantry_fidget(edict_t *self)
 	gi.sound(self, CHAN_VOICE, sound_idle, 1, ATTN_IDLE, 0);
 }
 
+void
+infantry_search(edict_t *self)
+{
+	if (!self)
+	{
+		return;
+	}
+
+	gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
+}
+
 static mframe_t infantry_frames_walk[] = {
 	{ai_walk, 5, infantry_footstep},
 	{ai_walk, 4, NULL},
@@ -850,6 +861,7 @@ SP_monster_infantry(edict_t *self)
 	self->monsterinfo.melee = NULL;
 	self->monsterinfo.sight = infantry_sight;
 	self->monsterinfo.idle = infantry_fidget;
+	self->monsterinfo.search = infantry_search;
 
 	gi.linkentity(self);
 

--- a/src/game/monster/parasite/parasite.c
+++ b/src/game/monster/parasite/parasite.c
@@ -120,7 +120,7 @@ parasite_search(edict_t *self)
 		return;
 	}
 
-	gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_IDLE, 0);
+	gi.sound(self, CHAN_VOICE, sound_search, 1, ATTN_NORM, 0);
 }
 
 static mframe_t parasite_frames_start_fidget[] = {
@@ -784,6 +784,7 @@ SP_monster_parasite(edict_t *self)
 	self->monsterinfo.attack = parasite_attack;
 	self->monsterinfo.sight = parasite_sight;
 	self->monsterinfo.idle = parasite_idle;
+	self->monsterinfo.search = parasite_search;
 
 	gi.linkentity(self);
 

--- a/src/game/savegame/tables/gamefunc_decs.h
+++ b/src/game/savegame/tables/gamefunc_decs.h
@@ -341,6 +341,7 @@ extern void medic_dodge (edict_t *, edict_t *, float);
 extern void soldier_dodge (edict_t *, edict_t *, float);
 // monsterinfo.idle
 extern void brain_idle (edict_t *);
+extern void flipper_idle (edict_t *);
 extern void floater_idle (edict_t *);
 extern void flyer_idle (edict_t *);
 extern void gladiator_idle (edict_t *);

--- a/src/game/savegame/tables/gamefunc_decs.h
+++ b/src/game/savegame/tables/gamefunc_decs.h
@@ -354,11 +354,15 @@ extern void berserk_search (edict_t *);
 extern void boss2_search (edict_t *);
 extern void jorg_search (edict_t *);
 extern void brain_search (edict_t *);
+extern void chick_search (edict_t *);
+extern void flipper_search (edict_t *);
 extern void gladiator_search (edict_t *);
 extern void gunner_search (edict_t *);
 extern void hover_search (edict_t *);
+extern void infantry_search (edict_t *);
 extern void medic_search (edict_t *);
 extern void mutant_search (edict_t *);
+extern void parasite_search (edict_t *);
 extern void supertank_search (edict_t *);
 // monsterinfo.sight
 extern void berserk_sight (edict_t *, edict_t *);

--- a/src/game/savegame/tables/gamefunc_list.h
+++ b/src/game/savegame/tables/gamefunc_list.h
@@ -453,6 +453,7 @@ static const functionList_t fnlist_mi_dodge =
 static const fnlist_entry_t fnentries_mi_idle[] =
 {
 	{"brain_idle", (byte *)brain_idle},
+	{"flipper_idle", (byte *)flipper_idle},
 	{"floater_idle", (byte *)floater_idle},
 	{"flyer_idle", (byte *)flyer_idle},
 	{"gladiator_idle", (byte *)gladiator_idle},

--- a/src/game/savegame/tables/gamefunc_list.h
+++ b/src/game/savegame/tables/gamefunc_list.h
@@ -474,11 +474,15 @@ static const fnlist_entry_t fnentries_mi_search[] =
 	{"boss2_search", (byte *)boss2_search},
 	{"jorg_search", (byte *)jorg_search},
 	{"brain_search", (byte *)brain_search},
+	{"chick_search", (byte *)chick_search},
+	{"flipper_search", (byte *)flipper_search},
 	{"gladiator_search", (byte *)gladiator_search},
 	{"gunner_search", (byte *)gunner_search},
 	{"hover_search", (byte *)hover_search},
+	{"infantry_search", (byte *)infantry_search},
 	{"medic_search", (byte *)medic_search},
 	{"mutant_search", (byte *)mutant_search},
+	{"parasite_search", (byte *)parasite_search},
 	{"supertank_search", (byte *)supertank_search},
 };
 static const functionList_t fnlist_mi_search =


### PR DESCRIPTION
Fixes https://github.com/yquake2/yquake2/issues/1315

Discovered that `chick` and `flipper` also precached search sounds that they never used.

EDIT: And discovered that flipper was precaching a `sound_idle` and not using it.