### PR TITLE
menu: Improve stability in some menu code and minor optimizations

### DIFF
--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -90,7 +90,6 @@ typedef struct
 {
 	menucommon_s    generic;
 	char *          focuspic;	
-	char *          errorpic;
 	int             width;
 	int             height;
 } menubitmap_s;

--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -147,7 +147,7 @@ void Menu_Draw(menuframework_s *menu);
 void *Menu_ItemAtCursor(menuframework_s *m);
 qboolean Menu_SelectItem(menuframework_s *s);
 void Menu_SetStatusBar(menuframework_s *s, const char *string);
-void Menu_SlideItem(menuframework_s *s, int dir);
+qboolean Menu_SlideItem(menuframework_s *s, int dir);
 
 void Menu_DrawString(int, int, const char *);
 void Menu_DrawStringDark(int, int, const char *);

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -4590,17 +4590,50 @@ RulesChangeFunc(void *self)
 	}
 }
 
+static const char *
+GetStartSpot(const char *startmap)
+{
+	const char **s;
+
+	static const char *spots[] =
+	{
+		"bunk1", "start",
+		"mintro", "start",
+		"fact1", "start",
+		"power1", "pstart",
+		"biggun", "bstart",
+		"hangar1", "unitstart",
+		"city1", "unitstart",
+		"boss1", "bosstart"
+	};
+
+	for (s = spots; s < ARREND(spots); s += 2)
+	{
+		if (!Q_stricmp(startmap, *s))
+		{
+			return *(s + 1);
+		}
+	}
+
+	return NULL;
+}
+
 static void
 StartServerActionFunc(void *self)
 {
-	char startmap[1024];
+	const char *startmap, *spot;
 	float timelimit;
 	float fraglimit;
 	float maxclients;
-	char *spot;
 
-	Q_strlcpy(startmap, strchr(mapnames[s_startmap_list.curvalue], '\n') + 1,
-		sizeof(startmap));
+	startmap = strchr(mapnames[s_startmap_list.curvalue], '\n');
+
+	if (!startmap)
+	{
+		return;
+	}
+
+	startmap++;
 
 	maxclients = (float)strtod(s_maxclients_field.buffer, (char **)NULL);
 	timelimit = (float)strtod(s_timelimit_field.buffer, (char **)NULL);
@@ -4636,45 +4669,7 @@ StartServerActionFunc(void *self)
 
 	if (s_rules_box.curvalue == 1)
 	{
-		if (Q_stricmp(startmap, "bunk1") == 0)
-		{
-			spot = "start";
-		}
-
-		else if (Q_stricmp(startmap, "mintro") == 0)
-		{
-			spot = "start";
-		}
-
-		else if (Q_stricmp(startmap, "fact1") == 0)
-		{
-			spot = "start";
-		}
-
-		else if (Q_stricmp(startmap, "power1") == 0)
-		{
-			spot = "pstart";
-		}
-
-		else if (Q_stricmp(startmap, "biggun") == 0)
-		{
-			spot = "bstart";
-		}
-
-		else if (Q_stricmp(startmap, "hangar1") == 0)
-		{
-			spot = "unitstart";
-		}
-
-		else if (Q_stricmp(startmap, "city1") == 0)
-		{
-			spot = "unitstart";
-		}
-
-		else if (Q_stricmp(startmap, "boss1") == 0)
-		{
-			spot = "bosstart";
-		}
+		spot = GetStartSpot(startmap);
 	}
 
 	if (spot)

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -660,7 +660,7 @@ InitMainMenu(void)
 		"m_main_options",
 		"m_main_video",
 		"m_main_quit",
-		0
+		NULL
 	};
 
 	for (i = 0; names[i] != 0; i++)
@@ -685,7 +685,7 @@ InitMainMenu(void)
 	s_plaque.generic.x = (x - (m_cursor_width + 5) - w);
 	s_plaque.generic.y = y;
 	s_plaque.generic.name = "m_main_plaque";
-	s_plaque.generic.callback = 0;
+	s_plaque.generic.callback = NULL;
 	s_plaque.focuspic = 0;
 
 	s_logo.generic.type = MTYPE_BITMAP;
@@ -693,7 +693,7 @@ InitMainMenu(void)
 	s_logo.generic.x = (x - (m_cursor_width + 5) - w);
 	s_logo.generic.y = y + h + 5;
 	s_logo.generic.name = "m_main_logo";
