### PR TITLE
menu: Sound related fixes/improvements and further stability

### DIFF
--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -27,6 +27,10 @@
 #ifndef CL_MENU_QMENU_H
 #define CL_MENU_QMENU_H
 
+extern const char *menu_in_sound;
+extern const char *menu_move_sound;
+extern const char *menu_out_sound;
+
 #define RCOLUMN_OFFSET  16
 #define LCOLUMN_OFFSET -16
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -42,10 +42,6 @@ static int m_cursor_width = 0;
 /* Signals the file system to start the demo loop. */
 qboolean menu_startdemoloop;
 
-static char *menu_in_sound = "misc/menu1.wav";
-static char *menu_move_sound = "misc/menu2.wav";
-static char *menu_out_sound = "misc/menu3.wav";
-
 void M_Menu_Main_f(void);
 static void M_Menu_Game_f(void);
 static void M_Menu_LoadGame_f(void);
@@ -7065,9 +7061,12 @@ M_Keydown(int key)
 	if (m_active.key)
 	{
 		const char *s;
-		if ((s = m_active.key(key)) != 0)
+
+		s = m_active.key(key);
+
+		if (s)
 		{
-			S_StartLocalSound((char *)s);
+			S_StartLocalSound(s);
 		}
 	}
 }

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -356,7 +356,7 @@ Default_MenuKey(menuframework_s *m, int key)
 		}
 
 		M_PopMenu();
-		return menu_out_sound;
+		break;
 
 	case K_UPARROW:
 		if (m)

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -2252,7 +2252,9 @@ ConfigGyroFunc(void *unused)
 static void
 InvertJoyPitchFunc(void *unused)
 {
-	Cvar_SetValue("joy_pitchspeed", -Cvar_VariableValue("joy_pitchspeed"));
+	float v = fabsf(Cvar_VariableValue("joy_pitchspeed"));
+
+	Cvar_SetValue("joy_pitchspeed", s_joy_invertpitch_box.curvalue ? -v : v);
 }
 
 static void
@@ -2525,13 +2527,13 @@ CustomizeJoyFunc(void *unused)
 static void
 AlwaysRunFunc(void *unused)
 {
-	Cvar_SetValue("cl_run", (float)s_options_alwaysrun_box.curvalue);
+	Cvar_SetValue("cl_run", s_options_alwaysrun_box.curvalue);
 }
 
 static void
 FreeLookFunc(void *unused)
 {
-	Cvar_SetValue("freelook", (float)s_options_freelook_box.curvalue);
+	Cvar_SetValue("freelook", s_options_freelook_box.curvalue);
 }
 
 static void
@@ -2597,13 +2599,15 @@ ControlsResetDefaultsFunc(void *unused)
 static void
 InvertMouseFunc(void *unused)
 {
-	Cvar_SetValue("m_pitch", -m_pitch->value);
+	float v = fabsf(m_pitch->value);
+
+	Cvar_SetValue("m_pitch", s_options_invertmouse_box.curvalue ? -v : v);
 }
 
 static void
 LookstrafeFunc(void *unused)
 {
-	Cvar_SetValue("lookstrafe", (float)!lookstrafe->value);
+	Cvar_SetValue("lookstrafe", s_options_lookstrafe_box.curvalue);
 }
 
 static void
