### PR TITLE
server: Prevent crash on invalid modelindex values

### DIFF
--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -541,24 +541,19 @@ typedef struct
 static int
 SV_HullForEntity(edict_t *ent)
 {
-	/* decide which clipping hull to use, based on the size */
 	if (ent->solid == SOLID_BSP)
 	{
 		const cmodel_t *model;
+		int mi;
 
-		/* explicit hulls in the BSP model */
-		model = sv.models[ent->s.modelindex];
+		mi = ent->s.modelindex;
 
-		if (!model)
-		{
-			Com_Error(ERR_FATAL, "MOVETYPE_PUSH with a non bsp model");
-			return 0;
-		}
+		model = ((mi >= 0) && (mi < MAX_MODELS)) ?
+			sv.models[mi] : NULL;
 
-		return model->headnode;
+		return model ? model->headnode : 0;
 	}
 
-	/* create a temp hull from bounding box sizes */
 	return CM_HeadnodeForBox(ent->mins, ent->maxs);
 }
 


### PR DESCRIPTION
The `sv.models` array was being indexed without any bounds checks in `SV_HullForEntity`. A buggy or malicious game library could assign invalid values to `ent->s.modelindex` to trigger a crash or returning an undefined headnode value.

And it is no longer a fatal error if a `SOLID_BSP` entity has no model. There will simply be no collision with the entity.