-	s_logo.generic.callback = 0;
+	s_logo.generic.callback = NULL;
 	s_logo.focuspic = 0;
 
 	y += 10;
@@ -1742,7 +1742,7 @@ Stick_MenuInit(void)
 		"southpaw",
 		"legacy",
 		"legacy southpaw",
-		0
+		NULL
 	};
 
 	static const char *stick_layouts_fs[] =
@@ -1753,7 +1753,7 @@ Stick_MenuInit(void)
 		"legacy southpaw",
 		"flick stick",
 		"flick stick spaw",
-		0
+		NULL
 	};
 
 	unsigned short int y = 0, i;
@@ -1984,7 +1984,7 @@ Gyro_MenuInit(void)
 		"off, button enables",
 		"on, button disables",
 		"always on",
-		0
+		NULL
 	};
 
 	static const char *gyro_space_choices[] =
@@ -1992,7 +1992,7 @@ Gyro_MenuInit(void)
 		"local",
 		"player",
 		"world",
-		0
+		NULL
 	};
 
 	static const char *gyro_local_roll_choices[] =
@@ -2000,14 +2000,14 @@ Gyro_MenuInit(void)
 		"off",
 		"on",
 		"on, invert",
-		0
+		NULL
 	};
 
 	static const char *onoff_names[] =
 	{
 		"off",
 		"on",
-		0
+		NULL
 	};
 
 	unsigned short int y = 0;
@@ -2280,7 +2280,7 @@ Joy_MenuInit(void)
 	{
 		"no",
 		"yes",
-		0
+		NULL
 	};
 
 	static const char *custom_names[] =
@@ -2288,7 +2288,7 @@ Joy_MenuInit(void)
 		"",
 		"custom",
 		"",
-		0,
+		NULL
 	};
 
 	extern qboolean show_haptic;
@@ -2707,26 +2707,26 @@ Options_MenuInit(void)
 		"sequential",
 		"random",
 		"truly random",
-		0
+		NULL
 	};
 
 	static const char *able_items[] =
 	{
 		"disabled",
 		"enabled",
-		0
+		NULL
 	};
 
 	static const char *sound_items[] =
 	{
-		"openal", "sdl", 0
+		"openal", "sdl", NULL
 	};
 
 	static const char *yesno_names[] =
 	{
 		"no",
 		"yes",
-		0
+		NULL
 	};
 
 	static const char *crosshair_names[] =
@@ -2735,7 +2735,7 @@ Options_MenuInit(void)
 		"cross",
 		"dot",
 		"angle",
-		0
+		NULL
 	};
 
 	static const char *crosshair_color_names[] =
@@ -2748,7 +2748,7 @@ Options_MenuInit(void)
 		"cyan",
 		"magenta",
 		"orange",
-		0
+		NULL
 	};
 
 	float scale = SCR_GetMenuScale();
@@ -3039,7 +3039,7 @@ static const char *idcredits[] = {
 	"trademark of Activision, Inc. All",
 	"other trademarks and trade names are",
 	"properties of their respective owners.",
-	0
+	NULL
 };
 
 static const char *xatcredits[] =
@@ -3180,7 +3180,7 @@ static const char *xatcredits[] =
 	"Inc. All other trademarks and trade",
 	"names are properties of their",
 	"respective owners.",
-	0
+	NULL
 };
 
 static const char *roguecredits[] =
@@ -3294,7 +3294,7 @@ static const char *roguecredits[] =
 	"Inc. All other trademarks and trade",
 	"names are properties of their",
 	"respective owners.",
-	0
+	NULL
 };
 
 static void
@@ -4965,14 +4965,14 @@ StartServer_MenuInit(void)
 	{
 		"deathmatch",
 		"cooperative",
-		0
+		NULL
 	};
 	static const char *dm_coop_names_rogue[] =
 	{
 		"deathmatch",
 		"cooperative",
 		"tag",
-		0
+		NULL
 	};
 
 	float scale = SCR_GetMenuScale();