@@ -2615,7 +2619,7 @@ OGGShuffleFunc(void *unused)
 static void
 EnableOGGMusic(void *unused)
 {
-	Cvar_SetValue("ogg_enable", (float)s_options_oggenable_box.curvalue);
+	Cvar_SetValue("ogg_enable", s_options_oggenable_box.curvalue);
 
 	if (s_options_oggenable_box.curvalue)
 	{

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -383,16 +383,20 @@ Default_MenuKey(menuframework_s *m, int key)
 	case K_LEFTARROW:
 		if (m)
 		{
-			Menu_SlideItem(m, -1);
-			sound = menu_move_sound;
+			if (Menu_SlideItem(m, -1))
+			{
+				sound = menu_move_sound;
+			}
 		}
 		break;
 
 	case K_RIGHTARROW:
 		if (m)
 		{
-			Menu_SlideItem(m, 1);
-			sound = menu_move_sound;
+			if (Menu_SlideItem(m, 1))
+			{
+				sound = menu_move_sound;
+			}
 		}
 		break;
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -759,20 +759,16 @@ static void
 M_Main_Draw(void)
 {
 	const menucommon_s * item = NULL;
-	int x = 0;
-	int y = 0;
 
-	item = ( menucommon_s * )s_main.items[s_main.cursor];
+	Menu_Draw(&s_main);
+
+	item = Menu_ItemAtCursor(&s_main);
 
 	if (item)
 	{
-		x = item->x;
-		y = item->y;
+		M_DrawCursor(item->x - m_cursor_width, item->y,
+			(cls.realtime / 100) % NUM_CURSOR_FRAMES);
 	}
-
-	Menu_Draw(&s_main);
-	M_DrawCursor(x - m_cursor_width, y,
-		( int )(cls.realtime / 100) % NUM_CURSOR_FRAMES);
 }
 
 static const char *
@@ -785,26 +781,10 @@ void
 M_Menu_Main_f(void)
 {
 	InitMainMenu();
-
-	// force first available item to have focus
-	while (s_main.cursor >= 0 && s_main.cursor < s_main.nitems)
-	{
-		const menucommon_s * item = NULL;
-
-		item = ( menucommon_s * )s_main.items[s_main.cursor];
-
-		if ((item->flags & (QMF_INACTIVE)))
-		{
-			s_main.cursor++;
-		}
-		else
-		{
-			break;
-		}
-	}
-
 	s_main.draw = M_Main_Draw;
 	s_main.key  = M_Main_Key;
+
+	Menu_AdjustCursor(&s_main, 1);
 
 	M_PushMenu(&s_main);
 }
@@ -1036,17 +1016,26 @@ M_FindKeysForCommand(char *command, int *twokeys, int scope)
 static void
 KeyCursorDrawFunc(menuframework_s *menu)
 {
-	float scale = SCR_GetMenuScale();
+	float scale;
+	int c;
+
+	if (!Menu_ItemAtCursor(menu))
+	{
+		return;
+	}
 
 	if (menukeyitem_bind)
 	{
-		Draw_CharScaled(menu->x, (menu->y + menu->cursor * 9) * scale, '=', scale);
+		c = '=';
 	}
 	else
 	{
-		Draw_CharScaled(menu->x, (menu->y + menu->cursor * 9) * scale, 12 +
-				  ((int)(Sys_Milliseconds() / 250) & 1), scale);
+		c = 12 + ((int)(Sys_Milliseconds() / 250) & 1);
 	}
+
+	scale = SCR_GetMenuScale();
+
+	Draw_CharScaled(menu->x, (menu->y + menu->cursor * 9) * scale, c, scale);
 }
 
 static void

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -95,7 +95,7 @@ M_IsGame(const char *gamename)
 	return false;
 }
 
-static void
+void
 M_Banner(const char *name)
 {
 	int w, h;
@@ -116,7 +116,7 @@ M_ForceMenuOff(void)
 	Cvar_Set("paused", "0");
 }
 
-void
+static void
 M_PopMenu(void)
 {
 	S_StartLocalSound(menu_out_sound);
@@ -328,87 +328,78 @@ Key_GetMenuKey(int key)
 	return key;
 }
 
-static const char *
+const char *
 Default_MenuKey(menuframework_s *m, int key)
 {
-	const char *sound = NULL;
-	int menu_key = Key_GetMenuKey(key);
+	const char *sound;
+	menucommon_s *item;
+	int menu_key;
 
-	if (m)
+	menu_key = Key_GetMenuKey(key);
+
+	if (!m)
 	{
-		menucommon_s *item = Menu_ItemAtCursor(m);
-
-		if (item && item->type == MTYPE_FIELD)
+		if (menu_key == K_ESCAPE)
 		{
-			if (Field_Key((menufield_s *)item, key))
-			{
-				return NULL;
-			}
+			M_PopMenu();
+		}
+
+		return NULL;
+	}
+
+	item = Menu_ItemAtCursor(m);
+
+	if (item && item->type == MTYPE_FIELD)
+	{
+		if (Field_Key((menufield_s *)item, key))
+		{
+			return NULL;
 		}
 	}
 
+	sound = NULL;
+
 	switch (menu_key)
 	{
-	case K_ESCAPE:
-		if (m)
-		{
+		case K_ESCAPE:
 			Field_ResetCursor(m);
-		}
+			M_PopMenu();
+			break;
 
-		M_PopMenu();
-		break;
-
-	case K_UPARROW:
-		if (m)
-		{
+		case K_UPARROW:
 			Field_ResetCursor(m);
-
 			m->cursor--;
 			Menu_AdjustCursor(m, -1);
 			sound = menu_move_sound;
-		}
-		break;
+			break;
 
-	case K_DOWNARROW:
-		if (m)
-		{
+		case K_DOWNARROW:
 			Field_ResetCursor(m);
-
 			m->cursor++;
 			Menu_AdjustCursor(m, 1);
 			sound = menu_move_sound;
-		}
-		break;
+			break;
 
-	case K_LEFTARROW:
-		if (m)
-		{
+		case K_LEFTARROW:
 			if (Menu_SlideItem(m, -1))
 			{
 				sound = menu_move_sound;
 			}
-		}
-		break;
+			break;
 
-	case K_RIGHTARROW:
-		if (m)
-		{
+		case K_RIGHTARROW:
 			if (Menu_SlideItem(m, 1))
 			{
 				sound = menu_move_sound;
 			}
-		}
-		break;
+			break;
 
-	case K_ENTER:
-		if (m)
-		{
+		case K_ENTER:
 			if (Menu_SelectItem(m))
 			{
 				sound = menu_move_sound;
 			}
-		}
-		break;
+			break;
 	}
 
 	return sound;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -403,9 +403,11 @@ Default_MenuKey(menuframework_s *m, int key)
 	case K_ENTER:
 		if (m)
 		{
-			Menu_SelectItem(m);
+			if (Menu_SelectItem(m))
+			{
+				sound = menu_move_sound;
+			}
 		}
-		sound = menu_move_sound;
 		break;
 	}
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -669,7 +669,9 @@ InitMainMenu(void)
 	x = (viddef.width / scale - widest + 70) / 2;
 	y = (viddef.height / (2 * scale) - 110);
 
+	int tmp = s_main.cursor;
 	memset(&s_main, 0, sizeof( menuframework_s ));
+	s_main.cursor = tmp;
 
 	Draw_GetPicSize(&w, &h, "m_main_plaque");
 

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -47,6 +47,10 @@ extern viddef_t viddef;
 #define VID_WIDTH viddef.width
 #define VID_HEIGHT viddef.height
 
+const char *menu_in_sound = "misc/menu1.wav";
+const char *menu_move_sound = "misc/menu2.wav";
+const char *menu_out_sound = "misc/menu3.wav";
+
 // "Wrapper" for Q_clamp to evaluate parameters just once (TODO: delete?)
 float
 ClampCvar(float min, float max, float value)

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -585,10 +585,10 @@ Menu_ItemAtCursor(menuframework_s *m)
 qboolean
 Menu_SelectItem(menuframework_s *s)
 {
-	menucommon_s * item = ( menucommon_s * )Menu_ItemAtCursor(s);
+	menucommon_s *item = (menucommon_s *)Menu_ItemAtCursor(s);
 
-	if (item->callback) {
-
+	if (item->callback)
+	{
 		item->callback(item);
 
 		return true;

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -760,15 +760,28 @@ Slider_Draw(menuslider_s *s)
 	}
 }
 
+static int
+NumItemNames(const char **items)
+{
+	const char **i;
+
+	for (i = items; *i; i++)
+	{
+	}
+
+	return i - items;
+}
+
 static qboolean
 SpinControl_DoSlide(menulist_s *s, int dir)
 {
-	if (!s->itemnames)
+	if (!s->itemnames || !s->itemnames[0])
 	{
 		return false;
 	}
 
-	if ((s->curvalue < 0) || (!s->itemnames[s->curvalue]))
+	if ((s->curvalue < 0) ||
+		(s->curvalue >= NumItemNames(s->itemnames)))
 	{
 		s->curvalue = 0;
 	}
@@ -793,6 +806,23 @@ SpinControl_DoSlide(menulist_s *s, int dir)
 	return true;
 }
 
+static const char *
+GetSelectedItem(const menulist_s *s)
+{
+	if (!s->itemnames || !s->itemnames[0])
+	{
+		return "(empty)";
+	}
+
+	if ((s->curvalue < 0) ||
+		(s->curvalue >= NumItemNames(s->itemnames)))
+	{
+		return "(invalid)";
+	}
+
+	return s->itemnames[s->curvalue];
+}
+
 static void
 SpinControl_Draw(menulist_s *s)
 {
@@ -810,16 +840,7 @@ SpinControl_Draw(menulist_s *s)
 			y, s->generic.name);
 	}
 
-	if (!s->itemnames)
-	{
-		item = "(empty)";
-	}
-	else
-	{
-		item = ((s->curvalue < 0) || (!s->itemnames[s->curvalue])) ?
-			"(invalid)" : s->itemnames[s->curvalue];
-	}
-
+	item = GetSelectedItem(s);
 	nl = strchr(item, '\n');
 
 	if (!nl)

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -29,7 +29,9 @@
 #include "../../client/menu/header/qmenu.h"
 #include "header/qmenu.h"
 
+extern void M_Banner(const char *name);
 extern void M_ForceMenuOff(void);
+extern const char *Default_MenuKey(menuframework_s *m, int key);
 
 static cvar_t *r_mode;
 static cvar_t *vid_displayindex;
@@ -972,66 +974,15 @@ VID_MenuInit(void)
 void
 VID_MenuDraw(void)
 {
-	int w, h;
-	float scale = SCR_GetMenuScale();
-
-	/* draw the banner */
-	Draw_GetPicSize(&w, &h, "m_banner_video");
-	Draw_PicScaled(viddef.width / 2 - (w * scale) / 2, viddef.height / 2 - (110 * scale),
-			"m_banner_video", scale);
-
-	/* move cursor to a reasonable starting position */
+	M_Banner("m_banner_video");
 	Menu_AdjustCursor(&s_opengl_menu, 1);
-
-	/* draw the menu */
 	Menu_Draw(&s_opengl_menu);
 }
 
 const char *
 VID_MenuKey(int key)
 {
-	extern void M_PopMenu(void);
-
-	menuframework_s *m = &s_opengl_menu;
-	const char *sound = NULL;
-	int menu_key = Key_GetMenuKey(key);
-
-	switch (menu_key)
-	{
-		case K_ESCAPE:
-			M_PopMenu();
-			break;
-		case K_UPARROW:
-			m->cursor--;
-			Menu_AdjustCursor(m, -1);
-			sound = menu_move_sound;
-			break;
-		case K_DOWNARROW:
-			m->cursor++;
-			Menu_AdjustCursor(m, 1);
-			sound = menu_move_sound;
-			break;
-		case K_LEFTARROW:
-			if (Menu_SlideItem(m, -1))
-			{
-				sound = menu_move_sound;
-			}
-			break;
-		case K_RIGHTARROW:
-			if (Menu_SlideItem(m, 1))
-			{
-				sound = menu_move_sound;
-			}
-			break;
-		case K_ENTER:
-			if (Menu_SelectItem(m))
-			{
-				sound = menu_move_sound;
-			}
-			break;
-	}
-
-	return sound;
+	return Default_MenuKey(&s_opengl_menu, key);
 }
 
 /*

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -1024,8 +1024,10 @@ VID_MenuKey(int key)
 			}
 			break;
 		case K_ENTER:
-			Menu_SelectItem(m);
-			sound = menu_move_sound;
+			if (Menu_SelectItem(m))
+			{
+				sound = menu_move_sound;
+			}
 			break;
 	}
 

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -1012,12 +1012,16 @@ VID_MenuKey(int key)
 			sound = menu_move_sound;
 			break;
 		case K_LEFTARROW:
-			Menu_SlideItem(m, -1);
-			sound = menu_move_sound;
+			if (Menu_SlideItem(m, -1))
+			{
+				sound = menu_move_sound;
+			}
 			break;
 		case K_RIGHTARROW:
-			Menu_SlideItem(m, 1);
-			sound = menu_move_sound;
+			if (Menu_SlideItem(m, 1))
+			{
+				sound = menu_move_sound;
+			}
 			break;
 		case K_ENTER:
 			Menu_SelectItem(m);

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -993,30 +993,35 @@ VID_MenuKey(int key)
 	extern void M_PopMenu(void);
 
 	menuframework_s *m = &s_opengl_menu;
-	static const char *sound = "misc/menu1.wav";
+	const char *sound = NULL;
 	int menu_key = Key_GetMenuKey(key);
 
 	switch (menu_key)
 	{
 		case K_ESCAPE:
 			M_PopMenu();
-			return NULL;
+			break;
 		case K_UPARROW:
 			m->cursor--;
 			Menu_AdjustCursor(m, -1);
+			sound = menu_move_sound;
 			break;
 		case K_DOWNARROW:
 			m->cursor++;
 			Menu_AdjustCursor(m, 1);
+			sound = menu_move_sound;
 			break;
 		case K_LEFTARROW:
 			Menu_SlideItem(m, -1);
+			sound = menu_move_sound;
 			break;
 		case K_RIGHTARROW:
 			Menu_SlideItem(m, 1);
+			sound = menu_move_sound;
 			break;
 		case K_ENTER:
 			Menu_SelectItem(m);
+			sound = menu_move_sound;
 			break;
 	}
 

--- a/src/client/sound/header/sound.h
+++ b/src/client/sound/header/sound.h
@@ -40,7 +40,7 @@ void S_StartSound(vec3_t origin, int entnum, int entchannel,
 		struct sfx_s *sfx, float fvol, float attenuation,
 		float timeofs);
 
-void S_StartLocalSound(char *sound);
+void S_StartLocalSound(const char *sound);
 void S_RawSamples(int samples, int rate, int width, int channels,
 		const byte *data, float volume);
 void S_StopAllSounds(void);

--- a/src/client/sound/sound.c
+++ b/src/client/sound/sound.c
@@ -1328,7 +1328,7 @@ S_StartSound(vec3_t origin, int entnum, int entchannel, sfx_t *sfx,
  * system.
  */
 void
-S_StartLocalSound(char *sound)
+S_StartLocalSound(const char *sound)
 {
 	sfx_t *sfx;
 


### PR DESCRIPTION
This PR continues where https://github.com/yquake2/yquake2/pull/1328 left off, with further stability improvements and menu sound fixes/improvements.

Sound fixes/improvements
* Fixed video menu using the wrong move sound. All other menus use `misc/menu2.wav` but the video menu was using `misc/menu1.wav`
* Fixed menu exit sound playing louder for some menus. `Default_MenuKey` was causing `S_StartLocalSound` to be called twice - in `M_Keydown` and `M_PopMenu`
* Pressing Left/Right arrow now only plays a sound if the selected option changed its value
* Pressing Enter now only plays a sound if the option has a callback action

Other fixes
* Fixed main menu forgetting previous cursor position on each re-open. Commit 07fc65f9c51b02009693da3ace49c411f74a5e05 added a memset for `s_main` which reset the cursor value to 0. The commit comment doesn't indicate that this was intentional
* Fixed invert mouse/joystick and lookstrafe options changing state even if the option didn't change to a different value. Their callbacks were changing the cvar values without checking the current value of the option. So for example pressing Enter on invert mouse would turn on invert mouse even if the option still says "no"

Stability
* Additional checks in cursor drawing code
* Upper bound checks for spin control `curvalue`
* `S_StartLocalSound` arg is now const
* Video menu code now uses `Default_MenuKey` and `M_Banner` to avoid code copy-paste