### PR TITLE
game: Improved robustness and a bit of refactoring in physics code

### DIFF
--- a/src/game/g_phys.c
+++ b/src/game/g_phys.c
@@ -1301,6 +1301,10 @@ G_RunEntity(edict_t *ent)
 			SV_Physics_Toss(ent);
 			break;
 		default:
-			gi.error("%s: bad movetype %i", __func__, (int)ent->movetype);
+			gi.dprintf("%s:%d has bad movetype: %d\n",
+				ent->classname, ent->s.number, ent->movetype);
+			ent->movetype = MOVETYPE_NONE;
+			SV_Physics_None(ent);
+			break;
 	}
 }

--- a/src/game/g_phys.c
+++ b/src/game/g_phys.c
@@ -580,6 +580,9 @@ retry:
 	return trace;
 }
 
+/*
+ * Pushed API
+ */
 typedef struct
 {
 	edict_t *ent;
@@ -588,24 +591,83 @@ typedef struct
 } pushed_t;
 
 static pushed_t pushed[MAX_EDICTS], *pushed_p;
-static edict_t *obstacle;
+
+static void
+Pushed_Init(void)
+{
+	pushed_p = pushed;
+}
+
+static qboolean
+Pushed_Append(edict_t *e)
+{
+	if (pushed_p >= ARREND(pushed))
+	{
+		return false;
+	}
+
+	pushed_p->ent = e;
+	VectorCopy(e->s.origin, pushed_p->origin);
+	VectorCopy(e->s.angles, pushed_p->angles);
+
+	pushed_p++;
+
+	return true;
+}
+
+static void
+Pushed_Pop(void)
+{
+	if (pushed_p > pushed)
+	{
+		pushed_p--;
+	}
+}
+
+static void
+Pushed_Undo(void)
+{
+	pushed_t *p;
+
+	/* go backwards, so if the same entity was pushed
+	   twice, it goes back to the original position */
+	for (p = pushed_p - 1; p >= pushed; p--)
+	{
+		VectorCopy(p->origin, p->ent->s.origin);
+		VectorCopy(p->angles, p->ent->s.angles);
+
+		gi.linkentity(p->ent);
+	}
+
+	pushed_p = pushed;
+}
+
+static void
+Pushed_TouchTriggers(void)
+{
+	pushed_t *p;
+
+	for (p = pushed_p - 1; p >= pushed; p--)
+	{
+		G_TouchTriggers(p->ent);
+	}
+}
 
 /*
  * Objects need to be moved back on a failed push,
  * otherwise riders would continue to slide.
  */
-static qboolean
+static edict_t *
 SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 {
-	int i, e;
-	edict_t *check, *block;
-	pushed_t *p;
-	vec3_t org, org2, move2, forward, right, up;
+	int i;
+	edict_t *check;
+	vec3_t org, forward, right, up;
 	vec3_t realmins, realmaxs;
 
 	if (!pusher)
 	{
-		return false;
+		return NULL;
 	}
 
 	/* clamp the move to 1/8 units, so the position will
@@ -631,13 +693,11 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 	VectorSubtract(vec3_origin, amove, org);
 	AngleVectors(org, forward, right, up);
 
-	/* save the pusher's original position */
-	pushed_p->ent = pusher;
-	VectorCopy(pusher->s.origin, pushed_p->origin);
-	VectorCopy(pusher->s.angles, pushed_p->angles);
-	pushed_p++;
+	if (!Pushed_Append(pusher))
+	{
+		return NULL;
+	}
 
-	/* move the pusher to it's final position */
 	VectorAdd(pusher->s.origin, move, pusher->s.origin);
 	VectorAdd(pusher->s.angles, amove, pusher->s.angles);
 	gi.linkentity(pusher);
@@ -648,9 +708,7 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 
 	/* see if any solid entities
 	   are inside the final position */
-	check = g_edicts + 1;
-
-	for (e = 1; e < globals.num_edicts; e++, check++)
+	for (check = g_edicts + 1; check < &g_edicts[globals.num_edicts]; check++)
 	{
 		if (!check->inuse)
 		{
@@ -696,11 +754,12 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 		if ((pusher->movetype == MOVETYPE_PUSH) ||
 			(check->groundentity == pusher))
 		{
-			/* move this entity */
-			pushed_p->ent = check;
-			VectorCopy(check->s.origin, pushed_p->origin);
-			VectorCopy(check->s.angles, pushed_p->angles);
-			pushed_p++;
+			vec3_t org2, move2;
+
+			if (!Pushed_Append(check))
+			{
+				continue;
+			}
 
 			/* try moving the contacted entity */
 			VectorAdd(check->s.origin, move, check->s.origin);
@@ -719,14 +778,9 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 				check->groundentity = NULL;
 			}
 
-			block = SV_TestEntityPosition(check);
-
-			if (!block)
+			if (!SV_TestEntityPosition(check))
 			{
-				/* pushed ok */
 				gi.linkentity(check);
-
-				/* impact? */
 				continue;
 			}
 
@@ -734,40 +788,22 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 			   this is only relevent for riding entities, not
 			   pushed */
 			VectorSubtract(check->s.origin, move, check->s.origin);
-			block = SV_TestEntityPosition(check);
 
-			if (!block)
+			if (!SV_TestEntityPosition(check))
 			{
-				pushed_p--;
+				Pushed_Pop();
 				continue;
 			}
 		}
 
-		/* save off the obstacle so we can
-		   call the block function */
-		obstacle = check;
+		Pushed_Undo();
 
-		/* move back any entities we already moved
-		   go backwards, so if the same entity was pushed
-		   twice, it goes back to the original position */
-		for (p = pushed_p - 1; p >= pushed; p--)
-		{
-			VectorCopy(p->origin, p->ent->s.origin);
-			VectorCopy(p->angles, p->ent->s.angles);
-
-			gi.linkentity(p->ent);
-		}
-
-		return false;
+		return check;
 	}
 
-	/* see if anything we moved has touched a trigger */
-	for (p = pushed_p - 1; p >= pushed; p--)
-	{
-		G_TouchTriggers(p->ent);
-	}
+	Pushed_TouchTriggers();
 
-	return true;
+	return NULL;
 }
 
 /*
@@ -777,8 +813,7 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 static void
 SV_Physics_Pusher(edict_t *ent)
 {
-	vec3_t move, amove;
-	edict_t *part, *mv;
+	edict_t *part, *obstacle;
 
 	if (!ent)
 	{
@@ -792,37 +827,36 @@ SV_Physics_Pusher(edict_t *ent)
 		return;
 	}
 
+	Pushed_Init();
+	obstacle = NULL;
+
 	/* make sure all team slaves can move before commiting
 	   any moves or calling any think functions if the move
 	   is blocked, all moved objects will be backed out */