@@ -5389,11 +5389,11 @@ DMOptions_MenuInit(void)
 {
 	static const char *yes_no_names[] =
 	{
-		"no", "yes", 0
+		"no", "yes", NULL
 	};
 	static const char *teamplay_names[] =
 	{
-		"disabled", "by skin", "by model", 0
+		"disabled", "by skin", "by model", NULL
 	};
 	int dmflags = Cvar_VariableValue("dmflags");
 	unsigned short int y = 0;
@@ -5711,7 +5711,7 @@ DownloadOptions_MenuInit(void)
 {
 	static const char *yes_no_names[] =
 	{
-		"no", "yes", 0
+		"no", "yes", NULL
 	};
 	unsigned short int y = 0;
 	float scale = SCR_GetMenuScale();
@@ -5853,8 +5853,8 @@ AddressBook_MenuInit(void)
 		f = &s_addressbook_fields[i];
 
 		f->generic.type = MTYPE_FIELD;
-		f->generic.name = 0;
-		f->generic.callback = 0;
+		f->generic.name = NULL;
+		f->generic.callback = NULL;
 		f->generic.x = 0;
 		f->generic.y = i * 18 + 0;
 		f->generic.localdata[0] = i;
@@ -5936,7 +5936,7 @@ static strlist_t s_directory;
 
 static int rate_tbl[] = {2500, 3200, 5000, 10000, 25000, 0};
 static const char *rate_names[] = {"28.8 Modem", "33.6 Modem", "Single ISDN",
-								   "Dual ISDN/Cable", "T1/LAN", "User defined", 0 };
+								   "Dual ISDN/Cable", "T1/LAN", "User defined", NULL};
 
 static void
 DownloadOptionsFunc(void *self)
@@ -6582,7 +6582,7 @@ PlayerConfig_MenuInit(void)
 	extern cvar_t *name;
 	const extern cvar_t *skin;
 	cvar_t *hand = Cvar_Get( "hand", "0", CVAR_USERINFO | CVAR_ARCHIVE );
-	static const char *handedness[] = { "right", "left", "center", 0 };
+	static const char *handedness[] = { "right", "left", "center", NULL};
 	char mdlname[MAX_QPATH];
 	char imgname[MAX_QPATH];
 	int mdlindex = 0;
@@ -6639,7 +6639,7 @@ PlayerConfig_MenuInit(void)
 
 	s_player_name_field.generic.type = MTYPE_FIELD;
 	s_player_name_field.generic.name = "name";
-	s_player_name_field.generic.callback = 0;
+	s_player_name_field.generic.callback = NULL;
 	s_player_name_field.generic.x = 0;
 	s_player_name_field.generic.y = 0;
 	s_player_name_field.length = 20;
@@ -6652,8 +6652,8 @@ PlayerConfig_MenuInit(void)
 	s_player_icon_bitmap.generic.flags = QMF_INACTIVE;
 	s_player_icon_bitmap.generic.x = ((viddef.width / scale - 95) / 2) - 87;
 	s_player_icon_bitmap.generic.y = ((viddef.height / (2 * scale))) - 72;
-	s_player_icon_bitmap.generic.name = 0;
-	s_player_icon_bitmap.generic.callback = 0;
+	s_player_icon_bitmap.generic.name = NULL;
+	s_player_icon_bitmap.generic.callback = NULL;
 	s_player_icon_bitmap.focuspic = 0;
 
 	s_player_model_title.generic.type = MTYPE_SEPARATOR;
@@ -6677,8 +6677,8 @@ PlayerConfig_MenuInit(void)
 	s_player_skin_box.generic.type = MTYPE_SPINCONTROL;
 	s_player_skin_box.generic.x = -56 * scale;
 	s_player_skin_box.generic.y = 94;
-	s_player_skin_box.generic.name = 0;
-	s_player_skin_box.generic.callback = 0;
+	s_player_skin_box.generic.name = NULL;
+	s_player_skin_box.generic.callback = NULL;
 	s_player_skin_box.generic.cursor_offset = -48;
 	s_player_skin_box.curvalue = imgindex;
 	s_player_skin_box.itemnames = (const char **)s_skinnames[mdlindex].data;
@@ -6691,7 +6691,7 @@ PlayerConfig_MenuInit(void)
 	s_player_handedness_box.generic.type = MTYPE_SPINCONTROL;
 	s_player_handedness_box.generic.x = -56 * scale;
 	s_player_handedness_box.generic.y = 118;
-	s_player_handedness_box.generic.name = 0;
+	s_player_handedness_box.generic.name = NULL;
 	s_player_handedness_box.generic.cursor_offset = -48;
 	s_player_handedness_box.generic.callback = HandednessCallback;
 	s_player_handedness_box.curvalue = ClampCvar(0, 2, hand->value);
@@ -6713,7 +6713,7 @@ PlayerConfig_MenuInit(void)
 	s_player_rate_box.generic.type = MTYPE_SPINCONTROL;
 	s_player_rate_box.generic.x = -56 * scale;
 	s_player_rate_box.generic.y = 166;
-	s_player_rate_box.generic.name = 0;
+	s_player_rate_box.generic.name = NULL;
 	s_player_rate_box.generic.cursor_offset = -48;
 	s_player_rate_box.generic.callback = RateCallback;
 	s_player_rate_box.curvalue = i;

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -745,11 +745,11 @@ SpinControl_DoSlide(menulist_s *s, int dir)
 static void
 SpinControl_Draw(menulist_s *s)
 {
-	char buffer[100];
-	float scale = SCR_GetMenuScale();
-	int x = 0;
-	int y = 0;
+	const char *item, *nl;
+	float scale;
+	int x, y;
 
+	scale = SCR_GetMenuScale();
 	x = s->generic.parent->x + s->generic.x;
 	y = s->generic.parent->y + s->generic.y;
 
@@ -759,20 +759,40 @@ SpinControl_Draw(menulist_s *s)
 			y, s->generic.name);
 	}
 
-	if (!strchr(s->itemnames[s->curvalue], '\n'))
+	if (!s->itemnames)
 	{
-		Menu_DrawString(x + (RCOLUMN_OFFSET * scale),
-			y, s->itemnames[s->curvalue]);
+		item = "(empty)";
 	}
 	else
 	{
-		Q_strlcpy(buffer, s->itemnames[s->curvalue], sizeof(buffer));
-		*strchr(buffer, '\n') = 0;
+		item = ((s->curvalue < 0) || (!s->itemnames[s->curvalue])) ?
+			"(invalid)" : s->itemnames[s->curvalue];
+	}
+
+	nl = strchr(item, '\n');
+
+	if (!nl)
+	{
+		Menu_DrawString(x + (RCOLUMN_OFFSET * scale),
+			y, item);
+	}
+	else
+	{
+		char *nlb, buffer[100];
+
+		Q_strlcpy(buffer, item, sizeof(buffer));
+		nlb = strchr(buffer, '\n');
+
+		if (nlb)
+		{
+			*nlb = '\0';
+
+			Menu_DrawString(x + (RCOLUMN_OFFSET * scale),
+				y + 10, nlb + 1);
+		}
+
 		Menu_DrawString(x + (RCOLUMN_OFFSET * scale),
 			y, buffer);
-		strcpy(buffer, strchr(s->itemnames[s->curvalue], '\n') + 1);
-		Menu_DrawString(x + (RCOLUMN_OFFSET * scale),
-			y + 10, buffer);
 	}
 }
 

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -36,10 +36,11 @@ static void Action_Draw(menuaction_s *a);
 static void Menu_DrawStatusBar(const char *string);
 static void MenuList_Draw(menulist_s *l);
 static void Separator_Draw(menuseparator_s *s);
-static void Slider_DoSlide(menuslider_s *s, int dir);
 static void Slider_Draw(menuslider_s *s);
 static void SpinControl_Draw(menulist_s *s);
-static void SpinControl_DoSlide(menulist_s *s, int dir);
+
+static qboolean Slider_DoSlide(menuslider_s *s, int dir);
+static qboolean SpinControl_DoSlide(menulist_s *s, int dir);
 
 extern viddef_t viddef;
 
@@ -592,23 +593,25 @@ Menu_SetStatusBar(menuframework_s *m, const char *string)
 	m->statusbar = string;
 }
 
-void
+qboolean
 Menu_SlideItem(menuframework_s *s, int dir)
 {
 	menucommon_s *item = (menucommon_s *)Menu_ItemAtCursor(s);
 
-	if (item)
+	if (!item)
 	{
-		switch (item->type)
-		{
-			case MTYPE_SLIDER:
-				Slider_DoSlide((menuslider_s *)item, dir);
-				break;
-			case MTYPE_SPINCONTROL:
-				SpinControl_DoSlide((menulist_s *)item, dir);
-				break;
-		}
+		return false;
 	}
+
+	switch (item->type)
+	{
+		case MTYPE_SLIDER:
+			return Slider_DoSlide((menuslider_s *)item, dir);
+		case MTYPE_SPINCONTROL:
+			return SpinControl_DoSlide((menulist_s *)item, dir);
+	}
+
+	return false;
 }
 
 static void