-	pushed_p = pushed;
-
 	for (part = ent; part; part = part->teamchain)
 	{
-		if (part->velocity[0] || part->velocity[1] || part->velocity[2] ||
-			part->avelocity[0] || part->avelocity[1] || part->avelocity[2])
-		{
-			/* object is moving */
-			VectorScale(part->velocity, FRAMETIME, move);
-			VectorScale(part->avelocity, FRAMETIME, amove);
+		vec3_t move, amove;
 
-			if (!SV_Push(part, move, amove))
-			{
-				break; /* move was blocked */
-			}
+		if (VectorCompare(part->velocity, vec3_origin) &&
+			VectorCompare(part->avelocity, vec3_origin))
+		{
+			continue;
+		}
+
+		VectorScale(part->velocity, FRAMETIME, move);
+		VectorScale(part->avelocity, FRAMETIME, amove);
+
+		obstacle = SV_Push(part, move, amove);
+		if (obstacle)
+		{
+			break;
 		}
 	}
 
-	if (pushed_p > &pushed[MAX_EDICTS - 1])
+	if (part) /* move failed */
 	{
-		gi.error("pushed_p > &pushed[MAX_EDICTS - 1], memory corrupted");
-		return;
-	}
+		edict_t *mv;
 
-	if (part)
-	{
-		/* the move failed, bump all nextthink
-		   times and back out moves */
 		for (mv = ent; mv; mv = mv->teamchain)
 		{
 			if (mv->nextthink > 0)
@@ -831,9 +865,6 @@ SV_Physics_Pusher(edict_t *ent)
 			}
 		}
 
-		/* if the pusher has a "blocked" function, call it
-		   otherwise, just stay in place until the obstacle
-		   is gone */
 		if (part->blocked)
 		{
 			part->blocked(part, obstacle);
@@ -841,7 +872,6 @@ SV_Physics_Pusher(edict_t *ent)
 	}
 	else
 	{
-		/* the move succeeded, so call all think functions */
 		for (part = ent; part; part = part->teamchain)
 		{
 			SV_RunThink(part);
@@ -862,7 +892,6 @@ SV_Physics_None(edict_t *ent)
 		return;
 	}
 
-	/* regular thinking */
 	SV_RunThink(ent);
 }
 
@@ -877,7 +906,6 @@ SV_Physics_Noclip(edict_t *ent)
 		return;
 	}
 
-	/* regular thinking */
 	if (!SV_RunThink(ent))
 	{
 		return;
@@ -913,7 +941,6 @@ SV_Physics_Toss(edict_t *ent)
 		return;
 	}
 
-	/* regular thinking */
 	SV_RunThink(ent);
 
 	/* entities are very often freed during thinking */
@@ -1260,7 +1287,6 @@ SV_Physics_Step(edict_t *ent)
 		}
 	}
 
-	/* regular thinking */
 	SV_RunThink(ent);
 }
 


### PR DESCRIPTION
This PR improves robustness in the game's physics code. Also a bit of clean-up refactoring

* Unknown movetype no longer drops the server. Now the game prints a warning and defaults to `MOVETYPE_NONE`
* `SV_Push` can no longer corrupts memory if more than `MAX_EDICTS` entities are being pushed, possible now that the server supports more than that. Now there is a `pushed_t`API that is used to handle this situation gracefully, avoiding both the memory corruption and the `gi.error` call
* A bit of refactoring: Marked some functions `static`, reduced scope of some variables, removed some useless comments and `obstacle` is now a local variable and `SV_Push` returns the obstacle instead of true/false