@@ -656,17 +659,32 @@ Separator_Draw(menuseparator_s *s)
 	}
 }
 
-static void
+static qboolean
 Slider_DoSlide(menuslider_s *s, int dir)
 {
 	const float step = (s->slidestep)? s->slidestep : 0.1f;
-	float value = Cvar_VariableValue(s->cvar);
+	float value;
 	float sign = 1.0f;
+
+	if (!s->cvar)
+	{
+		return false;
+	}
+
+	value = Cvar_VariableValue(s->cvar);
 
 	if (s->abs && value < 0)	// absolute value treatment
 	{
 		value = -value;
 		sign = -1.0f;
+	}
+
+	dir = (dir <= 0) ? -1 : 1;
+
+	if ((value == s->minvalue && dir == -1) ||
+		(value == s->maxvalue && dir == 1))
+	{
+		return false;
 	}
 
 	value += dir * step;
@@ -676,6 +694,8 @@ Slider_DoSlide(menuslider_s *s, int dir)
 	{
 		s->generic.callback(s);
 	}
+
+	return true;
 }
 
 #define SLIDER_RANGE 10
@@ -683,23 +703,20 @@ Slider_DoSlide(menuslider_s *s, int dir)
 static void
 Slider_Draw(menuslider_s *s)
 {
-	const float scale = SCR_GetMenuScale();
-	const int x = s->generic.parent->x + s->generic.x;
-	const int y = s->generic.parent->y + s->generic.y;
-	const int x_rcol = x + (RCOLUMN_OFFSET * scale);
+	float scale;
+	int x, x_rcol, y;
 	int i;
-	char buffer[5];
 
-	float value = Cvar_VariableValue(s->cvar);
-	if (s->abs && value < 0)	// absolute value
+	scale = SCR_GetMenuScale();
+	x = s->generic.parent->x + s->generic.x;
+	x_rcol = x + (RCOLUMN_OFFSET * scale);
+	y = s->generic.parent->y + s->generic.y;
+
+	if (s->generic.name)
 	{
-		value = -value;
+		Menu_DrawStringR2LDark(x + (LCOLUMN_OFFSET * scale),
+			y, s->generic.name);
 	}
-	const float range = (ClampCvar(s->minvalue, s->maxvalue, value) - s->minvalue) /
-			(s->maxvalue - s->minvalue);
-
-	Menu_DrawStringR2LDark(x + (LCOLUMN_OFFSET * scale),
-		y, s->generic.name);
 
 	Draw_CharScaled(x_rcol,
 		y * scale, 128, scale);
@@ -712,34 +729,62 @@ Slider_Draw(menuslider_s *s)
 
 	Draw_CharScaled(x_rcol + (i * 8) + 8,
 		y * scale, 130, scale);
-	Draw_CharScaled(x_rcol + (int)((SLIDER_RANGE * scale - 1) * 8 * range) + 8,
-		y * scale, 131, scale);
 
-	snprintf(buffer, 5, (s->printformat)? s->printformat : "%.1f", value);
-	Menu_DrawString(x_rcol + ((SLIDER_RANGE + 2) * scale * 8),
-		y, buffer);
+	if (s->cvar)
+	{
+		float value, range;
+		char buffer[5];
+
+		value = Cvar_VariableValue(s->cvar);
+		if (s->abs && value < 0)
+		{
+			value = -value;
+		}
+
+		range = (ClampCvar(s->minvalue, s->maxvalue, value) - s->minvalue) /
+			(s->maxvalue - s->minvalue);
+
+		Draw_CharScaled(x_rcol + (int)((SLIDER_RANGE * scale - 1) * 8 * range) + 8,
+			y * scale, 131, scale);
+
+		Com_sprintf(buffer, sizeof(buffer),
+			(s->printformat)? s->printformat : "%.1f", value);
+		Menu_DrawString(x_rcol + ((SLIDER_RANGE + 2) * scale * 8),
+			y, buffer);
+	}
 }
 
-static void
+static qboolean
 SpinControl_DoSlide(menulist_s *s, int dir)
 {
-	s->curvalue += dir;
+	if (!s->itemnames)
+	{
+		return false;
+	}
 
-	if (s->curvalue < 0)
+	if ((s->curvalue < 0) || (!s->itemnames[s->curvalue]))
 	{
 		s->curvalue = 0;
-		return;
 	}
-	else if (s->itemnames[s->curvalue] == 0)
+	else
 	{
-		s->curvalue--;
-		return;
+		dir = (dir <= 0) ? -1 : 1;
+
+		if ((s->curvalue == 0 && dir == -1) ||
+			(!s->itemnames[s->curvalue + 1] && dir == 1))
+		{
+			return false;
+		}
+
+		s->curvalue += dir;
 	}
 
 	if (s->generic.callback)
 	{
 		s->generic.callback(s);
 	}
+
+	return true;
 }
 
 static void
@@ -778,13 +823,13 @@ SpinControl_Draw(menulist_s *s)
 	}
 	else
 	{
-		char *nlb, buffer[100];
+		char buffer[100];
 
-		Q_strlcpy(buffer, item, sizeof(buffer));
-		nlb = strchr(buffer, '\n');
-
-		if (nlb)
+		if (Q_strlcpy(buffer, item, sizeof(buffer)) < sizeof(buffer))
 		{
+			char *nlb;
+
+			nlb = buffer + (nl - item);
 			*nlb = '\0';
 
 			Menu_DrawString(x + (RCOLUMN_OFFSET * scale),

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -79,7 +79,7 @@ Bitmap_Draw(menubitmap_s * item)
 	}
 }
 
-void
+static void
 Action_Draw(menuaction_s *a)
 {
 	float scale = SCR_GetMenuScale();
@@ -493,7 +493,7 @@ Menu_Draw(menuframework_s *menu)
 	}
 }
 
-void
+static void
 Menu_DrawStatusBar(const char *string)
 {
 	float scale = SCR_GetMenuScale();
@@ -611,7 +611,7 @@ Menu_SlideItem(menuframework_s *s, int dir)
 	}
 }
 
-void
+static void
 MenuList_Draw(menulist_s *l)
 {
 	const char **n;
@@ -640,7 +640,7 @@ MenuList_Draw(menulist_s *l)
 	}
 }
 
-void
+static void
 Separator_Draw(menuseparator_s *s)
 {
 	int x = 0;
@@ -656,7 +656,7 @@ Separator_Draw(menuseparator_s *s)
 	}
 }
 
-void
+static void
 Slider_DoSlide(menuslider_s *s, int dir)
 {
 	const float step = (s->slidestep)? s->slidestep : 0.1f;
@@ -680,7 +680,7 @@ Slider_DoSlide(menuslider_s *s, int dir)
 
 #define SLIDER_RANGE 10
 
-void
+static void
 Slider_Draw(menuslider_s *s)
 {
 	const float scale = SCR_GetMenuScale();
@@ -720,7 +720,7 @@ Slider_Draw(menuslider_s *s)
 		y, buffer);
 }
 
-void
+static void
 SpinControl_DoSlide(menulist_s *s, int dir)
 {
 	s->curvalue += dir;
@@ -742,7 +742,7 @@ SpinControl_DoSlide(menulist_s *s, int dir)
 	}
 }
 
-void
+static void
 SpinControl_Draw(menulist_s *s)
 {
 	char buffer[100];

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -354,7 +354,7 @@ Menu_AdjustCursor(menuframework_s *m, int dir)
 	/* see if it's in a valid spot */
 	if ((m->cursor >= 0) && (m->cursor < m->nitems))
 	{
-		if ((citem = Menu_ItemAtCursor(m)) != 0)
+		if ((citem = Menu_ItemAtCursor(m)) != NULL)
 		{
 			if (citem->type != MTYPE_SEPARATOR &&
 				(citem->flags & QMF_INACTIVE) != QMF_INACTIVE)
@@ -565,7 +565,7 @@ Menu_ItemAtCursor(menuframework_s *m)
 {
 	if ((m->cursor < 0) || (m->cursor >= m->nitems))
 	{
-		return 0;
+		return NULL;
 	}
 
 	return m->items[m->cursor];

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -519,7 +519,7 @@ Menu_DrawString(int x, int y, const char *string)
 	unsigned i;
 	float scale = SCR_GetMenuScale();
 
-	for (i = 0; i < strlen(string); i++)
+	for (i = 0; string[i] != '\0'; i++)
 	{
 		Draw_CharScaled(x + i * 8 * scale, y * scale, string[i], scale);
 	}
@@ -531,7 +531,7 @@ Menu_DrawStringDark(int x, int y, const char *string)
 	unsigned i;
 	float scale = SCR_GetMenuScale();
 
-	for (i = 0; i < strlen(string); i++)
+	for (i = 0; string[i] != '\0'; i++)
 	{
 		Draw_CharScaled(x + i * 8 * scale, y * scale, string[i] + 128, scale);
 	}
@@ -540,24 +540,30 @@ Menu_DrawStringDark(int x, int y, const char *string)
 void
 Menu_DrawStringR2L(int x, int y, const char *string)
 {
-	unsigned i;
-	float scale = SCR_GetMenuScale();
+	unsigned i, slen;
+	float scale;
 
-	for (i = 0; i < strlen(string); i++)
+	slen = strlen(string);
+	scale = SCR_GetMenuScale();
+
+	for (i = 0; i < slen; i++)
 	{
-		Draw_CharScaled(x - i * 8 * scale, y * scale, string[strlen(string) - i - 1], scale);
+		Draw_CharScaled(x - i * 8 * scale, y * scale, string[slen - i - 1], scale);
 	}
 }
 
 void
 Menu_DrawStringR2LDark(int x, int y, const char *string)
 {
-	unsigned i;
-	float scale = SCR_GetMenuScale();
+	unsigned i, slen;
+	float scale;
 
-	for (i = 0; i < strlen(string); i++)
+	slen = strlen(string);
+	scale = SCR_GetMenuScale();
+
+	for (i = 0; i < slen; i++)
 	{
-		Draw_CharScaled(x - i * 8 * scale, y * scale, string[strlen(string) - i - 1] + 128, scale);
+		Draw_CharScaled(x - i * 8 * scale, y * scale, string[slen - i - 1] + 128, scale);
 	}
 }
 

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -519,26 +519,26 @@ VID_MenuInit(void)
 		"5x",
 		"6x",
 		"custom",
-		0
+		NULL
 	};
 
 	static const char *onoff_names[] = {
 		"off",
 		"on",
-		0
+		NULL
 	};
 
 	static const char *yesno_names[] = {
 		"no",
 		"yes",
-		0
+		NULL
 	};
 
 	static const char *fullscreen_names[] = {
-			"no",
-			"native fullscreen",
-			"fullscreen window",
-			0
+		"no",
+		"native fullscreen",
+		"fullscreen window",
+		NULL
 	};
 
 	static const char *pow2_names[] = {
@@ -547,7 +547,7 @@ VID_MenuInit(void)
 		"4x",
 		"8x",
 		"16x",
-		0
+		NULL
 	};
 
 	static const char *filter_names[] = {
@@ -555,7 +555,7 @@ VID_MenuInit(void)
 		"standard",
 		"trilinear",
 		"custom",
-		0
+		NULL
 	};
 
 	if (!r_mode)


### PR DESCRIPTION

This PR does a bit of stability improvements for the `DoSlide` and `Draw` functions as well as a bit of cleanup.

* Fixed mismatch of `static` for prototype and declaration of some functions
* Removed unused `errorpic` field from `menubitmap_s` struct
* Replaced 0 with `NULL` for pointer assignments
* `Menu_SlideItem` now return true/false depending on if their value changed with the interaction
* `Slider_DoSlide` and `Slider_Draw` now gracefully handle a `NULL` `s->cvar`
* `SpinControl_DoSlide` and `SpinControl_Draw` now gracefully handle `NULL` or empty itemlist and invalid selection
* These functions were also optimized and cleaned up a bit
* Optimized out large `startmap` 1024 byte buffer from `StartServerActionFunc` and moved the hard-coded start spot code to `GetStartSpot` function and made it more data-driven

I was thinking, have you ever noticed how the sound always plays when pressing left/right arrow on a slider/option, even if the value didn't change? I could do a commit that makes the sound only play if the option changes. Would be good for accessibility, then the user can hear when they have reached the end of the available range.