### PR TITLE
GL3: Significantly reduce draw calls with batching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/build/
+/build*/
 /debug/
 /release/
 *.mk

--- a/src/client/cl_network.c
+++ b/src/client/cl_network.c
@@ -304,7 +304,7 @@ CL_Disconnect(void)
 
 		if (time > 0)
 		{
-			Com_Printf("%i frames, %3.1f seconds: %3.1f fps\n",
+			Com_Printf("%i frames, %3.1f seconds: %3.1f fps\n\n",
 					cl.timedemo_frames, time / 1000.0,
 					cl.timedemo_frames * 1000.0 / time);
 		}

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -6465,7 +6465,7 @@ PlayerConfig_MenuDraw(menuframework_s *m)
 		refdef.areabits = 0;
 		refdef.num_entities = (entities[1].model) ? 2 : 1;
 		refdef.entities = entities;
-		refdef.lightstyles = 0;
+		refdef.lightstyles = NULL;
 		refdef.rdflags = RDF_NOWORLDMODEL;
 
 		Com_sprintf(scratch, sizeof(scratch), "/players/%s/%s_i.pcx", mdlname,

--- a/src/client/refresh/gl1/gl1_draw.c
+++ b/src/client/refresh/gl1/gl1_draw.c
@@ -217,6 +217,8 @@ RDraw_PicScaled(int x, int y, const char *pic, float factor)
 		Scrap_Update();
 	}
 
+	R_ApplyGLBuffer();	// respect drawing order
+
 	R_Bind(gl->texnum);
 
 	GLfloat vtx[] = {

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -251,7 +251,11 @@ GL3_Draw_CharScaled(int x, int y, int num, float scale)
 
 	scaledSize = 8*scale;
 
-	drawTexturedRectangle(draw_chars->texnum, x, y, scaledSize, scaledSize, fcol, frow, fcol+size, frow+size);
+	drawTexturedRectangle( draw_chars->texnum, x, y, scaledSize, scaledSize,
+	                       draw_chars->sl + fcol * (draw_chars->sh - draw_chars->sl),
+	                       draw_chars->tl + frow * (draw_chars->th - draw_chars->tl),
+	                       draw_chars->sl + (fcol + size) * (draw_chars->sh - draw_chars->sl),
+	                       draw_chars->tl + (frow + size) * (draw_chars->th - draw_chars->tl) );
 }
 
 // DG: copy of DrawStringScaled(), so we can draw some stats right here in the render DLL

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -496,20 +496,26 @@ void GL3_EndFrame(void)
 {
 	// TODO: draw last 2D batch
 
+	// by saving those values into a variable and setting them to 0 afterwards,
+	// gl3_show_draw_stats can include its own drawcalls (from previous frame)
+	int num3D = gl3_num3Ddraws;
+	int num2D = gl3_num2Ddraws;
+	int numBufVtx = gl3_numBufferVtxData;
+	int numBufUni = gl3_numBufferUniforms;
+	gl3_num3Ddraws = 0;
+	gl3_num2Ddraws = 0;
+	gl3_numBufferVtxData = 0;
+	gl3_numBufferUniforms = 0;
+
 	if(gl3_show_draw_stats->value)
 	{
 		float factor = 2.0f; // TODO: like SCR_GetConsoleScale()
 		char stbuf[128] = {0};
 		snprintf(stbuf, sizeof(stbuf), "3D drawcalls: %d - 2D drawcalls: %d - buffer vtx data: %d - buffer uniforms: %d",
-		         gl3_num3Ddraws, gl3_num2Ddraws, gl3_numBufferVtxData, gl3_numBufferUniforms);
+		         num3D, num2D, numBufVtx, numBufUni);
 
 		GL3_DrawStringScaled(10, 5, stbuf, factor);
 	}
-
-	gl3_num3Ddraws = 0;
-	gl3_num2Ddraws = 0;
-	gl3_numBufferVtxData = 0;
-	gl3_numBufferUniforms = 0;
 
 	if(gl3config.useBigVBO)
 	{

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -172,11 +172,6 @@ drawTexturedRectangle(GLuint texNum, float x, float y, float w, float h,
 	addIdx[3] = firstIdx+1; // second triangle
 	addIdx[4] = firstIdx+3;
 	addIdx[5] = firstIdx+2;
-
-	// FIXME: right now all this is still a bit buggy, e.g. the player model
-	// in the multiplayer menu is hidden when not enabling the next line..
-	// probably need to call drawLastBatch() before several other kinds of drawcalls
-	//drawLastBatch();
 }
 
 // bind the texture before calling this
@@ -193,6 +188,10 @@ drawTexturedRectangleNow(float x, float y, float w, float h,
 	 * sl,tl--------sh,tl
 	 *  x,y        x+w,y
 	 */
+
+	// in case some batched 2D draws are outstanding, draw them now
+	// to preserve draw order
+	GL3_DrawCurrent2Dbatch();
 
 	gl3_drawVert2D vBuf[4] = {
 	//    X,   Y,   S,  T
@@ -388,7 +387,6 @@ GL3_Draw_Fill(int x, int y, int w, int h, int c)
 		unsigned c;
 		byte v[4];
 	} color;
-	int i;
 
 	if ((unsigned)c > 255)
 	{
@@ -396,6 +394,10 @@ GL3_Draw_Fill(int x, int y, int w, int h, int c)
 	}
 
 	color.c = d_8to24table[c];
+
+	// in case some batched 2D draws are outstanding, draw them now
+	// to preserve draw order
+	GL3_DrawCurrent2Dbatch();
 
 	GLfloat vBuf[8] = {
 	//  X,   Y
@@ -405,7 +407,7 @@ GL3_Draw_Fill(int x, int y, int w, int h, int c)
 		x+w, y
 	};
 
-	for(i=0; i<3; ++i)
+	for(int i=0; i<3; ++i)
 	{
 		gl3state.uniCommonData.color.Elements[i] = color.v[i] * (1.0f/255.0f);
 	}
@@ -436,7 +438,9 @@ GL3_Draw_Flash(const float color[4], float x, float y, float w, float h)
 		return;
 	}
 
-	int i=0;
+	// in case some batched 2D draws are outstanding, draw them now
+	// to preserve draw order
+	GL3_DrawCurrent2Dbatch();
 
 	GLfloat vBuf[8] = {
 	//  X,   Y
@@ -448,7 +452,8 @@ GL3_Draw_Flash(const float color[4], float x, float y, float w, float h)
 
 	glEnable(GL_BLEND);
 
-	for(i=0; i<4; ++i)  gl3state.uniCommonData.color.Elements[i] = color[i];
+	for(int i=0; i<4; ++i)
+		gl3state.uniCommonData.color.Elements[i] = color[i];
 
 	GL3_UpdateUBOCommon();
 

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -33,6 +33,8 @@ gl3image_t *draw_chars;
 
 static GLuint vbo2D = 0, vao2D = 0, vao2Dcolor = 0; // vao2D is for textured rendering, vao2Dcolor for color-only
 
+int gl3_num3Ddraws = 0, gl3_num2Ddraws = 0, gl3_numBufferVtxData = 0, gl3_numBufferUniforms = 0;
+
 void
 GL3_Draw_InitLocal(void)
 {
@@ -116,8 +118,9 @@ drawTexturedRectangle(float x, float y, float w, float h,
 	//       implicitly bind the vbo, so I need to explicitly bind it before glBufferData()
 	GL3_BindVBO(vbo2D);
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vBuf), vBuf, GL_STREAM_DRAW);
-
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+	++gl3_numBufferVtxData;
+	++gl3_num2Ddraws;
 
 	//glMultiDrawArrays(mode, first, count, drawcount) ??
 }
@@ -158,6 +161,18 @@ GL3_Draw_CharScaled(int x, int y, int num, float scale)
 	GL3_UseProgram(gl3state.si2D.shaderProgram);
 	GL3_Bind(draw_chars->texnum);
 	drawTexturedRectangle(x, y, scaledSize, scaledSize, fcol, frow, fcol+size, frow+size);
+}
+
+// DG: copy of DrawStringScaled(), so we can draw some stats right here in the render DLL
+void
+GL3_DrawStringScaled(int x, int y, const char *s, float factor)
+{
+	while (*s)
+	{
+		GL3_Draw_CharScaled(x, y, *s ^ 0x80, factor);
+		x += 8*factor;
+		s++;
+	}
 }
 
 gl3image_t *
@@ -246,6 +261,9 @@ GL3_Draw_PicScaledCol(int x, int y, const char *pic, float factor, const float c
 void
 GL3_Draw_TileClear(int x, int y, int w, int h, const char *pic)
 {
+	if(w <= 0 || h <= 0)
+		return;
+
 	gl3image_t *image = R_FindPic(pic, (findimage_t)GL3_FindImage);
 	if (!image)
 	{
@@ -323,6 +341,9 @@ GL3_Draw_Fill(int x, int y, int w, int h, int c)
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vBuf), vBuf, GL_STREAM_DRAW);
 
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+	++gl3_numBufferVtxData;
+	++gl3_num2Ddraws;
 }
 
 // in GL1 this is called R_Flash() (which just calls R_PolyBlend())
@@ -360,6 +381,9 @@ GL3_Draw_Flash(const float color[4], float x, float y, float w, float h)
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vBuf), vBuf, GL_STREAM_DRAW);
 
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+	++gl3_numBufferVtxData;
+	++gl3_num2Ddraws;
 
 	glDisable(GL_BLEND);
 }
@@ -432,4 +456,38 @@ GL3_Draw_StretchRaw(int x, int y, int w, int h, int cols, int rows, const byte *
 	glDeleteTextures(1, &glTex);
 
 	GL3_Bind(0);
+}
+
+/*
+ * Called at the end of the frame, after 2D (UI) rendering is done.
+ * Does some internal housekeeping, then swaps the buffers
+ * and shows the next frame.
+ */
+void GL3_EndFrame(void)
+{
+	if(gl3_show_draw_stats->value)
+	{
+		float factor = 2.0f; // TODO: like SCR_GetConsoleScale()
+		char stbuf[128] = {0};
+		snprintf(stbuf, sizeof(stbuf), "3D drawcalls: %d - 2D drawcalls: %d - buffer vtx data: %d - buffer uniforms: %d",
+		         gl3_num3Ddraws, gl3_num2Ddraws, gl3_numBufferVtxData, gl3_numBufferUniforms);
+
+		GL3_DrawStringScaled(10, 5, stbuf, factor);
+	}
+
+	gl3_num3Ddraws = 0;
+	gl3_num2Ddraws = 0;
+	gl3_numBufferVtxData = 0;
+	gl3_numBufferUniforms = 0;
+
+	if(gl3config.useBigVBO)
+	{
+		// I think this is a good point to orphan the VBO and get a fresh one
+		GL3_BindVAO(gl3state.vao3D);
+		GL3_BindVBO(gl3state.vbo3D);
+		glBufferData(GL_ARRAY_BUFFER, gl3state.vbo3Dsize, NULL, GL_STREAM_DRAW);
+		gl3state.vbo3DcurOffset = 0;
+	}
+
+	GL3_SwapWindow();
 }

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -27,13 +27,26 @@
 
 #include "header/local.h"
 
+#include "header/DG_dynarr.h"
+
 unsigned d_8to24table[256];
 
 gl3image_t *draw_chars;
 
-static GLuint vbo2D = 0, vao2D = 0, vao2Dcolor = 0; // vao2D is for textured rendering, vao2Dcolor for color-only
+static GLuint vbo2D = 0, ebo2D = 0, vao2D = 0, vao2Dcolor = 0; // vao2D is for textured rendering, vao2Dcolor for color-only
 
 int gl3_num3Ddraws = 0, gl3_num2Ddraws = 0, gl3_numBufferVtxData = 0, gl3_numBufferUniforms = 0;
+
+typedef struct gl3_drawVert2D_s {
+	float x, y, s, t;
+} gl3_drawVert2D;
+
+DA_TYPEDEF(gl3_drawVert2D, Vtx2DArray_t);
+DA_TYPEDEF(GLushort, UShortArray_t);
+// dynamic arrays to batch all consecutive 2D draws with same texture to reduce drawcalls
+static Vtx2DArray_t vtxBuf = {0};
+static UShortArray_t idxBuf = {0};
+static GLuint lastBatchTexture = 0;
 
 void
 GL3_Draw_InitLocal(void)
@@ -52,6 +65,7 @@ GL3_Draw_InitLocal(void)
 
 	glGenBuffers(1, &vbo2D);
 	GL3_BindVBO(vbo2D);
+	glGenBuffers(1, &ebo2D);
 
 	GL3_UseProgram(gl3state.si2D.shaderProgram);
 
@@ -81,14 +95,47 @@ GL3_Draw_InitLocal(void)
 void
 GL3_Draw_ShutdownLocal(void)
 {
+	glDeleteBuffers(1, &ebo2D);
+	ebo2D = 0;
 	glDeleteBuffers(1, &vbo2D);
 	vbo2D = 0;
 	glDeleteVertexArrays(1, &vao2D);
 	vao2D = 0;
 	glDeleteVertexArrays(1, &vao2Dcolor);
 	vao2Dcolor = 0;
+
+	da_free(vtxBuf);
+	da_free(idxBuf);
 }
 
+void
+GL3_DrawCurrent2Dbatch()
+{
+	int numVtx = da_count(vtxBuf);
+	if(numVtx == 0)
+		return;
+
+	GL3_UseProgram(gl3state.si2D.shaderProgram);
+	GL3_Bind(lastBatchTexture);
+
+	GL3_BindVAO(vao2D);
+
+	// Note: while vao2D "remembers" its vbo for drawing, binding the vao does *not*
+	//       implicitly bind the vbo, so I need to explicitly bind it before glBufferData()
+	GL3_BindVBO(vbo2D);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(gl3_drawVert2D)*numVtx, vtxBuf.p, GL_STREAM_DRAW);
+
+	GL3_BindEBO(ebo2D);
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, da_count(idxBuf)*sizeof(GLushort), idxBuf.p, GL_STREAM_DRAW);
+	glDrawElements(GL_TRIANGLES, da_count(idxBuf), GL_UNSIGNED_SHORT, NULL);
+
+	++gl3_numBufferVtxData;
+	++gl3_num2Ddraws;
+
+	lastBatchTexture = 0;
+	da_clear(vtxBuf);
+	da_clear(idxBuf);
+}
 
 static void
 drawTexturedRectangle(GLuint texNum, float x, float y, float w, float h,
@@ -104,28 +151,32 @@ drawTexturedRectangle(GLuint texNum, float x, float y, float w, float h,
 	 *  x,y        x+w,y
 	 */
 
-	GLfloat vBuf[16] = {
-	//  X,   Y,   S,  T
-		x,   y+h, sl, th,
-		x,   y,   sl, tl,
-		x+w, y+h, sh, th,
-		x+w, y,   sh, tl
-	};
+	if((lastBatchTexture != 0 && texNum != lastBatchTexture) || da_count(vtxBuf)+4 > UINT16_MAX)
+		GL3_DrawCurrent2Dbatch();
 
-	// TODO: batch this stuff
+	lastBatchTexture = texNum;
 
-	GL3_UseProgram(gl3state.si2D.shaderProgram);
-	GL3_Bind(texNum);
+	GLushort firstIdx = da_count(vtxBuf);
 
-	GL3_BindVAO(vao2D);
+	gl3_drawVert2D* addVtx = da_addn_uninit(vtxBuf, 4);
+	//                            X,   Y,   S,  T
+	addVtx[0] = (gl3_drawVert2D){ x,   y+h, sl, th };
+	addVtx[1] = (gl3_drawVert2D){ x,   y,   sl, tl };
+	addVtx[2] = (gl3_drawVert2D){ x+w, y+h, sh, th };
+	addVtx[3] = (gl3_drawVert2D){ x+w, y,   sh, tl };
 
-	// Note: while vao2D "remembers" its vbo for drawing, binding the vao does *not*
-	//       implicitly bind the vbo, so I need to explicitly bind it before glBufferData()
-	GL3_BindVBO(vbo2D);
-	glBufferData(GL_ARRAY_BUFFER, sizeof(vBuf), vBuf, GL_STREAM_DRAW);
-	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-	++gl3_numBufferVtxData;
-	++gl3_num2Ddraws;
+	GLushort* addIdx = da_addn_uninit(idxBuf, 6);
+	addIdx[0] = firstIdx;  // first triangle of rectangle
+	addIdx[1] = firstIdx+1;
+	addIdx[2] = firstIdx+2;
+	addIdx[3] = firstIdx+1; // second triangle
+	addIdx[4] = firstIdx+3;
+	addIdx[5] = firstIdx+2;
+
+	// FIXME: right now all this is still a bit buggy, e.g. the player model
+	// in the multiplayer menu is hidden when not enabling the next line..
+	// probably need to call drawLastBatch() before several other kinds of drawcalls
+	//drawLastBatch();
 }
 
 // bind the texture before calling this
@@ -143,12 +194,12 @@ drawTexturedRectangleNow(float x, float y, float w, float h,
 	 *  x,y        x+w,y
 	 */
 
-	GLfloat vBuf[16] = {
-	//  X,   Y,   S,  T
-		x,   y+h, sl, th,
-		x,   y,   sl, tl,
-		x+w, y+h, sh, th,
-		x+w, y,   sh, tl
+	gl3_drawVert2D vBuf[4] = {
+	//    X,   Y,   S,  T
+		{ x,   y+h, sl, th },
+		{ x,   y,   sl, tl },
+		{ x+w, y+h, sh, th },
+		{ x+w, y,   sh, tl }
 	};
 
 	GL3_BindVAO(vao2D);
@@ -494,7 +545,7 @@ GL3_Draw_StretchRaw(int x, int y, int w, int h, int cols, int rows, const byte *
  */
 void GL3_EndFrame(void)
 {
-	// TODO: draw last 2D batch
+	GL3_DrawCurrent2Dbatch();
 
 	// by saving those values into a variable and setting them to 0 afterwards,
 	// gl3_show_draw_stats can include its own drawcalls (from previous frame)
@@ -515,6 +566,7 @@ void GL3_EndFrame(void)
 		         num3D, num2D, numBufVtx, numBufUni);
 
 		GL3_DrawStringScaled(10, 5, stbuf, factor);
+		GL3_DrawCurrent2Dbatch();
 	}
 
 	if(gl3config.useBigVBO)

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -115,6 +115,9 @@ GL3_DrawCurrent2Dbatch()
 	if(numVtx == 0)
 		return;
 
+	if(gl3_scrap_dirty)
+		GL3_Scrap_Upload();
+
 	GL3_UseProgram(gl3state.si2D.shaderProgram);
 	GL3_Bind(lastBatchTexture);
 
@@ -192,6 +195,9 @@ drawTexturedRectangleNow(float x, float y, float w, float h,
 	// in case some batched 2D draws are outstanding, draw them now
 	// to preserve draw order
 	GL3_DrawCurrent2Dbatch();
+
+	if (gl3_scrap_dirty)
+		GL3_Scrap_Upload();
 
 	gl3_drawVert2D vBuf[4] = {
 	//    X,   Y,   S,  T
@@ -319,6 +325,9 @@ GL3_Draw_PicScaledCol(int x, int y, const char *pic, float factor, const float c
 		Com_Printf("Can't find pic: %s\n", pic);
 		return;
 	}
+
+	if (gl3_scrap_dirty)
+		GL3_Scrap_Upload();
 
 	gl3state.uniCommonData.color = HMM_Vec4(color[0], color[1], color[2], 1.0f);
 	GL3_UpdateUBOCommon();

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -89,9 +89,48 @@ GL3_Draw_ShutdownLocal(void)
 	vao2Dcolor = 0;
 }
 
+
+static void
+drawTexturedRectangle(GLuint texNum, float x, float y, float w, float h,
+                      float sl, float tl, float sh, float th)
+{
+	/*
+	 *  x,y+h      x+w,y+h
+	 * sl,th--------sh,th
+	 *  |             |
+	 *  |             |
+	 *  |             |
+	 * sl,tl--------sh,tl
+	 *  x,y        x+w,y
+	 */
+
+	GLfloat vBuf[16] = {
+	//  X,   Y,   S,  T
+		x,   y+h, sl, th,
+		x,   y,   sl, tl,
+		x+w, y+h, sh, th,
+		x+w, y,   sh, tl
+	};
+
+	// TODO: batch this stuff
+
+	GL3_UseProgram(gl3state.si2D.shaderProgram);
+	GL3_Bind(texNum);
+
+	GL3_BindVAO(vao2D);
+
+	// Note: while vao2D "remembers" its vbo for drawing, binding the vao does *not*
+	//       implicitly bind the vbo, so I need to explicitly bind it before glBufferData()
+	GL3_BindVBO(vbo2D);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(vBuf), vBuf, GL_STREAM_DRAW);
+	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+	++gl3_numBufferVtxData;
+	++gl3_num2Ddraws;
+}
+
 // bind the texture before calling this
 static void
-drawTexturedRectangle(float x, float y, float w, float h,
+drawTexturedRectangleNow(float x, float y, float w, float h,
                       float sl, float tl, float sh, float th)
 {
 	/*
@@ -156,11 +195,7 @@ GL3_Draw_CharScaled(int x, int y, int num, float scale)
 
 	scaledSize = 8*scale;
 
-	// TODO: batchen?
-
-	GL3_UseProgram(gl3state.si2D.shaderProgram);
-	GL3_Bind(draw_chars->texnum);
-	drawTexturedRectangle(x, y, scaledSize, scaledSize, fcol, frow, fcol+size, frow+size);
+	drawTexturedRectangle(draw_chars->texnum, x, y, scaledSize, scaledSize, fcol, frow, fcol+size, frow+size);
 }
 
 // DG: copy of DrawStringScaled(), so we can draw some stats right here in the render DLL
@@ -209,10 +244,7 @@ GL3_Draw_StretchPic(int x, int y, int w, int h, const char *pic)
 		return;
 	}
 
-	GL3_UseProgram(gl3state.si2D.shaderProgram);
-	GL3_Bind(gl->texnum);
-
-	drawTexturedRectangle(x, y, w, h, gl->sl, gl->tl, gl->sh, gl->th);
+	drawTexturedRectangle(gl->texnum, x, y, w, h, gl->sl, gl->tl, gl->sh, gl->th);
 }
 
 void
@@ -225,10 +257,7 @@ GL3_Draw_PicScaled(int x, int y, const char *pic, float factor)
 		return;
 	}
 
-	GL3_UseProgram(gl3state.si2D.shaderProgram);
-	GL3_Bind(gl->texnum);
-
-	drawTexturedRectangle(x, y, gl->width*factor, gl->height*factor, gl->sl, gl->tl, gl->sh, gl->th);
+	drawTexturedRectangle(gl->texnum, x, y, gl->width*factor, gl->height*factor, gl->sl, gl->tl, gl->sh, gl->th);
 }
 
 void
@@ -247,7 +276,9 @@ GL3_Draw_PicScaledCol(int x, int y, const char *pic, float factor, const float c
 	GL3_UseProgram(gl3state.si2Dtinted.shaderProgram);
 	GL3_Bind(gl->texnum);
 
-	drawTexturedRectangle(x, y, gl->width*factor, gl->height*factor, gl->sl, gl->tl, gl->sh, gl->th);
+	// NOTE: this function (and this shader) are only used for the crosshair
+	//       so use the simple immediate (unbatched) draw function
+	drawTexturedRectangleNow(x, y, gl->width*factor, gl->height*factor, gl->sl, gl->tl, gl->sh, gl->th);
 
 	gl3state.uniCommonData.color = HMM_Vec4(1, 1, 1, 1);
 	GL3_UpdateUBOCommon();
@@ -271,10 +302,7 @@ GL3_Draw_TileClear(int x, int y, int w, int h, const char *pic)
 		return;
 	}
 
-	GL3_UseProgram(gl3state.si2D.shaderProgram);
-	GL3_Bind(image->texnum);
-
-	drawTexturedRectangle(x, y, w, h, x/64.0f, y/64.0f, (x+w)/64.0f, (y+h)/64.0f);
+	drawTexturedRectangle(image->texnum, x, y, w, h, x/64.0f, y/64.0f, (x+w)/64.0f, (y+h)/64.0f);
 }
 
 void
@@ -295,7 +323,7 @@ GL3_DrawFrameBufferObject(int x, int y, int w, int h, GLuint fboTexture, const f
 		glUniform4fv(shader->uniVblend, 1, v_blend);
 	}
 
-	drawTexturedRectangle(x, y, w, h, 0, 1, 1, 0);
+	drawTexturedRectangleNow(x, y, w, h, 0, 1, 1, 0);
 }
 
 /*
@@ -451,7 +479,8 @@ GL3_Draw_StretchRaw(int x, int y, int w, int h, int cols, int rows, const byte *
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
 
-	drawTexturedRectangle(x, y, w, h, 0.0f, 0.0f, 1.0f, 1.0f);
+	// NOTE: this is only used for videos and only called once per frame (or not at all)
+	drawTexturedRectangleNow(x, y, w, h, 0.0f, 0.0f, 1.0f, 1.0f);
 
 	glDeleteTextures(1, &glTex);
 
@@ -465,6 +494,8 @@ GL3_Draw_StretchRaw(int x, int y, int w, int h, int cols, int rows, const byte *
  */
 void GL3_EndFrame(void)
 {
+	// TODO: draw last 2D batch
+
 	if(gl3_show_draw_stats->value)
 	{
 		float factor = 2.0f; // TODO: like SCR_GetConsoleScale()

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -587,6 +587,7 @@ void GL3_EndFrame(void)
 		GL3_DrawCurrent2Dbatch();
 	}
 
+#if 0
 	if(gl3config.useBigVBO)
 	{
 		// I think this is a good point to orphan the VBO and get a fresh one
@@ -595,6 +596,7 @@ void GL3_EndFrame(void)
 		glBufferData(GL_ARRAY_BUFFER, gl3state.vbo3Dsize, NULL, GL_STREAM_DRAW);
 		gl3state.vbo3DcurOffset = 0;
 	}
+#endif
 
 	GL3_SwapWindow();
 }

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -587,16 +587,5 @@ void GL3_EndFrame(void)
 		GL3_DrawCurrent2Dbatch();
 	}
 
-#if 0
-	if(gl3config.useBigVBO)
-	{
-		// I think this is a good point to orphan the VBO and get a fresh one
-		GL3_BindVAO(gl3state.vao3D);
-		GL3_BindVBO(gl3state.vbo3D);
-		glBufferData(GL_ARRAY_BUFFER, gl3state.vbo3Dsize, NULL, GL_STREAM_DRAW);
-		gl3state.vbo3DcurOffset = 0;
-	}
-#endif
-
 	GL3_SwapWindow();
 }

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -587,5 +587,13 @@ void GL3_EndFrame(void)
 		GL3_DrawCurrent2Dbatch();
 	}
 
+#ifdef YQ2_GL3_GLES
+	if (gl_discardfb->value)
+	{
+		static const GLenum attachments[] = {GL_COLOR_ATTACHMENT0, GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT};
+		glInvalidateFramebuffer(GL_FRAMEBUFFER, 3, attachments);
+	}
+#endif
+
 	GL3_SwapWindow();
 }

--- a/src/client/refresh/gl3/gl3_image.c
+++ b/src/client/refresh/gl3/gl3_image.c
@@ -54,23 +54,23 @@ enum {
 	SCRAP_HEIGHT = 1024
 };
 
-static int scrap_allocated[SCRAP_WIDTH]; // FIXME: why not short
+static short scrap_allocated[SCRAP_WIDTH];
 static GLuint gl3_scrap_texnum = 0;
-static byte scrap_texels[SCRAP_WIDTH * SCRAP_HEIGHT]; // FIXME: [4] ?
+static unsigned scrap_texels[SCRAP_WIDTH * SCRAP_HEIGHT];
 qboolean gl3_scrap_dirty = false;
 
 void
 GL3_Scrap_Init(void)
 {
 	memset (scrap_allocated, 0, sizeof(scrap_allocated));	// empty
-	memset (scrap_texels, 255, sizeof(scrap_texels));	// transparent
+	memset (scrap_texels, 0, sizeof(scrap_texels));	// transparent
 
 	glGenTextures(1, &gl3_scrap_texnum);
 }
 
 /* returns a texture number (relative to g3_scrap_texnum) and the position inside it */
 static int
-GL3_Scrap_AllocBlock(int w, int h, int *x, int *y)
+GL3_Scrap_AllocBlock(int w, int h, int *x, int *y, const unsigned *pic)
 {
 	w += 2;	// add an empty border to all sides
 	h += 2;
@@ -113,6 +113,16 @@ GL3_Scrap_AllocBlock(int w, int h, int *x, int *y)
 	}
 	(*x)++;	// jump the border
 	(*y)++;
+
+	int k=0;
+	for(int i=0; i < h-2; i++)
+	{
+		memcpy(&scrap_texels[(*y + i) * SCRAP_WIDTH + *x],
+				pic + k, (w - 2) * sizeof(unsigned));
+		k += w - 2; // -2 because of w += 2 above
+	}
+
+	gl3_scrap_dirty = true;
 
 	return 0;
 }
@@ -327,7 +337,8 @@ GL3_Scrap_Upload(void)
 {
 	GL3_Bind(gl3_scrap_texnum);
 
-	GL3_Upload8(scrap_texels, SCRAP_WIDTH, SCRAP_HEIGHT, false);
+	GL3_Upload32(scrap_texels, SCRAP_WIDTH, SCRAP_HEIGHT, false);
+
 	if (r_2D_unfiltered->value != 0)
 	{
 		// 2D textures shouldn't be filtered by default (r_2D_unfiltered),
@@ -444,28 +455,39 @@ GL3_LoadPic(char *name, byte *pic, int width, int realwidth,
 	}
 
 	/* load little pics into the scrap */
-	if (nolerp == default2Dnolerp && (image->type == it_pic) && (bits == 8) &&
+	if (nolerp == default2Dnolerp && (image->type == it_pic) &&
 		(image->width <= 128) && (image->height <= 128))
 	{
 		int x=0, y=0;
 
-		if (GL3_Scrap_AllocBlock(image->width, image->height, &x, &y) == -1)
-		{
-			goto nonscrap;
-		}
-
-		gl3_scrap_dirty = true;
-
 		/* copy the texels into the scrap block */
-		int k = 0;
-
-		for (int i = 0; i < image->height; i++)
+		if(bits == 8)
 		{
-			for (int j = 0; j < image->width; j++, k++)
+			unsigned *trans = R_Convert8to32(pic, width, height, d_8to24table);
+			if (trans)
 			{
-				// TODO: could do 8->32 conversion here
-				scrap_texels[(y + i) * SCRAP_WIDTH + x + j] = pic[k];
+				int scrapnum = GL3_Scrap_AllocBlock(width, height, &x, &y, trans);
+				free(trans);
+				if(scrapnum == -1)
+					goto nonscrap;
 			}
+			else
+			{
+				Sys_Error("Error: Couldn't convert texture '%s' to 32bit?!\n", name);
+				return NULL;
+			}
+		}
+		else if(bits == 32)
+		{
+			if (GL3_Scrap_AllocBlock(image->width, image->height, &x, &y, (unsigned*)pic) == -1)
+			{
+				goto nonscrap;
+			}
+		}
+		else
+		{
+			Sys_Error("Error: texture '%s' has %d bits per pixel, only 8 and 32 supported!\n", name, bits);
+			return NULL;
 		}
 
 		image->texnum = gl3_scrap_texnum;
@@ -528,21 +550,6 @@ GL3_LoadPic(char *name, byte *pic, int width, int realwidth,
 						(image->type != it_pic && image->type != it_sky));
 		}
 
-		if (realwidth && realheight)
-		{
-			if ((realwidth <= image->width) && (realheight <= image->height))
-			{
-				image->width = realwidth;
-				image->height = realheight;
-			}
-			else
-			{
-				Com_DPrintf(
-						"Warning, image '%s' has hi-res replacement smaller than the original! (%d x %d) < (%d x %d)\n",
-						name, image->width, image->height, realwidth, realheight);
-			}
-		}
-
 		image->sl = 0;
 		image->sh = 1;
 		image->tl = 0;
@@ -552,6 +559,21 @@ GL3_LoadPic(char *name, byte *pic, int width, int realwidth,
 		{
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		}
+	}
+
+	if (realwidth && realheight)
+	{
+		if ((realwidth <= image->width) && (realheight <= image->height))
+		{
+			image->width = realwidth;
+			image->height = realheight;
+		}
+		else
+		{
+			Com_DPrintf(
+					"Warning, image '%s' has hi-res replacement smaller than the original! (%d x %d) < (%d x %d)\n",
+					name, image->width, image->height, realwidth, realheight);
 		}
 	}
 

--- a/src/client/refresh/gl3/gl3_image.c
+++ b/src/client/refresh/gl3/gl3_image.c
@@ -794,9 +794,10 @@ GL3_ImageList_f(void)
 				imageType = '?';
 				break;
 		}
+		char isScrap = image->scrap ? 'S' : ' ';
 		char isLava = image->is_lava ? 'L' : ' ';
 
-		Com_Printf("%c%c %3i %3i %s %s: %s %s\n", imageType, isLava, w, h,
+		Com_Printf("%c%c%c %3i %3i %s %s: %s %s\n", isScrap, imageType, isLava, w, h,
 		         formatstrings[image->has_alpha], potstrings[isNPOT], image->name, in_use);
 	}
 

--- a/src/client/refresh/gl3/gl3_image.c
+++ b/src/client/refresh/gl3/gl3_image.c
@@ -49,6 +49,74 @@ gl3image_t gl3textures[MAX_GL3TEXTURES];
 int numgl3textures = 0;
 static int image_max = 0;
 
+enum {
+	SCRAP_WIDTH = 1024,
+	SCRAP_HEIGHT = 1024
+};
+
+static int scrap_allocated[SCRAP_WIDTH]; // FIXME: why not short
+static GLuint gl3_scrap_texnum = 0;
+static byte scrap_texels[SCRAP_WIDTH * SCRAP_HEIGHT]; // FIXME: [4] ?
+qboolean gl3_scrap_dirty = false;
+
+void
+GL3_Scrap_Init(void)
+{
+	memset (scrap_allocated, 0, sizeof(scrap_allocated));	// empty
+	memset (scrap_texels, 255, sizeof(scrap_texels));	// transparent
+
+	glGenTextures(1, &gl3_scrap_texnum);
+}
+
+/* returns a texture number (relative to g3_scrap_texnum) and the position inside it */
+static int
+GL3_Scrap_AllocBlock(int w, int h, int *x, int *y)
+{
+	w += 2;	// add an empty border to all sides
+	h += 2;
+
+	int best = SCRAP_HEIGHT;
+
+	for (int i = 0; i < SCRAP_WIDTH - w; i++)
+	{
+		int j;
+		int best2 = 0;
+
+		for (j = 0; j < w; j++)
+		{
+			if (scrap_allocated[i + j] >= best)
+			{
+				break;
+			}
+
+			if (scrap_allocated[i + j] > best2)
+			{
+				best2 = scrap_allocated[i + j];
+			}
+		}
+
+		if (j == w)
+		{   /* this is a valid spot */
+			*x = i;
+			*y = best = best2;
+		}
+	}
+
+	if (best + h > SCRAP_HEIGHT)
+	{
+		return -1;
+	}
+
+	for (int i = 0; i < w; i++)
+	{
+		scrap_allocated[*x + i] = best + h;
+	}
+	(*x)++;	// jump the border
+	(*y)++;
+
+	return 0;
+}
+
 void
 GL3_TextureMode(char *string)
 {
@@ -254,6 +322,29 @@ GL3_Upload8(const byte *data, size_t width, size_t height, qboolean mipmap)
 	return ret;
 }
 
+void
+GL3_Scrap_Upload(void)
+{
+	GL3_Bind(gl3_scrap_texnum);
+
+	GL3_Upload8(scrap_texels, SCRAP_WIDTH, SCRAP_HEIGHT, false);
+	if (r_2D_unfiltered->value != 0)
+	{
+		// 2D textures shouldn't be filtered by default (r_2D_unfiltered),
+		// so the scrap shouldn't be filtered
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	}
+	else // 2D textures should be filtered by default => filter the scrap
+	{
+		// we can't use gl_filter_min which might be GL_*_MIPMAP_*
+		// also, there's no anisotropic filtering for textures w/o mipmaps
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, gl_filter_max);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, gl_filter_max);
+	}
+	gl3_scrap_dirty = false;
+}
+
 /*
  * This is also used as an entry point for the generated r_notexture
  */
@@ -267,7 +358,8 @@ GL3_LoadPic(char *name, byte *pic, int width, int realwidth,
 	int i;
 
 	qboolean nolerp = false;
-	if (r_2D_unfiltered->value && type == it_pic)
+	qboolean default2Dnolerp = r_2D_unfiltered->value != 0.0f;
+	if (default2Dnolerp && type == it_pic)
 	{
 		// if r_2D_unfiltered is true(ish), nolerp should usually be true,
 		// *unless* the texture is on the r_lerp_list
@@ -351,139 +443,90 @@ GL3_LoadPic(char *name, byte *pic, int width, int realwidth,
 		}
 	}
 
-	image->is_lava = (strstr(name, "lava") != NULL);
-
-	// image->scrap = false; // TODO: reintroduce scrap? would allow optimizations in 2D rendering..
-
-	glGenTextures(1, &texNum);
-
-	image->texnum = texNum;
-
-	GL3_SelectTMU(GL_TEXTURE0);
-	GL3_Bind(texNum);
-
-	if (bits == 8)
-	{
-		// resize 8bit images only when we forced such logic
-		if (r_scale8bittextures->value)
-		{
-			byte *image_converted;
-			int scale = 2;
-
-			// scale 3 times if lerp image
-			if (!nolerp && (vid.height >= 240 * 3))
-				scale = 3;
-
-			image_converted = malloc(width * height * scale * scale);
-			if (!image_converted)
-				return NULL;
-
-			if (scale == 3) {
-				scale3x(pic, image_converted, width, height);
-			} else {
-				scale2x(pic, image_converted, width, height);
-			}
-
-			image->has_alpha = GL3_Upload8(image_converted, width * scale, height * scale,
-						(image->type != it_pic && image->type != it_sky));
-			free(image_converted);
-		}
-		else
-		{
-			image->has_alpha = GL3_Upload8(pic, width, height,
-						(image->type != it_pic && image->type != it_sky));
-		}
-	}
-	else
-	{
-		image->has_alpha = GL3_Upload32((unsigned *)pic, width, height,
-					(image->type != it_pic && image->type != it_sky));
-	}
-
-	if (realwidth && realheight)
-	{
-		if ((realwidth <= image->width) && (realheight <= image->height))
-		{
-			image->width = realwidth;
-			image->height = realheight;
-		}
-		else
-		{
-			Com_DPrintf(
-					"Warning, image '%s' has hi-res replacement smaller than the original! (%d x %d) < (%d x %d)\n",
-					name, image->width, image->height, realwidth, realheight);
-		}
-	}
-
-	image->sl = 0;
-	image->sh = 1;
-	image->tl = 0;
-	image->th = 1;
-
-	if (nolerp)
-	{
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	}
-#if 0 // TODO: the scrap could allow batch rendering 2D stuff? not sure it's worth the hassle..
 	/* load little pics into the scrap */
-	if (!nolerp && (image->type == it_pic) && (bits == 8) &&
-		(image->width < 64) && (image->height < 64))
+	if (nolerp == default2Dnolerp && (image->type == it_pic) && (bits == 8) &&
+		(image->width <= 128) && (image->height <= 128))
 	{
-		int x, y;
-		int i, j, k;
-		int texnum;
+		int x=0, y=0;
 
-		texnum = Scrap_AllocBlock(image->width, image->height, &x, &y);
-
-		if (texnum == -1)
+		if (GL3_Scrap_AllocBlock(image->width, image->height, &x, &y) == -1)
 		{
 			goto nonscrap;
 		}
 
-		scrap_dirty = true;
+		gl3_scrap_dirty = true;
 
 		/* copy the texels into the scrap block */
-		k = 0;
+		int k = 0;
 
-		for (i = 0; i < image->height; i++)
+		for (int i = 0; i < image->height; i++)
 		{
-			for (j = 0; j < image->width; j++, k++)
+			for (int j = 0; j < image->width; j++, k++)
 			{
-				scrap_texels[texnum][(y + i) * BLOCK_WIDTH + x + j] = pic[k];
+				// TODO: could do 8->32 conversion here
+				scrap_texels[(y + i) * SCRAP_WIDTH + x + j] = pic[k];
 			}
 		}
 
-		image->texnum = TEXNUM_SCRAPS + texnum;
+		image->texnum = gl3_scrap_texnum;
 		image->scrap = true;
 		image->has_alpha = true;
-		image->sl = (x + 0.01) / (float)BLOCK_WIDTH;
-		image->sh = (x + image->width - 0.01) / (float)BLOCK_WIDTH;
-		image->tl = (y + 0.01) / (float)BLOCK_WIDTH;
-		image->th = (y + image->height - 0.01) / (float)BLOCK_WIDTH;
+		image->sl = (float)x / SCRAP_WIDTH;
+		image->sh = (float)(x + image->width) / SCRAP_WIDTH;
+		image->tl = (float)y / SCRAP_HEIGHT;
+		image->th = (float)(y + image->height) / SCRAP_HEIGHT;
 	}
 	else
 	{
 	nonscrap:
+
+		image->is_lava = (strstr(name, "lava") != NULL);
 		image->scrap = false;
-		image->texnum = TEXNUM_IMAGES + (image - gltextures);
-		R_Bind(image->texnum);
+
+		glGenTextures(1, &texNum);
+
+		image->texnum = texNum;
+
+		GL3_SelectTMU(GL_TEXTURE0);
+		GL3_Bind(texNum);
 
 		if (bits == 8)
 		{
-			image->has_alpha = R_Upload8(pic, width, height,
-						(image->type != it_pic && image->type != it_sky),
-						image->type == it_sky);
+			// resize 8bit images only when we forced such logic
+			if (r_scale8bittextures->value)
+			{
+				byte *image_converted;
+				int scale = 2;
+
+				// scale 3 times if lerp image
+				if (!nolerp && (vid.height >= 240 * 3))
+					scale = 3;
+
+				image_converted = malloc(width * height * scale * scale);
+				if (!image_converted)
+					return NULL;
+
+				if (scale == 3) {
+					scale3x(pic, image_converted, width, height);
+				} else {
+					scale2x(pic, image_converted, width, height);
+				}
+
+				image->has_alpha = GL3_Upload8(image_converted, width * scale, height * scale,
+							(image->type != it_pic && image->type != it_sky));
+				free(image_converted);
+			}
+			else
+			{
+				image->has_alpha = GL3_Upload8(pic, width, height,
+							(image->type != it_pic && image->type != it_sky));
+			}
 		}
 		else
 		{
-			image->has_alpha = R_Upload32((unsigned *)pic, width, height,
+			image->has_alpha = GL3_Upload32((unsigned *)pic, width, height,
 						(image->type != it_pic && image->type != it_sky));
 		}
-
-		image->upload_width = upload_width; /* after power of 2 and scales */
-		image->upload_height = upload_height;
-		image->paletted = uploaded_paletted;
 
 		if (realwidth && realheight)
 		{
@@ -511,7 +554,7 @@ GL3_LoadPic(char *name, byte *pic, int width, int realwidth,
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		}
 	}
-#endif // 0
+
 	return image;
 }
 
@@ -667,6 +710,8 @@ GL3_ShutdownImages(void)
 		glDeleteTextures(1, &image->texnum);
 		memset(image, 0, sizeof(*image));
 	}
+
+	glDeleteTextures(1, &gl3_scrap_texnum);
 }
 
 static qboolean IsNPOT(int v)

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -136,11 +136,12 @@ static cvar_t *gl_znear;
 DA_TYPEDEF(gl3_3D_vtx_t, Vtx3DArray_t);
 DA_TYPEDEF(GLushort, UShortArray_t);
 DA_TYPEDEF(gl3drawCmd_t, DrawCommandArray_t);
+DA_TYPEDEF(hmm_mat4, Mat4Array_t);
 // dynamic arrays to batch all consecutive 3D draws (with gl3_3D_vtx_t) with same texture to reduce drawcalls
 static Vtx3DArray_t vtxBuf = {0};
 static UShortArray_t idxBuf = {0};
 static DrawCommandArray_t drawCmds = {0};
-
+static Mat4Array_t transModelMats = {0};
 
 // Yaw-Pitch-Roll
 // equivalent to R_z * R_y * R_x where R_x is the trans matrix for rotating around X axis for aroundXdeg
@@ -190,7 +191,7 @@ GL3_RotateUni3DforEntity(entity_t *e)
 // if replaceTransModelMat is true, the existing value of drawCmd->transModelMat
 // is ignored and it's replaced with the one calculated here (otherwise they're multiplied)
 void
-GL3_RotateForEntity(entity_t *e, gl3drawCmd_t* drawCmd, qboolean replaceTransModelMat)
+GL3_RotateForEntity(entity_t *e, gl3drawCmd_t* drawCmd)
 {
 	// TODO: shortcut for "not rotated at all"?
 
@@ -203,11 +204,7 @@ GL3_RotateForEntity(entity_t *e, gl3drawCmd_t* drawCmd, qboolean replaceTransMod
 		transMat.Elements[3][i] = e->origin[i]; // set translation
 	}
 
-	if (replaceTransModelMat)
-		drawCmd->transModelMat = transMat;
-	else
-		drawCmd->transModelMat = HMM_MultiplyMat4(drawCmd->transModelMat, transMat);
-	drawCmd->flags &= ~DCFlag_IsIdentityMat;
+	GL3_SetDrawCmdTransMatrix(drawCmd, transMat);
 }
 
 
@@ -551,6 +548,9 @@ GL3_Init(void)
 	GetPCXPalette (&colormap, d_8to24table);
 	free(colormap);
 
+	da_clear(transModelMats);
+	da_add(transModelMats, gl3_identityMat4); // element 0 is always the identity matrix
+
 	GL3_Register();
 
 	/* set our "safe" mode */
@@ -694,6 +694,7 @@ GL3_Shutdown(void)
 	da_free(vtxBuf);
 	da_free(idxBuf);
 	da_free(drawCmds);
+	da_free(transModelMats);
 
 	/* shutdown OS specific OpenGL stuff like contexts, etc.  */
 	GL3_ShutdownContext();
@@ -765,21 +766,21 @@ void GL3_Draw3DBatchesNow()
 
 	// set curState to something that reflects the actual state, as far as possible,
 	// and otherwise makes sure it'll be set in the loop
-	gl3drawCmd_t curState = GL3_CreateDrawCmd(true);
-	curState.flags = ~drawCmds.p[0].flags; // just the opposite flags of the first element
+	gl3drawCmd_t curState = GL3_CreateDrawCmd();
+
 	curState.texnum = gl3state.currenttexture;
 	curState.lmtexnum = gl3state.currentlightmap;
 	curState.alpha = gl3state.uni3DData.alpha;
 	curState.scroll = gl3state.uni3DData.scroll;
 	curState.lightScaleForTurb = gl3state.uni3DData.lightScaleForTurb;
 
-	gl3ShaderInfo_t* shader = NULL;
+	// for the next two the approach is setting a value that
+	// is different from the one in the first drawCmd, to make sure
+	// the corresponding state is set in the first iteration
+	curState.flags = ~drawCmds.p[0].flags; // just the opposite flags of the first element
+	curState.transModelMatIdx = drawCmds.p[0].transModelMatIdx + 1;
 
-	// .. but at least set the identity mat so DCFlag_IsIdentityMat can be set
-	// as a sane default
-	curState.flags |= DCFlag_IsIdentityMat;
-	gl3state.uni3DData.transModelMat4 = gl3_identityMat4;
-	GL3_UpdateUBO3D();
+	gl3ShaderInfo_t* shader = NULL;
 
 	for(int i=0, n=da_count(drawCmds); i < n; ++i)
 	{
@@ -862,20 +863,11 @@ void GL3_Draw3DBatchesNow()
 			updateUni3D = true;
 		}
 
-		if((flags & DCFlag_IsIdentityMat) != (curFlags & DCFlag_IsIdentityMat))
+		if(cmd->transModelMatIdx != curState.transModelMatIdx)
 		{
-			// one is the identity matrix, the other isn't => we need to update
-			gl3state.uni3DData.transModelMat4 = cmd->transModelMat;
+			gl3state.uni3DData.transModelMat4 = da_get(transModelMats, cmd->transModelMatIdx);
 			updateUni3D = true;
 		}
-		else if( !(flags & DCFlag_IsIdentityMat) )
-		{
-			// neither is an identity matrix
-			// TODO: could check if they're identical and only update if not
-			gl3state.uni3DData.transModelMat4 = cmd->transModelMat;
-			updateUni3D = true;
-		}
-		// else both are the identity matrix - nothing to do
 
 		if(updateUni3D)
 			GL3_UpdateUBO3D();
@@ -891,13 +883,15 @@ void GL3_Draw3DBatchesNow()
 	da_clear(idxBuf);
 	da_clear(drawCmds);
 
+	da_setcount(transModelMats, 1); // keep index 0 (identity matrix)
+
 	// restore sane default for other draw operations (models, particles, 2D)
-	int curFlags = curState.flags;
-	if( !(curFlags & DCFlag_IsIdentityMat) )
+	if(curState.transModelMatIdx != 0)
 	{
 		gl3state.uni3DData.transModelMat4 = gl3_identityMat4;
 		GL3_UpdateUBO3D();
 	}
+	int curFlags = curState.flags;
 	if(curFlags & DCFlag_Blend)
 		glDisable(GL_BLEND);
 	if(curFlags & DCFlag_DisableDepthMask)
@@ -910,7 +904,8 @@ void GL3_Draw3DBatchesNow()
 static qboolean drawStateEqual(const gl3drawCmd_t* a, const gl3drawCmd_t* b)
 {
 	if( a->flags != b->flags || a->shaderIdx != b->shaderIdx
-	   || a->texnum != b->texnum || a->lmtexnum != b->lmtexnum )
+	   || a->texnum != b->texnum || a->lmtexnum != b->lmtexnum
+	   || a->transModelMatIdx != b->transModelMatIdx )
 		return false;
 
 	int flags = a->flags; // at this point we know the flags are identical
@@ -928,22 +923,17 @@ static qboolean drawStateEqual(const gl3drawCmd_t* a, const gl3drawCmd_t* b)
 		return false;
 
 	if((flags & DCFlag_UseLmStyles) && !lmstylesEqual(a->styles, b->styles))
-	{
 		return false;
-	}
-
-	if( !(flags & DCFlag_IsIdentityMat) )
-	{
-		const float* atm = a->transModelMat.Elements[0];
-		const float* btm = b->transModelMat.Elements[0];
-		for(int i=0; i<16; ++i)
-		{
-			if(atm[i] != btm[i]) // TODO: tolerance?
-				return false;
-		}
-	}
 
 	return true;
+}
+
+void
+GL3_SetDrawCmdTransMatrix(gl3drawCmd_t* drawCmd, hmm_mat4 mat)
+{
+	int idx = da_count(transModelMats);
+	da_add(transModelMats, mat);
+	drawCmd->transModelMatIdx = idx;
 }
 
 // assumes gl3state.v[ab]o3D are bound
@@ -1033,7 +1023,7 @@ GL3_DrawBeam(entity_t *e)
 	int i;
 	enum { NUM_BEAM_SEGS = 6 };
 
-	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(true);
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd();
 
 	vec3_t perpvec;
 	vec3_t direction, normalized_direction;
@@ -1109,7 +1099,7 @@ GL3_DrawSpriteModel(entity_t *e, gl3model_t *currentmodel)
 	dsprite_t *psprite;
 	gl3image_t *skin;
 
-	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(true);
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd();
 
 	/* don't even bother culling, because it's just
 	   a single polygon without a surface cache */
@@ -1180,7 +1170,7 @@ static void
 GL3_DrawNullModel(entity_t *currententity)
 {
 	vec3_t shadelight;
-	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(true);
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd();
 
 	if(currententity->flags & RF_TRANSLUCENT)
 		drawCmd.flags |= DCFlag_DisableDepthMask;
@@ -1194,7 +1184,7 @@ GL3_DrawNullModel(entity_t *currententity)
 		GL3_LightPoint(currententity, currententity->origin, shadelight);
 	}
 
-	GL3_RotateForEntity(currententity, &drawCmd, true);
+	GL3_RotateForEntity(currententity, &drawCmd);
 
 	drawCmd.alpha = 1.0f;
 	for(int i=0; i<3; ++i)

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -656,6 +656,8 @@ GL3_Init(void)
 
 	registration_sequence = 1; // from R_InitImages() (everything else from there shouldn't be needed anymore)
 
+	GL3_Scrap_Init();
+
 	GL3_Mod_Init();
 
 	GL3_InitParticleTexture();

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -1774,6 +1774,11 @@ GL3_SetLightLevel(entity_t *currententity)
 static void
 GL3_RenderFrame(refdef_t *fd)
 {
+	// in case some batched 2D draws are outstanding, draw them now
+	// to preserve draw order (I think here this is only relevant
+	// for the player model in the multiplayer player setup menu)
+	GL3_DrawCurrent2Dbatch();
+
 	GL3_RenderView(fd);
 	GL3_SetLightLevel(NULL);
 	qboolean usedFBO = gl3state.ppFBObound; // if it was/is used this frame

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -773,6 +773,8 @@ void GL3_Draw3DBatchesNow()
 	curState.scroll = gl3state.uni3DData.scroll;
 	curState.lightScaleForTurb = gl3state.uni3DData.lightScaleForTurb;
 
+	gl3ShaderInfo_t* shader = NULL;
+
 	// .. but at least set the identity mat so DCFlag_IsIdentityMat can be set
 	// as a sane default
 	curState.flags |= DCFlag_IsIdentityMat;
@@ -787,7 +789,11 @@ void GL3_Draw3DBatchesNow()
 		int curFlags = curState.flags;
 		qboolean updateUni3D = false;
 
-		GL3_UseProgram(cmd->shader->shaderProgram);
+		if(cmd->shaderIdx != curState.shaderIdx)
+		{
+			shader = GL3_GetDrawCmdShader(cmd);
+			GL3_UseProgram( shader->shaderProgram );
+		}
 		if(cmd->texnum != gl3state.currenttexture)
 			GL3_Bind(cmd->texnum);
 		if(cmd->lmtexnum >= 0)
@@ -836,7 +842,7 @@ void GL3_Draw3DBatchesNow()
 				lmScales[map].B = r_newrefdef.lightstyles[cmd->styles[map]].rgb[2];
 				lmScales[map].A = 1.0f;
 			}
-			UpdateLMscales(lmScales, cmd->shader);
+			UpdateLMscales(lmScales, shader);
 		}
 
 		if(flags & DCFlag_UseColor)
@@ -903,7 +909,7 @@ void GL3_Draw3DBatchesNow()
 
 static qboolean drawStateEqual(const gl3drawCmd_t* a, const gl3drawCmd_t* b)
 {
-	if( a->flags != b->flags || a->shader != b->shader
+	if( a->flags != b->flags || a->shaderIdx != b->shaderIdx
 	   || a->texnum != b->texnum || a->lmtexnum != b->lmtexnum )
 		return false;
 
@@ -952,7 +958,7 @@ GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode, gl
 
 	GLushort nextVtxIdx = da_count(vtxBuf);
 	drawCmd.idxBufOffset = da_count(idxBuf);
-	assert(drawCmd.shader != NULL);
+	assert(drawCmd.shaderIdx != -1);
 
 	// translate triangle fan/strip to just triangle indices
 	if(drawMode == GL_TRIANGLE_FAN)
@@ -1068,7 +1074,7 @@ GL3_DrawBeam(entity_t *e)
 	//glDisable(GL_TEXTURE_2D);
 	drawCmd.flags |= (DCFlag_Blend | DCFlag_DisableDepthMask | DCFlag_UseColor);
 
-	drawCmd.shader = &gl3state.si3DcolorOnly;
+	GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3DcolorOnly);
 
 	drawCmd.color[0] = (LittleLong(d_8to24table[e->skinnum & 0xFF])) & 0xFF;
 	drawCmd.color[1] = (LittleLong(d_8to24table[e->skinnum & 0xFF]) >> 8) & 0xFF;
@@ -1135,13 +1141,13 @@ GL3_DrawSpriteModel(entity_t *e, gl3model_t *currentmodel)
 	if (alpha == 1.0)
 	{
 		// use shader with alpha test
-		drawCmd.shader = &gl3state.si3DspriteAlpha;
+		GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3DspriteAlpha);
 	}
 	else
 	{
 		drawCmd.flags |= DCFlag_Blend;
 
-		drawCmd.shader = &gl3state.si3Dsprite;
+		GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3Dsprite);
 	}
 
 	verts[0].texCoord[0] = 0;
@@ -1198,8 +1204,7 @@ GL3_DrawNullModel(entity_t *currententity)
 	}
 	drawCmd.flags |= DCFlag_UseColor;
 
-	drawCmd.shader = &gl3state.si3DcolorOnly;
-
+	GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3DcolorOnly);
 
 	gl3_3D_vtx_t vtxA[6] = {
 		{{0, 0, -16}, {0,0}, {0,0}},

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -130,6 +130,8 @@ cvar_t *r_palettedtexture;
 cvar_t *r_validation;
 cvar_t *gl3_usefbo;
 
+cvar_t *gl3_show_draw_stats;
+
 static cvar_t *gl_znear;
 
 // Yaw-Pitch-Roll
@@ -268,6 +270,8 @@ GL3_Register(void)
 	gl_znear = ri.Cvar_Get("gl_znear", "4", CVAR_ARCHIVE);
 
 	gl3_usefbo = ri.Cvar_Get("gl3_usefbo", "1", CVAR_ARCHIVE); // use framebuffer object for postprocess effects (water)
+
+	gl3_show_draw_stats = ri.Cvar_Get("gl3_show_draw_stats", "0", CVAR_ARCHIVE);
 
 #if 0 // TODO!
 	//gl_lefthand = ri.Cvar_Get("hand", "0", CVAR_USERINFO | CVAR_ARCHIVE);
@@ -776,6 +780,8 @@ GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode)
 		gl3state.vbo3DcurOffset = curOffset + neededSize; // TODO: padding or sth needed?
 #endif
 	}
+	++gl3_num3Ddraws;
+	++gl3_numBufferVtxData;
 }
 
 static void
@@ -1063,6 +1069,8 @@ GL3_DrawParticles(void)
 		GL3_BindVBO(gl3state.vboParticle);
 		glBufferData(GL_ARRAY_BUFFER, sizeof(part_vtx)*numParticles, buf, GL_STREAM_DRAW);
 		glDrawArrays(GL_POINTS, 0, numParticles);
+		++gl3_num3Ddraws;
+		++gl3_numBufferVtxData;
 
 		glDisable(GL_BLEND);
 		glDepthMask(GL_TRUE);

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -134,6 +134,15 @@ cvar_t *gl3_show_draw_stats;
 
 static cvar_t *gl_znear;
 
+DA_TYPEDEF(gl3_3D_vtx_t, Vtx3DArray_t);
+DA_TYPEDEF(GLushort, UShortArray_t);
+DA_TYPEDEF(gl3drawCmd_t, DrawCommandArray_t);
+// dynamic arrays to batch all consecutive 3D draws (with gl3_3D_vtx_t) with same texture to reduce drawcalls
+static Vtx3DArray_t vtxBuf = {0};
+static UShortArray_t idxBuf = {0};
+static DrawCommandArray_t drawCmds = {0};
+
+
 // Yaw-Pitch-Roll
 // equivalent to R_z * R_y * R_x where R_x is the trans matrix for rotating around X axis for aroundXdeg
 static hmm_mat4 rotAroundAxisZYX(float aroundZdeg, float aroundYdeg, float aroundXdeg)
@@ -163,7 +172,7 @@ static hmm_mat4 rotAroundAxisZYX(float aroundZdeg, float aroundYdeg, float aroun
 }
 
 void
-GL3_RotateForEntity(entity_t *e)
+GL3_RotateUni3DforEntity(entity_t *e)
 {
 	// angles: pitch (around y), yaw (around z), roll (around x)
 	// rot matrices to be multiplied in order Z, Y, X (yaw, pitch, roll)
@@ -177,6 +186,29 @@ GL3_RotateForEntity(entity_t *e)
 	gl3state.uni3DData.transModelMat4 = HMM_MultiplyMat4(gl3state.uni3DData.transModelMat4, transMat);
 
 	GL3_UpdateUBO3D();
+}
+
+// if replaceTransModelMat is true, the existing value of drawCmd->transModelMat
+// is ignored and it's replaced with the one calculated here (otherwise they're multiplied)
+void
+GL3_RotateForEntity(entity_t *e, gl3drawCmd_t* drawCmd, qboolean replaceTransModelMat)
+{
+	// TODO: shortcut for "not rotated at all"?
+
+	// angles: pitch (around y), yaw (around z), roll (around x)
+	// rot matrices to be multiplied in order Z, Y, X (yaw, pitch, roll)
+	hmm_mat4 transMat = rotAroundAxisZYX(e->angles[1], -e->angles[0], -e->angles[2]);
+
+	for(int i=0; i<3; ++i)
+	{
+		transMat.Elements[3][i] = e->origin[i]; // set translation
+	}
+
+	if (replaceTransModelMat)
+		drawCmd->transModelMat = transMat;
+	else
+		drawCmd->transModelMat = HMM_MultiplyMat4(drawCmd->transModelMat, transMat);
+	drawCmd->flags &= ~DCFlag_IsIdentityMat;
 }
 
 
@@ -599,6 +631,7 @@ GL3_Init(void)
 	}
 
 	gl3config.useBigVBO = false;
+#if 0 // TODO: hopefully we can get rid of all this big vbo nonsense when doing more batching
 	if(gl3_usebigvbo->value == 1.0f)
 	{
 		Com_Printf("Enabling useBigVBO workaround because gl3_usebigvbo = 1\n");
@@ -638,6 +671,7 @@ GL3_Init(void)
 		}
 #endif
 	}
+#endif
 
 	// generate texture handles for all possible lightmaps
 	glGenTextures(MAX_LIGHTMAPS*MAX_LIGHTMAPS_PER_SURFACE, gl3state.lightmap_textureIDs[0]);
@@ -706,16 +740,337 @@ GL3_Shutdown(void)
 		gl3state.ppFBtexWidth = gl3state.ppFBtexHeight = -1;
 	}
 
+	da_free(vtxBuf);
+	da_free(idxBuf);
+	da_free(drawCmds);
+
 	/* shutdown OS specific OpenGL stuff like contexts, etc.  */
 	GL3_ShutdownContext();
+}
+
+static inline qboolean
+colorsEqual(const byte c1[3], const byte c2[3])
+{
+	return c1[0] == c2[0] && c1[1] == c2[1] && c1[2] == c2[2];
+}
+
+static inline qboolean
+lmstylesEqual(const byte st1[MAXLIGHTMAPS], const byte st2[MAXLIGHTMAPS])
+{
+	for(int i=0; i<MAXLIGHTMAPS; ++i)
+	{
+		byte astyle = st1[i];
+		if(astyle != st2[i])
+			return false;
+		// 255 indicates that this and the remaining styles can be ignored
+		// (still needed to check first if a and b agree about ignoring it)
+		if(astyle == 255)
+			break;
+	}
+	return true;
+}
+
+static void
+UpdateLMscales(const hmm_vec4 lmScales[MAX_LIGHTMAPS_PER_SURFACE], gl3ShaderInfo_t* si)
+{
+	int i;
+	qboolean hasChanged = false;
+
+	for(i=0; i<MAX_LIGHTMAPS_PER_SURFACE; ++i)
+	{
+		if(hasChanged)
+		{
+			si->lmScales[i] = lmScales[i];
+		}
+		else if(   si->lmScales[i].R != lmScales[i].R
+		        || si->lmScales[i].G != lmScales[i].G
+		        || si->lmScales[i].B != lmScales[i].B
+		        || si->lmScales[i].A != lmScales[i].A )
+		{
+			si->lmScales[i] = lmScales[i];
+			hasChanged = true;
+		}
+	}
+
+	if(hasChanged)
+	{
+		glUniform4fv(si->uniLmScalesOrTime, MAX_LIGHTMAPS_PER_SURFACE, si->lmScales[0].Elements);
+	}
+}
+
+void GL3_Draw3DBatchesNow()
+{
+	if(da_count(drawCmds) == 0)
+		return;
+
+	GL3_BindVAO(gl3state.vao3D);
+	GL3_BindVBO(gl3state.vbo3D);
+	GL3_BindEBO(gl3state.ebo3D);
+
+	glBufferData(GL_ARRAY_BUFFER, da_count(vtxBuf)*sizeof(gl3_3D_vtx_t), vtxBuf.p, GL_STREAM_DRAW);
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, da_count(idxBuf)*sizeof(GLushort), idxBuf.p, GL_STREAM_DRAW);
+
+	++gl3_numBufferVtxData;
+
+	// set curState to something that reflects the actual state, as far as possible,
+	// and otherwise makes sure it'll be set in the loop
+	gl3drawCmd_t curState = GL3_CreateDrawCmd(true);
+	curState.flags = ~drawCmds.p[0].flags; // just the opposite flags of the first element
+	curState.texnum = gl3state.currenttexture;
+	curState.lmtexnum = gl3state.currentlightmap;
+	curState.alpha = gl3state.uni3DData.alpha;
+	curState.scroll = gl3state.uni3DData.scroll;
+	curState.lightScaleForTurb = gl3state.uni3DData.lightScaleForTurb;
+
+	// .. but at least set the identity mat so DCFlag_IsIdentityMat can be set
+	// as a sane default
+	curState.flags |= DCFlag_IsIdentityMat;
+	gl3state.uni3DData.transModelMat4 = gl3_identityMat4;
+	GL3_UpdateUBO3D();
+
+	for(int i=0, n=da_count(drawCmds); i < n; ++i)
+	{
+		gl3drawCmd_t* cmd = da_getptr(drawCmds, i);
+
+		int flags = cmd->flags;
+		int curFlags = curState.flags;
+		qboolean updateUni3D = false;
+
+		GL3_UseProgram(cmd->shader->shaderProgram);
+		if(cmd->texnum != gl3state.currenttexture)
+			GL3_Bind(cmd->texnum);
+		if(cmd->lmtexnum >= 0)
+			GL3_BindLightmap(cmd->lmtexnum);
+
+		if((flags & DCFlag_DisableDepthMask) != (curFlags & DCFlag_DisableDepthMask))
+			glDepthMask((flags & DCFlag_DisableDepthMask) == 0);
+
+		if((flags & DCFlag_Blend) != (curFlags & DCFlag_Blend))
+		{
+			if(flags & DCFlag_Blend)
+				glEnable(GL_BLEND);
+			else
+				glDisable(GL_BLEND);
+		}
+
+		if((flags & DCFlag_PolyOffsetFill) != (curFlags & DCFlag_PolyOffsetFill))
+		{
+			if(flags & DCFlag_PolyOffsetFill)
+				glEnable(GL_POLYGON_OFFSET_FILL);
+			else
+				glDisable(GL_POLYGON_OFFSET_FILL);
+		}
+
+		if((flags & DCFlag_UseScroll) && cmd->scroll != gl3state.uni3DData.scroll)
+		{
+			gl3state.uni3DData.scroll = cmd->scroll;
+			updateUni3D = true;
+		}
+
+		if((flags & DCFlag_UseLightScaleForTurb)
+		   && cmd->lightScaleForTurb != gl3state.uni3DData.lightScaleForTurb)
+		{
+			gl3state.uni3DData.lightScaleForTurb = cmd->lightScaleForTurb;
+			updateUni3D = true;
+		}
+
+		if((flags & DCFlag_UseLmStyles) && !lmstylesEqual(cmd->styles, curState.styles))
+		{
+			hmm_vec4 lmScales[MAX_LIGHTMAPS_PER_SURFACE] = {0};
+			lmScales[0] = HMM_Vec4(1.0f, 1.0f, 1.0f, 1.0f);
+			for(int map = 0; map < MAX_LIGHTMAPS_PER_SURFACE && cmd->styles[map] != 255; map++)
+			{
+				lmScales[map].R = r_newrefdef.lightstyles[cmd->styles[map]].rgb[0];
+				lmScales[map].G = r_newrefdef.lightstyles[cmd->styles[map]].rgb[1];
+				lmScales[map].B = r_newrefdef.lightstyles[cmd->styles[map]].rgb[2];
+				lmScales[map].A = 1.0f;
+			}
+			UpdateLMscales(lmScales, cmd->shader);
+		}
+
+		if(flags & DCFlag_UseColor)
+		{
+			if(cmd->alpha != curState.alpha || !colorsEqual(cmd->color, curState.color))
+			{
+				gl3state.uniCommonData.color.R = cmd->color[0] * (1.0f/255.0f);
+				gl3state.uniCommonData.color.G = cmd->color[1] * (1.0f/255.0f);
+				gl3state.uniCommonData.color.B = cmd->color[2] * (1.0f/255.0f);
+				gl3state.uniCommonData.color.A = cmd->alpha;
+				GL3_UpdateUBOCommon();
+			}
+		}
+		else if((flags & DCFlag_Blend) && cmd->alpha != gl3state.uni3DData.alpha)
+		{
+			gl3state.uni3DData.alpha = cmd->alpha;
+			updateUni3D = true;
+		}
+
+		if((flags & DCFlag_IsIdentityMat) != (curFlags & DCFlag_IsIdentityMat))
+		{
+			// one is the identity matrix, the other isn't => we need to update
+			gl3state.uni3DData.transModelMat4 = cmd->transModelMat;
+			updateUni3D = true;
+		}
+		else if( !(flags & DCFlag_IsIdentityMat) )
+		{
+			// neither is an identity matrix
+			// TODO: could check if they're identical and only update if not
+			gl3state.uni3DData.transModelMat4 = cmd->transModelMat;
+			updateUni3D = true;
+		}
+		// else both are the identity matrix - nothing to do
+
+		if(updateUni3D)
+			GL3_UpdateUBO3D();
+
+		uintptr_t elemOffset = cmd->idxBufOffset * sizeof(GLushort);
+		glDrawElements(GL_TRIANGLES, cmd->numElements, GL_UNSIGNED_SHORT, (void*)elemOffset);
+		curState = *cmd;
+
+		++gl3_num3Ddraws;
+	}
+
+	da_clear(vtxBuf);
+	da_clear(idxBuf);
+	da_clear(drawCmds);
+
+	// restore sane default for other draw operations (models, particles, 2D)
+	int curFlags = curState.flags;
+	if( !(curFlags & DCFlag_IsIdentityMat) )
+	{
+		gl3state.uni3DData.transModelMat4 = gl3_identityMat4;
+		GL3_UpdateUBO3D();
+	}
+	if(curFlags & DCFlag_Blend)
+		glDisable(GL_BLEND);
+	if(curFlags & DCFlag_DisableDepthMask)
+		glDepthMask(GL_TRUE);
+
+	if(curFlags & DCFlag_PolyOffsetFill)
+		glDisable(GL_POLYGON_OFFSET_FILL);
+}
+
+static qboolean drawStateEqual(const gl3drawCmd_t* a, const gl3drawCmd_t* b)
+{
+	if( a->flags != b->flags || a->shader != b->shader
+	   || a->texnum != b->texnum || a->lmtexnum != b->lmtexnum )
+		return false;
+
+	int flags = a->flags; // at this point we know the flags are identical
+
+	if((flags & DCFlag_UseScroll) && a->scroll != b->scroll)
+		return false;
+
+	if((flags & DCFlag_UseLightScaleForTurb) && a->lightScaleForTurb != b->lightScaleForTurb)
+		return false;
+
+	if( (flags & DCFlag_UseColor) && !colorsEqual(a->color, b->color) )
+		return false;
+
+	if(a->alpha != b->alpha)
+		return false;
+
+	if((flags & DCFlag_UseLmStyles) && !lmstylesEqual(a->styles, b->styles))
+	{
+		return false;
+	}
+
+	if( !(flags & DCFlag_IsIdentityMat) )
+	{
+		const float* atm = a->transModelMat.Elements[0];
+		const float* btm = b->transModelMat.Elements[0];
+		for(int i=0; i<16; ++i)
+		{
+			if(atm[i] != btm[i]) // TODO: tolerance?
+				return false;
+		}
+	}
+
+	return true;
 }
 
 // assumes gl3state.v[ab]o3D are bound
 // buffers and draws gl3_3D_vtx_t vertices
 // drawMode is something like GL_TRIANGLE_STRIP or GL_TRIANGLE_FAN or whatever
 void
-GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode)
+GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode, gl3drawCmd_t drawCmd)
 {
+	if(da_count(vtxBuf)+numVerts > UINT16_MAX) {
+		GL3_Draw3DBatchesNow();
+	}
+
+	GLushort nextVtxIdx = da_count(vtxBuf);
+	drawCmd.idxBufOffset = da_count(idxBuf);
+	assert(drawCmd.shader != NULL);
+
+	// translate triangle fan/strip to just triangle indices
+	if(drawMode == GL_TRIANGLE_FAN)
+	{
+		for(GLushort i=1; i < numVerts-1; ++i)
+		{
+			GLushort* add = da_addn_uninit(idxBuf, 3);
+
+			add[0] = nextVtxIdx;
+			add[1] = nextVtxIdx+i;
+			add[2] = nextVtxIdx+i+1;
+		}
+	}
+	else if(drawMode == GL_TRIANGLE_STRIP)
+	{
+		GLushort i;
+		for(i=1; i < numVerts-2; i+=2)
+		{
+			// add two triangles at once, because the vertex order is different
+			// for odd vs even triangles
+			GLushort* add = da_addn_uninit(idxBuf, 6);
+
+			add[0] = nextVtxIdx + i-1;
+			add[1] = nextVtxIdx + i;
+			add[2] = nextVtxIdx + i+1;
+
+			add[3] = nextVtxIdx + i;
+			add[4] = nextVtxIdx + i+2;
+			add[5] = nextVtxIdx + i+1;
+		}
+		// add remaining triangle, if any
+		if(i < numVerts-1)
+		{
+			GLushort* add = da_addn_uninit(idxBuf, 3);
+
+			add[0] = nextVtxIdx + i-1;
+			add[1] = nextVtxIdx + i;
+			add[2] = nextVtxIdx + i+1;
+		}
+	}
+	else if(drawMode == GL_TRIANGLES)
+	{
+		GLushort* add = da_addn_uninit(idxBuf, numVerts);
+		for(GLushort i=0; i<numVerts; ++i)
+			add[i] = nextVtxIdx + i;
+	}
+	else
+	{
+		Com_Printf("GL3_BufferAndDraw3D(): WARNING: Unsupported drawmode 0x%x\n", drawMode);
+		return;
+	}
+
+	da_addn(vtxBuf, verts, numVerts);
+
+	int numAddedIndices = da_count(idxBuf) - drawCmd.idxBufOffset;
+
+	gl3drawCmd_t* lastDrawCmd = da_lastptr(drawCmds);
+	if(lastDrawCmd != NULL && drawStateEqual(lastDrawCmd, &drawCmd))
+	{
+		lastDrawCmd->numElements += numAddedIndices;
+	}
+	else
+	{
+		drawCmd.numElements = numAddedIndices;
+		da_add(drawCmds, drawCmd);
+	}
+
+
+#if 0 // let's get rid of useBigVBO etc
 	if(!gl3config.useBigVBO)
 	{
 		glBufferData( GL_ARRAY_BUFFER, sizeof(gl3_3D_vtx_t)*numVerts, verts, GL_STREAM_DRAW );
@@ -784,15 +1139,16 @@ GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode)
 	}
 	++gl3_num3Ddraws;
 	++gl3_numBufferVtxData;
+#endif
 }
 
 static void
 GL3_DrawBeam(entity_t *e)
 {
 	int i;
-	float r, g, b;
-
 	enum { NUM_BEAM_SEGS = 6 };
+
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(true);
 
 	vec3_t perpvec;
 	vec3_t direction, normalized_direction;
@@ -831,21 +1187,16 @@ GL3_DrawBeam(entity_t *e)
 	}
 
 	//glDisable(GL_TEXTURE_2D);
-	glEnable(GL_BLEND);
-	glDepthMask(GL_FALSE);
+	drawCmd.flags |= (DCFlag_Blend | DCFlag_DisableDepthMask | DCFlag_UseColor);
 
-	GL3_UseProgram(gl3state.si3DcolorOnly.shaderProgram);
+	drawCmd.shader = &gl3state.si3DcolorOnly;
 
-	r = (LittleLong(d_8to24table[e->skinnum & 0xFF])) & 0xFF;
-	g = (LittleLong(d_8to24table[e->skinnum & 0xFF]) >> 8) & 0xFF;
-	b = (LittleLong(d_8to24table[e->skinnum & 0xFF]) >> 16) & 0xFF;
+	drawCmd.color[0] = (LittleLong(d_8to24table[e->skinnum & 0xFF])) & 0xFF;
+	drawCmd.color[1] = (LittleLong(d_8to24table[e->skinnum & 0xFF]) >> 8) & 0xFF;
+	drawCmd.color[2] = (LittleLong(d_8to24table[e->skinnum & 0xFF]) >> 16) & 0xFF;
+	drawCmd.alpha = e->alpha;
 
-	r *= 1 / 255.0F;
-	g *= 1 / 255.0F;
-	b *= 1 / 255.0F;
 
-	gl3state.uniCommonData.color = HMM_Vec4(r, g, b, e->alpha);
-	GL3_UpdateUBOCommon();
 
 	for ( i = 0; i < NUM_BEAM_SEGS; i++ )
 	{
@@ -858,13 +1209,9 @@ GL3_DrawBeam(entity_t *e)
 		VectorCopy(end_points[pointb], verts[4*i+3].pos);
 	}
 
-	GL3_BindVAO(gl3state.vao3D);
-	GL3_BindVBO(gl3state.vbo3D);
 
-	GL3_BufferAndDraw3D(verts, NUM_BEAM_SEGS*4, GL_TRIANGLE_STRIP);
+	GL3_BufferAndDraw3D(verts, NUM_BEAM_SEGS*4, GL_TRIANGLE_STRIP, drawCmd);
 
-	glDisable(GL_BLEND);
-	glDepthMask(GL_TRUE);
 }
 
 static void
@@ -876,6 +1223,8 @@ GL3_DrawSpriteModel(entity_t *e, gl3model_t *currentmodel)
 	float *up, *right;
 	dsprite_t *psprite;
 	gl3image_t *skin;
+
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(true);
 
 	/* don't even bother culling, because it's just
 	   a single polygon without a surface cache */
@@ -890,14 +1239,11 @@ GL3_DrawSpriteModel(entity_t *e, gl3model_t *currentmodel)
 
 	if (e->flags & RF_TRANSLUCENT)
 	{
+		drawCmd.flags |= DCFlag_DisableDepthMask;
 		alpha = e->alpha;
 	}
 
-	if (alpha != gl3state.uni3DData.alpha)
-	{
-		gl3state.uni3DData.alpha = alpha;
-		GL3_UpdateUBO3D();
-	}
+	drawCmd.alpha = alpha;
 
 	skin = currentmodel->skins[e->frame];
 	if (!skin)
@@ -905,18 +1251,18 @@ GL3_DrawSpriteModel(entity_t *e, gl3model_t *currentmodel)
 		skin = gl3_notexture; /* fallback... */
 	}
 
-	GL3_Bind(skin->texnum);
+	drawCmd.texnum = skin->texnum;
 
 	if (alpha == 1.0)
 	{
 		// use shader with alpha test
-		GL3_UseProgram(gl3state.si3DspriteAlpha.shaderProgram);
+		drawCmd.shader = &gl3state.si3DspriteAlpha;
 	}
 	else
 	{
-		glEnable(GL_BLEND);
+		drawCmd.flags |= DCFlag_Blend;
 
-		GL3_UseProgram(gl3state.si3Dsprite.shaderProgram);
+		drawCmd.shader = &gl3state.si3Dsprite;
 	}
 
 	verts[0].texCoord[0] = 0;
@@ -940,23 +1286,19 @@ GL3_DrawSpriteModel(entity_t *e, gl3model_t *currentmodel)
 	VectorMA( e->origin, -frame->origin_y, up, verts[3].pos );
 	VectorMA( verts[3].pos, frame->width - frame->origin_x, right, verts[3].pos );
 
-	GL3_BindVAO(gl3state.vao3D);
-	GL3_BindVBO(gl3state.vbo3D);
 
-	GL3_BufferAndDraw3D(verts, 4, GL_TRIANGLE_FAN);
+	GL3_BufferAndDraw3D(verts, 4, GL_TRIANGLE_FAN, drawCmd);
 
-	if (alpha != 1.0F)
-	{
-		glDisable(GL_BLEND);
-		gl3state.uni3DData.alpha = 1.0f;
-		GL3_UpdateUBO3D();
-	}
 }
 
 static void
 GL3_DrawNullModel(entity_t *currententity)
 {
 	vec3_t shadelight;
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(true);
+
+	if(currententity->flags & RF_TRANSLUCENT)
+		drawCmd.flags |= DCFlag_DisableDepthMask;
 
 	if (currententity->flags & RF_FULLBRIGHT)
 	{
@@ -967,16 +1309,18 @@ GL3_DrawNullModel(entity_t *currententity)
 		GL3_LightPoint(currententity, currententity->origin, shadelight);
 	}
 
-	hmm_mat4 origModelMat = gl3state.uni3DData.transModelMat4;
-	GL3_RotateForEntity(currententity);
+	GL3_RotateForEntity(currententity, &drawCmd, true);
 
-	gl3state.uniCommonData.color = HMM_Vec4( shadelight[0], shadelight[1], shadelight[2], 1 );
-	GL3_UpdateUBOCommon();
+	drawCmd.alpha = 1.0f;
+	for(int i=0; i<3; ++i)
+	{
+		int c = shadelight[i] * 255.0f;
+		drawCmd.color[i] = c & 255;
+	}
+	drawCmd.flags |= DCFlag_UseColor;
 
-	GL3_UseProgram(gl3state.si3DcolorOnly.shaderProgram);
+	drawCmd.shader = &gl3state.si3DcolorOnly;
 
-	GL3_BindVAO(gl3state.vao3D);
-	GL3_BindVBO(gl3state.vbo3D);
 
 	gl3_3D_vtx_t vtxA[6] = {
 		{{0, 0, -16}, {0,0}, {0,0}},
@@ -987,17 +1331,15 @@ GL3_DrawNullModel(entity_t *currententity)
 		{{16 * cos( 4 * M_PI / 2 ), 16 * sin( 4 * M_PI / 2 ), 0}, {0,0}, {0,0}}
 	};
 
-	GL3_BufferAndDraw3D(vtxA, 6, GL_TRIANGLE_FAN);
+	GL3_BufferAndDraw3D(vtxA, 6, GL_TRIANGLE_FAN, drawCmd);
 
 	gl3_3D_vtx_t vtxB[6] = {
 		{{0, 0, 16}, {0,0}, {0,0}},
 		vtxA[5], vtxA[4], vtxA[3], vtxA[2], vtxA[1]
 	};
 
-	GL3_BufferAndDraw3D(vtxB, 6, GL_TRIANGLE_FAN);
+	GL3_BufferAndDraw3D(vtxB, 6, GL_TRIANGLE_FAN, drawCmd);
 
-	gl3state.uni3DData.transModelMat4 = origModelMat;
-	GL3_UpdateUBO3D();
 }
 
 static void
@@ -1144,6 +1486,10 @@ GL3_DrawEntitiesOnList(void)
 	/* draw transparent entities
 	   we could sort these if it ever
 	   becomes a problem... */
+
+	// make sure that drawing the solid entities is done first
+	GL3_Draw3DBatchesNow();
+
 	glDepthMask(GL_FALSE);
 
 	for (i = 0; i < r_newrefdef.num_entities; i++)
@@ -1186,6 +1532,11 @@ GL3_DrawEntitiesOnList(void)
 			}
 		}
 	}
+
+	// make sure that drawing the entities is done before drawing the shadows
+	GL3_Draw3DBatchesNow();
+
+	glDepthMask(GL_FALSE);
 
 	GL3_DrawAliasShadows();
 
@@ -1527,7 +1878,7 @@ SetupGL(void)
 extern int c_visible_lightmaps, c_visible_textures;
 
 /*
- * r_newrefdef must be set before the first call
+ * r_newrefdef must be set before the first call - FIXME: ?! it is set right here
  */
 static void
 GL3_RenderView(refdef_t *fd)
@@ -1686,6 +2037,9 @@ GL3_RenderView(refdef_t *fd)
 	GL3_DrawParticles();
 
 	GL3_DrawAlphaSurfaces();
+
+	// make sure all remaining batched 3D stuff is drawn
+	GL3_Draw3DBatchesNow();
 
 	// Note: R_Flash() is now GL3_Draw_Flash() and called from GL3_RenderFrame()
 

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -112,6 +112,7 @@ cvar_t *r_lerp_list;
 cvar_t *r_2D_unfiltered;
 cvar_t *r_videos_unfiltered;
 cvar_t *gl_nobind;
+cvar_t *gl_showtris;
 cvar_t *r_lockpvs;
 cvar_t *r_novis;
 cvar_t *r_speeds;
@@ -267,6 +268,7 @@ GL3_Register(void)
 	/* don't bilerp videos */
 	r_videos_unfiltered = ri.Cvar_Get("r_videos_unfiltered", "0", CVAR_ARCHIVE);
 	gl_nobind = ri.Cvar_Get("gl_nobind", "0", 0);
+	gl_showtris = ri.Cvar_Get("gl_showtris", "0", 0);
 
 	gl_texturemode = ri.Cvar_Get("gl_texturemode", "GL_LINEAR_MIPMAP_NEAREST", CVAR_ARCHIVE);
 	gl_anisotropic = ri.Cvar_Get("r_anisotropic", "0", CVAR_ARCHIVE);
@@ -322,7 +324,7 @@ GL3_Register(void)
 	//gl_lightmap = ri.Cvar_Get("r_lightmap", "0", 0);
 	//gl_shadows = ri.Cvar_Get("r_shadows", "0", CVAR_ARCHIVE);
 	//gl_nobind = ri.Cvar_Get("gl_nobind", "0", 0);
-	gl_showtris = ri.Cvar_Get("gl_showtris", "0", 0);
+
 	gl_showbbox = Cvar_Get("gl_showbbox", "0", 0);
 	//gl1_ztrick = ri.Cvar_Get("gl1_ztrick", "0", 0); NOTE: dump this.
 	//gl_zfix = ri.Cvar_Get("gl_zfix", "0", 0);

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -124,7 +124,6 @@ cvar_t *r_modulate;
 cvar_t *gl_lightmap;
 cvar_t *gl_shadows;
 cvar_t *gl3_debugcontext;
-cvar_t *gl3_usebigvbo;
 cvar_t *r_fixsurfsky;
 cvar_t *r_palettedtexture;
 cvar_t *r_validation;
@@ -253,11 +252,6 @@ GL3_Register(void)
 	// if set to 0, lights (from lightmaps, dynamic lights and on models) are white instead of colored
 	gl3_colorlight = ri.Cvar_Get("gl3_colorlight", "1", CVAR_ARCHIVE);
 	gl_polyblend = ri.Cvar_Get("gl_polyblend", "1", CVAR_ARCHIVE);
-
-	//  0: use lots of calls to glBufferData()
-	//  1: reduce calls to glBufferData() with one big VBO (see GL3_BufferAndDraw3D())
-	// -1: auto (let yq2 choose to enable/disable this based on detected driver)
-	gl3_usebigvbo = ri.Cvar_Get("gl3_usebigvbo", "-1", CVAR_ARCHIVE);
 
 	r_norefresh = ri.Cvar_Get("r_norefresh", "0", 0);
 	r_drawentities = ri.Cvar_Get("r_drawentities", "1", 0);
@@ -629,49 +623,6 @@ GL3_Init(void)
 	{
 		Com_Printf(" - OpenGL Debug Output: Not Supported\n");
 	}
-
-	gl3config.useBigVBO = false;
-#if 0 // TODO: hopefully we can get rid of all this big vbo nonsense when doing more batching
-	if(gl3_usebigvbo->value == 1.0f)
-	{
-		Com_Printf("Enabling useBigVBO workaround because gl3_usebigvbo = 1\n");
-		gl3config.useBigVBO = true;
-	}
-	else if(gl3_usebigvbo->value == -1.0f)
-	{
-		// enable for AMDs proprietary Windows and Linux drivers
-#ifdef _WIN32
-		if(gl3config.version_string != NULL && gl3config.vendor_string != NULL
-		   && strstr(gl3config.vendor_string, "ATI Technologies Inc") != NULL)
-		{
-			int a, b, ver;
-			if(sscanf(gl3config.version_string, " %d.%d.%d ", &a, &b, &ver) >= 3 && ver >= 13431)
-			{
-				// turns out the legacy driver is a lot faster *without* the workaround :-/
-				// GL_VERSION for legacy 16.2.1 Beta driver: 3.2.13399 Core Profile Forward-Compatible Context 15.200.1062.1004
-				//            (this is the last version that supports the Radeon HD 6950)
-				// GL_VERSION for (non-legacy) 16.3.1 driver on Radeon R9 200: 4.5.13431 Compatibility Profile Context 16.150.2111.0
-				// GL_VERSION for non-legacy 17.7.2 WHQL driver: 4.5.13491 Compatibility Profile/Debug Context 22.19.662.4
-				// GL_VERSION for 18.10.1 driver: 4.6.13541 Compatibility Profile/Debug Context 25.20.14003.1010
-				// GL_VERSION for (current) 19.3.2 driver: 4.6.13547 Compatibility Profile/Debug Context 25.20.15027.5007
-				// (the 3.2/4.5/4.6 can probably be ignored, might depend on the card and what kind of context was requested
-				//  but AFAIK the number behind that can be used to roughly match the driver version)
-				// => let's try matching for x.y.z with z >= 13431
-				// (no, I don't feel like testing which release since 16.2.1 has introduced the slowdown.)
-				Com_Printf("Detected AMD Windows GPU driver, enabling useBigVBO workaround\n");
-				gl3config.useBigVBO = true;
-			}
-		}
-#elif defined(__linux__)
-		if(gl3config.vendor_string != NULL && strstr(gl3config.vendor_string, "Advanced Micro Devices, Inc.") != NULL)
-		{
-			Com_Printf("Detected proprietary AMD GPU driver, enabling useBigVBO workaround\n");
-			Com_Printf("(consider using the open source RadeonSI drivers, they tend to work better overall)\n");
-			gl3config.useBigVBO = true;
-		}
-#endif
-	}
-#endif
 
 	// generate texture handles for all possible lightmaps
 	glGenTextures(MAX_LIGHTMAPS*MAX_LIGHTMAPS_PER_SURFACE, gl3state.lightmap_textureIDs[0]);
@@ -1068,78 +1019,6 @@ GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode, gl
 		drawCmd.numElements = numAddedIndices;
 		da_add(drawCmds, drawCmd);
 	}
-
-
-#if 0 // let's get rid of useBigVBO etc
-	if(!gl3config.useBigVBO)
-	{
-		glBufferData( GL_ARRAY_BUFFER, sizeof(gl3_3D_vtx_t)*numVerts, verts, GL_STREAM_DRAW );
-		glDrawArrays( drawMode, 0, numVerts );
-	}
-	else // gl3config.useBigVBO == true
-	{
-		/*
-		 * For some reason, AMD's Windows driver doesn't seem to like lots of
-		 * calls to glBufferData() (some of them seem to take very long then).
-		 * GL3_BufferAndDraw3D() is called a lot when drawing world geometry
-		 * (once for each visible face I think?).
-		 * The simple code above caused noticeable slowdowns - even a fast
-		 * quadcore CPU and a Radeon RX580 weren't able to maintain 60fps..
-		 * The workaround is to not call glBufferData() with small data all the time,
-		 * but to allocate a big buffer and on each call to GL3_BufferAndDraw3D()
-		 * to use a different region of that buffer, resulting in a lot less calls
-		 * to glBufferData() (=> a lot less buffer allocations in the driver).
-		 * Only when the buffer is full and at the end of a frame (=> GL3_EndFrame())
-		 * we get a fresh buffer.
-		 *
-		 * BTW, we couldn't observe this kind of problem with any other driver:
-		 * Neither nvidias driver, nor AMDs or Intels Open Source Linux drivers,
-		 * not even Intels Windows driver seem to care that much about the
-		 * glBufferData() calls.. However, at least nvidias driver doesn't like
-		 * this workaround (with glMapBufferRange()), the framerate dropped
-		 * significantly - that's why both methods are available and
-		 * selectable at runtime.
-		 */
-#if 0
-		// I /think/ doing it with glBufferSubData() didn't really help
-		const int bufSize = gl3state.vbo3Dsize;
-		int neededSize = numVerts*sizeof(gl3_3D_vtx_t);
-		int curOffset = gl3state.vbo3DcurOffset;
-		if(curOffset + neededSize > gl3state.vbo3Dsize)
-			curOffset = 0;
-		int curIdx = curOffset / sizeof(gl3_3D_vtx_t);
-
-		gl3state.vbo3DcurOffset = curOffset + neededSize;
-
-		glBufferSubData( GL_ARRAY_BUFFER, curOffset, neededSize, verts );
-		glDrawArrays( drawMode, curIdx, numVerts );
-#else
-		int curOffset = gl3state.vbo3DcurOffset;
-		int neededSize = numVerts*sizeof(gl3_3D_vtx_t);
-		if(curOffset+neededSize > gl3state.vbo3Dsize)
-		{
-			// buffer is full, need to start again from the beginning
-			// => need to sync or get fresh buffer
-			// (getting fresh buffer seems easier)
-			glBufferData(GL_ARRAY_BUFFER, gl3state.vbo3Dsize, NULL, GL_STREAM_DRAW);
-			curOffset = 0;
-		}
-
-		// as we make sure to use a previously unused part of the buffer,
-		// doing it unsynchronized should be safe..
-		GLbitfield accessBits = GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_RANGE_BIT | GL_MAP_UNSYNCHRONIZED_BIT;
-		void* data = glMapBufferRange(GL_ARRAY_BUFFER, curOffset, neededSize, accessBits);
-		memcpy(data, verts, neededSize);
-		glUnmapBuffer(GL_ARRAY_BUFFER);
-
-		glDrawArrays(drawMode, curOffset/sizeof(gl3_3D_vtx_t), numVerts);
-
-		gl3state.vbo3DcurOffset = curOffset + neededSize; // TODO: padding or sth needed?
-#endif
-	}
-	++gl3_num3Ddraws;
-	++gl3_numBufferVtxData;
-#endif
 }
 
 static void

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -942,9 +942,16 @@ GL3_SetDrawCmdTransMatrix(gl3drawCmd_t* drawCmd, hmm_mat4 mat)
 // buffers and draws gl3_3D_vtx_t vertices
 // drawMode is something like GL_TRIANGLE_STRIP or GL_TRIANGLE_FAN or whatever
 void
-GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode, gl3drawCmd_t drawCmd)
+GL3_Add3DdrawCmdToBatch(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode, gl3drawCmd_t drawCmd)
 {
-	if(da_count(vtxBuf)+numVerts > UINT16_MAX) {
+	if(numVerts > UINT16_MAX)
+	{
+		Com_Printf("WARNING: Discarding a draw command with %d vertices (max %d allowed)!\n", numVerts, UINT16_MAX);
+		return;
+	}
+
+	if(da_count(vtxBuf)+numVerts > UINT16_MAX)
+	{
 		GL3_Draw3DBatchesNow();
 	}
 
@@ -1087,7 +1094,7 @@ GL3_DrawBeam(entity_t *e)
 	}
 
 
-	GL3_BufferAndDraw3D(verts, NUM_BEAM_SEGS*4, GL_TRIANGLE_STRIP, drawCmd);
+	GL3_Add3DdrawCmdToBatch(verts, NUM_BEAM_SEGS*4, GL_TRIANGLE_STRIP, drawCmd);
 
 }
 
@@ -1164,7 +1171,7 @@ GL3_DrawSpriteModel(entity_t *e, gl3model_t *currentmodel)
 	VectorMA( verts[3].pos, frame->width - frame->origin_x, right, verts[3].pos );
 
 
-	GL3_BufferAndDraw3D(verts, 4, GL_TRIANGLE_FAN, drawCmd);
+	GL3_Add3DdrawCmdToBatch(verts, 4, GL_TRIANGLE_FAN, drawCmd);
 
 }
 
@@ -1207,14 +1214,14 @@ GL3_DrawNullModel(entity_t *currententity)
 		{{16 * cos( 4 * M_PI / 2 ), 16 * sin( 4 * M_PI / 2 ), 0}, {0,0}, {0,0}}
 	};
 
-	GL3_BufferAndDraw3D(vtxA, 6, GL_TRIANGLE_FAN, drawCmd);
+	GL3_Add3DdrawCmdToBatch(vtxA, 6, GL_TRIANGLE_FAN, drawCmd);
 
 	gl3_3D_vtx_t vtxB[6] = {
 		{{0, 0, 16}, {0,0}, {0,0}},
 		vtxA[5], vtxA[4], vtxA[3], vtxA[2], vtxA[1]
 	};
 
-	GL3_BufferAndDraw3D(vtxB, 6, GL_TRIANGLE_FAN, drawCmd);
+	GL3_Add3DdrawCmdToBatch(vtxB, 6, GL_TRIANGLE_FAN, drawCmd);
 
 }
 

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -130,6 +130,10 @@ cvar_t *r_palettedtexture;
 cvar_t *r_validation;
 cvar_t *gl3_usefbo;
 
+#ifdef YQ2_GL3_GLES
+cvar_t *gl_discardfb;
+#endif
+
 cvar_t *gl3_show_draw_stats;
 
 static cvar_t *gl_znear;
@@ -293,6 +297,10 @@ GL3_Register(void)
 	r_speeds = ri.Cvar_Get("r_speeds", "0", 0);
 	gl_finish = ri.Cvar_Get("gl_finish", "0", CVAR_ARCHIVE);
 	gl_znear = ri.Cvar_Get("gl_znear", "4", CVAR_ARCHIVE);
+
+#ifdef YQ2_GL3_GLES
+	gl_discardfb = ri.Cvar_Get("gl_discardfb", "1", CVAR_ARCHIVE);
+#endif
 
 	gl3_usefbo = ri.Cvar_Get("gl3_usefbo", "1", CVAR_ARCHIVE); // use framebuffer object for postprocess effects (water)
 
@@ -528,6 +536,17 @@ GL3_SetMode(void)
 // only needed (and allowed!) if using OpenGL compatibility profile, it's not in 3.2 core
 enum { QGL_POINT_SPRITE = 0x8861 };
 
+static void
+GL3_ResetClearColor(void)
+{
+#ifdef YQ2_GL3_GLES
+	if (gl_discardfb->value && !r_clear->value)
+		glClearColor(0, 0, 0, 0.5);
+	else
+#endif
+		glClearColor(1, 0, 0.5, 0.5);
+}
+
 static qboolean
 GL3_Init(void)
 {
@@ -629,6 +648,7 @@ GL3_Init(void)
 	// generate texture handles for all possible lightmaps
 	glGenTextures(MAX_LIGHTMAPS*MAX_LIGHTMAPS_PER_SURFACE, gl3state.lightmap_textureIDs[0]);
 
+	GL3_ResetClearColor();
 	GL3_SetDefaultState();
 
 	if(GL3_InitShaders())
@@ -1504,7 +1524,7 @@ SetupFrame(void)
 				vid.height - r_newrefdef.height - r_newrefdef.y,
 				r_newrefdef.width, r_newrefdef.height);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-		glClearColor(1, 0, 0.5, 0.5);
+		GL3_ResetClearColor();
 		glDisable(GL_SCISSOR_TEST);
 	}
 }
@@ -2045,29 +2065,40 @@ GL3_RenderFrame(refdef_t *fd)
 static void
 GL3_Clear(void)
 {
-	// Check whether the stencil buffer needs clearing, and do so if need be.
-	GLbitfield stencilFlags = 0;
-#if 0 // TODO: stereo stuff
-	if (gl3state.stereo_mode >= STEREO_MODE_ROW_INTERLEAVED && gl_state.stereo_mode <= STEREO_MODE_PIXEL_INTERLEAVED) {
-		glClearStencil(0);
-		stencilFlags |= GL_STENCIL_BUFFER_BIT;
-	}
-#endif // 0
-
+	// Define which buffers need clearing
+	GLbitfield clearFlags = GL_DEPTH_BUFFER_BIT;
 
 	if (r_clear->value)
 	{
-		glClear(GL_COLOR_BUFFER_BIT | stencilFlags | GL_DEPTH_BUFFER_BIT);
+		clearFlags |= GL_COLOR_BUFFER_BIT;
 	}
-	else
+
+	// Stencilbuffer shadows
+	if (gl_shadows->value && gl3config.stencil)
 	{
-		glClear(GL_DEPTH_BUFFER_BIT | stencilFlags);
+		glClearStencil(1);
+		clearFlags |= GL_STENCIL_BUFFER_BIT;
 	}
+
+#if 0 // TODO: stereo stuff
+	if (gl3state.stereo_mode >= STEREO_MODE_ROW_INTERLEAVED && gl_state.stereo_mode <= STEREO_MODE_PIXEL_INTERLEAVED) {
+		glClearStencil(0);
+		clearFlags |= GL_STENCIL_BUFFER_BIT;
+	}
+#endif // 0
+
+#ifdef YQ2_GL3_GLES
+	if (gl_discardfb->value)
+	{
+		clearFlags |= GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
+	}
+#endif
+
+	glClear(clearFlags);
 
 	gl3depthmin = 0;
 	gl3depthmax = 1;
 	glDepthFunc(GL_LEQUAL);
-
 	glDepthRange(gl3depthmin, gl3depthmax);
 
 	if (gl_zfix->value)
@@ -2080,13 +2111,6 @@ GL3_Clear(void)
 		{
 			glPolygonOffset(-0.05, -1);
 		}
-	}
-
-	/* stencilbuffer shadows */
-	if (gl_shadows->value && gl3config.stencil)
-	{
-		glClearStencil(1);
-		glClear(GL_STENCIL_BUFFER_BIT);
 	}
 }
 
@@ -2231,7 +2255,7 @@ GL3_SetPalette(const unsigned char *palette)
 
 	glClearColor(0, 0, 0, 0);
 	glClear(GL_COLOR_BUFFER_BIT);
-	glClearColor(1, 0, 0.5, 0.5);
+	GL3_ResetClearColor();
 }
 
 /*

--- a/src/client/refresh/gl3/gl3_mesh.c
+++ b/src/client/refresh/gl3/gl3_mesh.c
@@ -849,7 +849,7 @@ GL3_DrawAliasModel(entity_t *entity)
 	origModelMat = gl3state.uni3DData.transModelMat4;
 
 	entity->angles[PITCH] = -entity->angles[PITCH];
-	GL3_RotateForEntity(entity);
+	GL3_RotateUni3DforEntity(entity);
 	entity->angles[PITCH] = -entity->angles[PITCH];
 
 
@@ -908,17 +908,16 @@ GL3_DrawAliasModel(entity_t *entity)
 
 	DrawAliasFrameLerp(paliashdr, entity, shadelight);
 
-	//glPopMatrix();
-	gl3state.uni3DData.transModelMat4 = origModelMat;
-	GL3_UpdateUBO3D();
-
 	if (entity->flags & RF_WEAPONMODEL)
 	{
 		gl3state.uni3DData.transProjViewMat4 = origProjViewMat;
-		GL3_UpdateUBO3D();
 		if(gl_lefthand->value == 1.0F)
 			glCullFace(GL_FRONT);
 	}
+
+	//glPopMatrix();
+	gl3state.uni3DData.transModelMat4 = origModelMat;
+	GL3_UpdateUBO3D();
 
 	if (entity->flags & RF_TRANSLUCENT)
 	{

--- a/src/client/refresh/gl3/gl3_mesh.c
+++ b/src/client/refresh/gl3/gl3_mesh.c
@@ -323,6 +323,9 @@ DrawAliasFrameLerp(dmdl_t *paliashdr, entity_t* entity, vec3_t shadelight)
 	GL3_BindEBO(gl3state.eboAlias);
 	glBufferData(GL_ELEMENT_ARRAY_BUFFER, da_count(idxBuf)*sizeof(GLushort), idxBuf.p, GL_STREAM_DRAW);
 	glDrawElements(GL_TRIANGLES, da_count(idxBuf), GL_UNSIGNED_SHORT, NULL);
+	++gl3_num3Ddraws;
+	++gl3_numBufferVtxData;
+	// TODO ++gl3_numBufferIdxData ?
 }
 
 static void
@@ -484,6 +487,9 @@ DrawAliasShadow(gl3_shadowinfo_t* shadowInfo)
 	GL3_BindEBO(gl3state.eboAlias);
 	glBufferData(GL_ELEMENT_ARRAY_BUFFER, da_count(idxBuf)*sizeof(GLushort), idxBuf.p, GL_STREAM_DRAW);
 	glDrawElements(GL_TRIANGLES, da_count(idxBuf), GL_UNSIGNED_SHORT, NULL);
+	++gl3_num3Ddraws;
+	++gl3_numBufferVtxData;
+	// TODO ++gl3_numBufferIdxData ?
 }
 
 static qboolean

--- a/src/client/refresh/gl3/gl3_misc.c
+++ b/src/client/refresh/gl3/gl3_misc.c
@@ -33,7 +33,6 @@ gl3image_t *gl3_particletexture; /* little dot for particles */
 void
 GL3_SetDefaultState(void)
 {
-	glClearColor(1, 0, 0.5, 0.5);
 #ifndef YQ2_GL3_GLES
 	// in GLES this is only supported with an extension:
 	// https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_multisample_compatibility.txt

--- a/src/client/refresh/gl3/gl3_sdl.c
+++ b/src/client/refresh/gl3/gl3_sdl.c
@@ -112,20 +112,8 @@ DebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei le
 
 // ---------
 
-/*
- * Swaps the buffers and shows the next frame.
- */
-void GL3_EndFrame(void)
+void GL3_SwapWindow(void)
 {
-	if(gl3config.useBigVBO)
-	{
-		// I think this is a good point to orphan the VBO and get a fresh one
-		GL3_BindVAO(gl3state.vao3D);
-		GL3_BindVBO(gl3state.vbo3D);
-		glBufferData(GL_ARRAY_BUFFER, gl3state.vbo3Dsize, NULL, GL_STREAM_DRAW);
-		gl3state.vbo3DcurOffset = 0;
-	}
-
 	SDL_GL_SwapWindow(window);
 }
 

--- a/src/client/refresh/gl3/gl3_shaders.c
+++ b/src/client/refresh/gl3/gl3_shaders.c
@@ -1378,6 +1378,8 @@ updateUBO(GLuint ubo, GLsizeiptr size, void* data)
 		glBindBuffer(GL_UNIFORM_BUFFER, ubo);
 	}
 
+	++gl3_numBufferUniforms;
+
 	// http://docs.gl/gl3/glBufferSubData says  "When replacing the entire data store,
 	// consider using glBufferSubData rather than completely recreating the data store
 	// with glBufferData. This avoids the cost of reallocating the data store."

--- a/src/client/refresh/gl3/gl3_shaders.c
+++ b/src/client/refresh/gl3/gl3_shaders.c
@@ -793,7 +793,8 @@ static const char* fragmentSrc3DspriteAlpha = MULTILINE_STRING(
 			// apply gamma correction and intensity
 			texel.rgb *= intensity;
 			outColor.rgb = pow(texel.rgb, vec3(gamma));
-			outColor.a = texel.a*alpha; // I think alpha shouldn't be modified by gamma and intensity
+			//outColor.a = texel.a*alpha; // I think alpha shouldn't be modified by gamma and intensity
+			outColor.a = texel.a; // I think in this case alpha from uni3d shouldn't be used
 		}
 );
 

--- a/src/client/refresh/gl3/gl3_shaders.c
+++ b/src/client/refresh/gl3/gl3_shaders.c
@@ -37,7 +37,7 @@ CompileShader(GLenum shaderType, const char* shaderSrc, const char* shaderSrc2)
 	GLuint shader = glCreateShader(shaderType);
 
 #ifdef YQ2_GL3_GLES3
-	const char* version = "#version 300 es\nprecision mediump float;\n";
+	const char* version = "#version 300 es\nprecision highp float;\n";
 #else // Desktop GL
 	const char* version = "#version 150\n";
 #endif

--- a/src/client/refresh/gl3/gl3_surf.c
+++ b/src/client/refresh/gl3/gl3_surf.c
@@ -187,62 +187,82 @@ GL3_DrawGLFlowingPoly(msurface_t *fa, gl3drawCmd_t drawCmd)
 	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN, drawCmd);
 }
 
+#define LINE_VTX_COUNT (256 * 6)
+
 static void
 DrawTriangleOutlines(void)
 {
-	STUB_ONCE("TODO: Implement for gl_showtris support!");
-#if 0
-	int i, j;
-	glpoly_t *p;
+	static gl3_3D_vtx_t vtx[LINE_VTX_COUNT];
+	const msurface_t *surf;
+	size_t i, curr_vtx;
 
 	if (!gl_showtris->value)
 	{
 		return;
 	}
 
-	glDisable(GL_TEXTURE_2D);
+	GL3_Draw3DBatchesNow();
+
 	glDisable(GL_DEPTH_TEST);
-	glColor4f(1, 1, 1, 1);
+	glUseProgram(gl3state.si3DcolorOnly.shaderProgram);
 
-	for (i = 0; i < MAX_LIGHTMAPS; i++)
+	gl3state.uniCommonData.color = HMM_Vec4(1.0f, 1.0f, 1.0f, 1.0f);
+	GL3_UpdateUBOCommon();
+	GL3_BindVAO(gl3state.vao3D);
+	GL3_BindVBO(gl3state.vbo3D);
+
+	curr_vtx = 0;
+
+	memset(vtx, 0, sizeof(vtx));
+	for (i = 0, surf = gl3_worldmodel->surfaces; i < gl3_worldmodel->numsurfaces; i++, surf++)
 	{
-		msurface_t *surf;
+		const glpoly_t *p;
 
-		for (surf = gl3_lms.lightmap_surfaces[i];
-				surf != 0;
-				surf = surf->lightmapchain)
+		if (surf->visframe != gl3_framecount)
 		{
-			p = surf->polys;
+			continue;
+		}
 
-			for ( ; p; p = p->chain)
+		for (p = surf->polys; p != NULL; p = p->chain)
+		{
+			size_t j;
+
+			for (j = 2; j < p->numverts; j++)
 			{
-				for (j = 2; j < p->numverts; j++)
+				size_t k;
+
+				if (curr_vtx > (LINE_VTX_COUNT - 6))
 				{
-					GLfloat vtx[12];
-					unsigned int k;
-
-					for (k=0; k<3; k++)
-					{
-						vtx[0+k] = p->vertices [ 0 ][ k ];
-						vtx[3+k] = p->vertices [ j - 1 ][ k ];
-						vtx[6+k] = p->vertices [ j ][ k ];
-						vtx[9+k] = p->vertices [ 0 ][ k ];
-					}
-
-					glEnableClientState( GL_VERTEX_ARRAY );
-
-					glVertexPointer( 3, GL_FLOAT, 0, vtx );
-					glDrawArrays( GL_LINE_STRIP, 0, 4 );
-
-					glDisableClientState( GL_VERTEX_ARRAY );
+					glBufferData(GL_ARRAY_BUFFER, sizeof(vtx), vtx, GL_STREAM_DRAW);
+					glDrawArrays(GL_LINES, 0, curr_vtx);
+					curr_vtx = 0;
+					memset(vtx, 0, sizeof(vtx));
 				}
+
+				for (k = 0; k < 3; k++)
+				{
+					vtx[curr_vtx + 0].pos[k] = p->vertices[0].pos[k];
+					vtx[curr_vtx + 1].pos[k] = p->vertices[j - 1].pos[k];
+
+					vtx[curr_vtx + 2].pos[k] = p->vertices[j - 1].pos[k];
+					vtx[curr_vtx + 3].pos[k] = p->vertices[j].pos[k];
+
+					vtx[curr_vtx + 4].pos[k] = p->vertices[j].pos[k];
+					vtx[curr_vtx + 5].pos[k] = p->vertices[0].pos[k];
+				}
+
+				curr_vtx += 6;
 			}
 		}
 	}
 
+	if (curr_vtx)
+	{
+		glBufferData(GL_ARRAY_BUFFER, sizeof(vtx), vtx, GL_STREAM_DRAW);
+		glDrawArrays(GL_LINES, 0, curr_vtx);
+	}
+
 	glEnable(GL_DEPTH_TEST);
-	glEnable(GL_TEXTURE_2D);
-#endif // 0
 }
 
 static void

--- a/src/client/refresh/gl3/gl3_surf.c
+++ b/src/client/refresh/gl3/gl3_surf.c
@@ -53,15 +53,6 @@ void GL3_SurfInit(void)
 	glGenBuffers(1, &gl3state.vbo3D);
 	GL3_BindVBO(gl3state.vbo3D);
 
-#if 0
-	if(gl3config.useBigVBO)
-	{
-		gl3state.vbo3Dsize = 5*1024*1024; // a 5MB buffer seems to work well?
-		gl3state.vbo3DcurOffset = 0;
-		glBufferData(GL_ARRAY_BUFFER, gl3state.vbo3Dsize, NULL, GL_STREAM_DRAW); // allocate/reserve that data
-	}
-#endif
-
 	glEnableVertexAttribArray(GL3_ATTRIB_POSITION);
 	qglVertexAttribPointer(GL3_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, sizeof(gl3_3D_vtx_t), 0);
 
@@ -193,15 +184,6 @@ GL3_DrawGLFlowingPoly(msurface_t *fa, gl3drawCmd_t drawCmd)
 	}
 	drawCmd.scroll = scroll;
 	drawCmd.flags |= DCFlag_UseScroll;
-
-#if 0
-	if(gl3state.uni3DData.scroll != scroll)
-	{
-		gl3state.uni3DData.scroll = scroll;
-		GL3_UpdateUBO3D();
-	}
-#endif
-
 
 	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN, drawCmd);
 }

--- a/src/client/refresh/gl3/gl3_surf.c
+++ b/src/client/refresh/gl3/gl3_surf.c
@@ -270,16 +270,15 @@ RenderBrushPoly(entity_t *currententity, msurface_t *fa, gl3drawCmd_t drawCmd)
 	//       and put fa->styles[] into the 3d draw vertex?
 	memcpy(drawCmd.styles, fa->styles, sizeof(fa->styles));
 	drawCmd.flags |= DCFlag_UseLmStyles;
-	static_assert(sizeof(fa->styles) == 4, "asd"); // TODO: remove
 
 	if (fa->texinfo->flags & SURF_FLOWING)
 	{
-		drawCmd.shader = &gl3state.si3DlmFlow;
+		GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3DlmFlow);
 		GL3_DrawGLFlowingPoly(fa, drawCmd);
 	}
 	else
 	{
-		drawCmd.shader = &gl3state.si3Dlm;
+		GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3Dlm);
 		GL3_DrawGLPoly(fa, drawCmd);
 	}
 
@@ -323,12 +322,12 @@ GL3_DrawAlphaSurfaces(void)
 		}
 		else if (s->texinfo->flags & SURF_FLOWING)
 		{
-			drawCmd.shader = &gl3state.si3DtransFlow;
+			GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3DtransFlow);
 			GL3_DrawGLFlowingPoly(s, drawCmd);
 		}
 		else
 		{
-			drawCmd.shader = &gl3state.si3Dtrans;
+			GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3Dtrans);
 			GL3_DrawGLPoly(s, drawCmd);
 		}
 	}
@@ -395,12 +394,12 @@ RenderLightmappedPoly(entity_t *currententity, msurface_t *surf, gl3drawCmd_t dr
 
 	if (surf->texinfo->flags & SURF_FLOWING)
 	{
-		drawCmd.shader = &gl3state.si3DlmFlow;
+		GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3DlmFlow);
 		GL3_DrawGLFlowingPoly(surf, drawCmd);
 	}
 	else
 	{
-		drawCmd.shader = &gl3state.si3Dlm;
+		GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3Dlm);
 		GL3_DrawGLPoly(surf, drawCmd);
 	}
 }

--- a/src/client/refresh/gl3/gl3_surf.c
+++ b/src/client/refresh/gl3/gl3_surf.c
@@ -164,7 +164,7 @@ GL3_DrawGLPoly(msurface_t *fa, gl3drawCmd_t drawCmd)
 {
 	glpoly_t *p = fa->polys;
 
-	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN, drawCmd);
+	GL3_Add3DdrawCmdToBatch(p->vertices, p->numverts, GL_TRIANGLE_FAN, drawCmd);
 }
 
 void
@@ -184,7 +184,7 @@ GL3_DrawGLFlowingPoly(msurface_t *fa, gl3drawCmd_t drawCmd)
 	drawCmd.scroll = scroll;
 	drawCmd.flags |= DCFlag_UseScroll;
 
-	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN, drawCmd);
+	GL3_Add3DdrawCmdToBatch(p->vertices, p->numverts, GL_TRIANGLE_FAN, drawCmd);
 }
 
 #define LINE_VTX_COUNT (256 * 6)

--- a/src/client/refresh/gl3/gl3_surf.c
+++ b/src/client/refresh/gl3/gl3_surf.c
@@ -164,7 +164,6 @@ GL3_DrawGLPoly(msurface_t *fa, gl3drawCmd_t drawCmd)
 {
 	glpoly_t *p = fa->polys;
 
-
 	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN, drawCmd);
 }
 
@@ -296,7 +295,7 @@ GL3_DrawAlphaSurfaces(void)
 	msurface_t *s;
 
 	/* go back to the world matrix */
-	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(true);
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd();
 	drawCmd.flags |= DCFlag_Blend;
 
 	for (s = gl3_alpha_surfaces; s != NULL; s = s->texturechain)
@@ -344,7 +343,7 @@ DrawTextureChains(entity_t *currententity)
 
 	c_visible_textures = 0;
 
-	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(true);
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd();
 
 	for (i = 0, image = gl3textures; i < numgl3textures; i++, image++)
 	{
@@ -477,7 +476,7 @@ GL3_DrawBrushModel(entity_t *e, gl3model_t *currentmodel)
 		return;
 	}
 
-	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(false);
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd();
 	if(e->flags & RF_TRANSLUCENT)
 		drawCmd.flags |= DCFlag_DisableDepthMask;
 
@@ -527,7 +526,7 @@ GL3_DrawBrushModel(entity_t *e, gl3model_t *currentmodel)
 
 	e->angles[0] = -e->angles[0];
 	e->angles[2] = -e->angles[2];
-	GL3_RotateForEntity(e, &drawCmd, true);
+	GL3_RotateForEntity(e, &drawCmd);
 	e->angles[0] = -e->angles[0];
 	e->angles[2] = -e->angles[2];
 

--- a/src/client/refresh/gl3/gl3_surf.c
+++ b/src/client/refresh/gl3/gl3_surf.c
@@ -53,12 +53,14 @@ void GL3_SurfInit(void)
 	glGenBuffers(1, &gl3state.vbo3D);
 	GL3_BindVBO(gl3state.vbo3D);
 
+#if 0
 	if(gl3config.useBigVBO)
 	{
 		gl3state.vbo3Dsize = 5*1024*1024; // a 5MB buffer seems to work well?
 		gl3state.vbo3DcurOffset = 0;
 		glBufferData(GL_ARRAY_BUFFER, gl3state.vbo3Dsize, NULL, GL_STREAM_DRAW); // allocate/reserve that data
 	}
+#endif
 
 	glEnableVertexAttribArray(GL3_ATTRIB_POSITION);
 	qglVertexAttribPointer(GL3_ATTRIB_POSITION, 3, GL_FLOAT, GL_FALSE, sizeof(gl3_3D_vtx_t), 0);
@@ -75,7 +77,7 @@ void GL3_SurfInit(void)
 	glEnableVertexAttribArray(GL3_ATTRIB_LIGHTFLAGS);
 	qglVertexAttribIPointer(GL3_ATTRIB_LIGHTFLAGS, 1, GL_UNSIGNED_INT, sizeof(gl3_3D_vtx_t), offsetof(gl3_3D_vtx_t, lightFlags));
 
-
+	glGenBuffers(1, &gl3state.ebo3D);
 
 	// init VAO and VBO for model vertexdata: 9 floats
 	// (X,Y,Z), (S,T), (R,G,B,A)
@@ -119,6 +121,8 @@ void GL3_SurfInit(void)
 
 void GL3_SurfShutdown(void)
 {
+	glDeleteBuffers(1, &gl3state.ebo3D);
+	gl3state.ebo3D = 0;
 	glDeleteBuffers(1, &gl3state.vbo3D);
 	gl3state.vbo3D = 0;
 	glDeleteVertexArrays(1, &gl3state.vao3D);
@@ -165,18 +169,16 @@ SetAllLightFlags(msurface_t *surf)
 }
 
 void
-GL3_DrawGLPoly(msurface_t *fa)
+GL3_DrawGLPoly(msurface_t *fa, gl3drawCmd_t drawCmd)
 {
 	glpoly_t *p = fa->polys;
 
-	GL3_BindVAO(gl3state.vao3D);
-	GL3_BindVBO(gl3state.vbo3D);
 
-	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN);
+	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN, drawCmd);
 }
 
 void
-GL3_DrawGLFlowingPoly(msurface_t *fa)
+GL3_DrawGLFlowingPoly(msurface_t *fa, gl3drawCmd_t drawCmd)
 {
 	glpoly_t *p;
 	float scroll;
@@ -189,17 +191,19 @@ GL3_DrawGLFlowingPoly(msurface_t *fa)
 	{
 		scroll = -64.0f;
 	}
+	drawCmd.scroll = scroll;
+	drawCmd.flags |= DCFlag_UseScroll;
 
+#if 0
 	if(gl3state.uni3DData.scroll != scroll)
 	{
 		gl3state.uni3DData.scroll = scroll;
 		GL3_UpdateUBO3D();
 	}
+#endif
 
-	GL3_BindVAO(gl3state.vao3D);
-	GL3_BindVBO(gl3state.vbo3D);
 
-	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN);
+	GL3_BufferAndDraw3D(p->vertices, p->numverts, GL_TRIANGLE_FAN, drawCmd);
 }
 
 static void
@@ -261,81 +265,40 @@ DrawTriangleOutlines(void)
 }
 
 static void
-UpdateLMscales(const hmm_vec4 lmScales[MAX_LIGHTMAPS_PER_SURFACE], gl3ShaderInfo_t* si)
+RenderBrushPoly(entity_t *currententity, msurface_t *fa, gl3drawCmd_t drawCmd)
 {
-	int i;
-	qboolean hasChanged = false;
-
-	for(i=0; i<MAX_LIGHTMAPS_PER_SURFACE; ++i)
-	{
-		if(hasChanged)
-		{
-			si->lmScales[i] = lmScales[i];
-		}
-		else if(   si->lmScales[i].R != lmScales[i].R
-		        || si->lmScales[i].G != lmScales[i].G
-		        || si->lmScales[i].B != lmScales[i].B
-		        || si->lmScales[i].A != lmScales[i].A )
-		{
-			si->lmScales[i] = lmScales[i];
-			hasChanged = true;
-		}
-	}
-
-	if(hasChanged)
-	{
-		glUniform4fv(si->uniLmScalesOrTime, MAX_LIGHTMAPS_PER_SURFACE, si->lmScales[0].Elements);
-	}
-}
-
-static void
-RenderBrushPoly(entity_t *currententity, msurface_t *fa)
-{
-	int map;
 	gl3image_t *image;
 
 	c_brush_polys++;
 
 	image = R_TextureAnimation(currententity, fa->texinfo);
+	drawCmd.texnum = image->texnum;
 
 	if (fa->flags & SURF_DRAWTURB)
 	{
-		GL3_Bind(image->texnum);
-
-		GL3_EmitWaterPolys(fa);
-
+		GL3_EmitWaterPolys(fa, drawCmd);
 		return;
 	}
-	else
-	{
-		GL3_Bind(image->texnum);
-	}
 
-	hmm_vec4 lmScales[MAX_LIGHTMAPS_PER_SURFACE] = {0};
-	lmScales[0] = HMM_Vec4(1.0f, 1.0f, 1.0f, 1.0f);
 
-	GL3_BindLightmap(fa->lightmaptexturenum);
+	drawCmd.lmtexnum = fa->lightmaptexturenum;
 
 	// Any dynamic lights on this surface?
-	for (map = 0; map < MAX_LIGHTMAPS_PER_SURFACE && fa->styles[map] != 255; map++)
-	{
-		lmScales[map].R = r_newrefdef.lightstyles[fa->styles[map]].rgb[0];
-		lmScales[map].G = r_newrefdef.lightstyles[fa->styles[map]].rgb[1];
-		lmScales[map].B = r_newrefdef.lightstyles[fa->styles[map]].rgb[2];
-		lmScales[map].A = 1.0f;
-	}
+	// TODO: maybe put lightstyles into a uniform (it's just 256 vec4)
+	//       and put fa->styles[] into the 3d draw vertex?
+	memcpy(drawCmd.styles, fa->styles, sizeof(fa->styles));
+	drawCmd.flags |= DCFlag_UseLmStyles;
+	static_assert(sizeof(fa->styles) == 4, "asd"); // TODO: remove
 
 	if (fa->texinfo->flags & SURF_FLOWING)
 	{
-		GL3_UseProgram(gl3state.si3DlmFlow.shaderProgram);
-		UpdateLMscales(lmScales, &gl3state.si3DlmFlow);
-		GL3_DrawGLFlowingPoly(fa);
+		drawCmd.shader = &gl3state.si3DlmFlow;
+		GL3_DrawGLFlowingPoly(fa, drawCmd);
 	}
 	else
 	{
-		GL3_UseProgram(gl3state.si3Dlm.shaderProgram);
-		UpdateLMscales(lmScales, &gl3state.si3Dlm);
-		GL3_DrawGLPoly(fa);
+		drawCmd.shader = &gl3state.si3Dlm;
+		GL3_DrawGLPoly(fa, drawCmd);
 	}
 
 	// Note: lightmap chains are gone, lightmaps are rendered together with normal texture in one pass
@@ -343,7 +306,7 @@ RenderBrushPoly(entity_t *currententity, msurface_t *fa)
 
 /*
  * Draw water surfaces and windows.
- * The BSP tree is waled front to back, so unwinding the chain
+ * The BSP tree is walked front to back, so unwinding the chain
  * of alpha_surfaces will draw back to front, giving proper ordering.
  */
 void
@@ -352,50 +315,41 @@ GL3_DrawAlphaSurfaces(void)
 	msurface_t *s;
 
 	/* go back to the world matrix */
-	gl3state.uni3DData.transModelMat4 = gl3_identityMat4;
-	GL3_UpdateUBO3D();
-
-	glEnable(GL_BLEND);
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(true);
+	drawCmd.flags |= DCFlag_Blend;
 
 	for (s = gl3_alpha_surfaces; s != NULL; s = s->texturechain)
 	{
-		GL3_Bind(s->texinfo->image->texnum);
+		drawCmd.texnum = s->texinfo->image->texnum;
 		c_brush_polys++;
-		float alpha = 1.0f;
 		if (s->texinfo->flags & SURF_TRANS33)
 		{
-			alpha = 0.333f;
+			drawCmd.alpha = 0.333f;
 		}
 		else if (s->texinfo->flags & SURF_TRANS66)
 		{
-			alpha = 0.666f;
+			drawCmd.alpha = 0.666f;
 		}
-		if(alpha != gl3state.uni3DData.alpha)
+		else
 		{
-			gl3state.uni3DData.alpha = alpha;
-			GL3_UpdateUBO3D();
+			drawCmd.alpha = 1.0f;
 		}
 
 		if (s->flags & SURF_DRAWTURB)
 		{
-			GL3_EmitWaterPolys(s);
+			GL3_EmitWaterPolys(s, drawCmd);
 		}
 		else if (s->texinfo->flags & SURF_FLOWING)
 		{
-			GL3_UseProgram(gl3state.si3DtransFlow.shaderProgram);
-			GL3_DrawGLFlowingPoly(s);
+			drawCmd.shader = &gl3state.si3DtransFlow;
+			GL3_DrawGLFlowingPoly(s, drawCmd);
 		}
 		else
 		{
-			GL3_UseProgram(gl3state.si3Dtrans.shaderProgram);
-			GL3_DrawGLPoly(s);
+			drawCmd.shader = &gl3state.si3Dtrans;
+			GL3_DrawGLPoly(s, drawCmd);
 		}
 	}
-
-	gl3state.uni3DData.alpha = 1.0f;
-	GL3_UpdateUBO3D();
-
-	glDisable(GL_BLEND);
 
 	gl3_alpha_surfaces = NULL;
 }
@@ -408,6 +362,8 @@ DrawTextureChains(entity_t *currententity)
 	gl3image_t *image;
 
 	c_visible_textures = 0;
+
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(true);
 
 	for (i = 0, image = gl3textures; i < numgl3textures; i++, image++)
 	{
@@ -428,7 +384,7 @@ DrawTextureChains(entity_t *currententity)
 		for ( ; s; s = s->texturechain)
 		{
 			SetLightFlags(s);
-			RenderBrushPoly(currententity, s);
+			RenderBrushPoly(currententity, s, drawCmd);
 		}
 
 		image->texturechain = NULL;
@@ -438,47 +394,37 @@ DrawTextureChains(entity_t *currententity)
 }
 
 static void
-RenderLightmappedPoly(entity_t *currententity, msurface_t *surf)
+RenderLightmappedPoly(entity_t *currententity, msurface_t *surf, gl3drawCmd_t drawCmd)
 {
-	int map;
 	gl3image_t *image = R_TextureAnimation(currententity, surf->texinfo);
 
-	hmm_vec4 lmScales[MAX_LIGHTMAPS_PER_SURFACE] = {0};
-	lmScales[0] = HMM_Vec4(1.0f, 1.0f, 1.0f, 1.0f);
 
 	assert((surf->texinfo->flags & (SURF_SKY | SURF_TRANS33 | SURF_TRANS66 | SURF_WARP)) == 0
 			&& "RenderLightMappedPoly mustn't be called with transparent, sky or warping surfaces!");
 
 	// Any dynamic lights on this surface?
-	for (map = 0; map < MAX_LIGHTMAPS_PER_SURFACE && surf->styles[map] != 255; map++)
-	{
-		lmScales[map].R = r_newrefdef.lightstyles[surf->styles[map]].rgb[0];
-		lmScales[map].G = r_newrefdef.lightstyles[surf->styles[map]].rgb[1];
-		lmScales[map].B = r_newrefdef.lightstyles[surf->styles[map]].rgb[2];
-		lmScales[map].A = 1.0f;
-	}
+	memcpy(drawCmd.styles, surf->styles, sizeof(surf->styles));
+	drawCmd.flags |= DCFlag_UseLmStyles;
 
 	c_brush_polys++;
 
-	GL3_Bind(image->texnum);
-	GL3_BindLightmap(surf->lightmaptexturenum);
+	drawCmd.texnum = image->texnum;
+	drawCmd.lmtexnum = surf->lightmaptexturenum;
 
 	if (surf->texinfo->flags & SURF_FLOWING)
 	{
-		GL3_UseProgram(gl3state.si3DlmFlow.shaderProgram);
-		UpdateLMscales(lmScales, &gl3state.si3DlmFlow);
-		GL3_DrawGLFlowingPoly(surf);
+		drawCmd.shader = &gl3state.si3DlmFlow;
+		GL3_DrawGLFlowingPoly(surf, drawCmd);
 	}
 	else
 	{
-		GL3_UseProgram(gl3state.si3Dlm.shaderProgram);
-		UpdateLMscales(lmScales, &gl3state.si3Dlm);
-		GL3_DrawGLPoly(surf);
+		drawCmd.shader = &gl3state.si3Dlm;
+		GL3_DrawGLPoly(surf, drawCmd);
 	}
 }
 
 static void
-DrawInlineBModel(entity_t *currententity, gl3model_t *currentmodel)
+DrawInlineBModel(entity_t *currententity, gl3model_t *currentmodel, gl3drawCmd_t drawCmd)
 {
 	int i, k;
 	cplane_t *pplane;
@@ -499,7 +445,7 @@ DrawInlineBModel(entity_t *currententity, gl3model_t *currentmodel)
 
 	if (currententity->flags & RF_TRANSLUCENT)
 	{
-		glEnable(GL_BLEND);
+		drawCmd.flags |= DCFlag_Blend;
 		/* TODO: should I care about the 0.25 part? we'll just set alpha to 0.33 or 0.66 depending on surface flag..
 		glColor4f(1, 1, 1, 0.25);
 		R_TexEnv(GL_MODULATE);
@@ -527,19 +473,15 @@ DrawInlineBModel(entity_t *currententity, gl3model_t *currentmodel)
 			else if(!(psurf->flags & SURF_DRAWTURB))
 			{
 				SetAllLightFlags(psurf);
-				RenderLightmappedPoly(currententity, psurf);
+				RenderLightmappedPoly(currententity, psurf, drawCmd);
 			}
 			else
 			{
-				RenderBrushPoly(currententity, psurf);
+				RenderBrushPoly(currententity, psurf, drawCmd);
 			}
 		}
 	}
 
-	if (currententity->flags & RF_TRANSLUCENT)
-	{
-		glDisable(GL_BLEND);
-	}
 }
 
 void
@@ -554,7 +496,10 @@ GL3_DrawBrushModel(entity_t *e, gl3model_t *currentmodel)
 		return;
 	}
 
-	gl3state.currenttexture = -1;
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(false);
+	if(e->flags & RF_TRANSLUCENT)
+		drawCmd.flags |= DCFlag_DisableDepthMask;
+
 
 	if (e->angles[0] || e->angles[1] || e->angles[2])
 	{
@@ -580,7 +525,7 @@ GL3_DrawBrushModel(entity_t *e, gl3model_t *currentmodel)
 
 	if (gl_zfix->value)
 	{
-		glEnable(GL_POLYGON_OFFSET_FILL);
+		drawCmd.flags |= DCFlag_PolyOffsetFill;
 	}
 
 	VectorSubtract(r_newrefdef.vieworg, e->origin, modelorg);
@@ -597,27 +542,18 @@ GL3_DrawBrushModel(entity_t *e, gl3model_t *currentmodel)
 		modelorg[2] = DotProduct(temp, up);
 	}
 
-
-
 	//glPushMatrix();
-	hmm_mat4 oldMat = gl3state.uni3DData.transModelMat4;
 
 	e->angles[0] = -e->angles[0];
 	e->angles[2] = -e->angles[2];
-	GL3_RotateForEntity(e);
+	GL3_RotateForEntity(e, &drawCmd, true);
 	e->angles[0] = -e->angles[0];
 	e->angles[2] = -e->angles[2];
 
-	DrawInlineBModel(e, currentmodel);
+	DrawInlineBModel(e, currentmodel, drawCmd);
 
 	// glPopMatrix();
-	gl3state.uni3DData.transModelMat4 = oldMat;
-	GL3_UpdateUBO3D();
 
-	if (gl_zfix->value)
-	{
-		glDisable(GL_POLYGON_OFFSET_FILL);
-	}
 }
 
 static void
@@ -785,6 +721,9 @@ GL3_DrawWorld(void)
 	DrawTextureChains(&ent);
 	GL3_DrawSkyBox();
 	DrawTriangleOutlines();
+
+	// make sure all this is drawed
+	GL3_Draw3DBatchesNow();
 }
 
 /*

--- a/src/client/refresh/gl3/gl3_warp.c
+++ b/src/client/refresh/gl3/gl3_warp.c
@@ -257,7 +257,7 @@ GL3_EmitWaterPolys(msurface_t *fa, gl3drawCmd_t drawCmd)
 
 	for (bp = fa->polys; bp != NULL; bp = bp->next)
 	{
-		GL3_BufferAndDraw3D(bp->vertices, bp->numverts, GL_TRIANGLE_FAN, drawCmd);
+		GL3_Add3DdrawCmdToBatch(bp->vertices, bp->numverts, GL_TRIANGLE_FAN, drawCmd);
 	}
 }
 
@@ -728,7 +728,7 @@ GL3_DrawSkyBox(void)
 		MakeSkyVec( skymaxs [ 0 ] [ i ], skymaxs [ 1 ] [ i ], i, &skyVertices[2] );
 		MakeSkyVec( skymaxs [ 0 ] [ i ], skymins [ 1 ] [ i ], i, &skyVertices[3] );
 
-		GL3_BufferAndDraw3D(skyVertices, 4, GL_TRIANGLE_FAN, drawCmd);
+		GL3_Add3DdrawCmdToBatch(skyVertices, 4, GL_TRIANGLE_FAN, drawCmd);
 	}
 
 	// glPopMatrix();

--- a/src/client/refresh/gl3/gl3_warp.c
+++ b/src/client/refresh/gl3/gl3_warp.c
@@ -228,7 +228,7 @@ GL3_SubdivideSurface(msurface_t *fa, gl3model_t* loadmodel)
  * Does a water warp on the pre-fragmented glpoly_t chain
  */
 void
-GL3_EmitWaterPolys(msurface_t *fa)
+GL3_EmitWaterPolys(msurface_t *fa, gl3drawCmd_t drawCmd)
 {
 	glpoly_t *bp;
 	float scroll = 0.0f;
@@ -241,37 +241,25 @@ GL3_EmitWaterPolys(msurface_t *fa)
 			scroll = -64.0f;
 		}
 	}
+	// set this even if scroll is 0, because the shader uses scroll
+	// so the uniform must be set either way
+	drawCmd.scroll = scroll;
+	drawCmd.flags |= DCFlag_UseScroll;
 
-	qboolean updateUni3D = false;
-	if(gl3state.uni3DData.scroll != scroll)
-	{
-		gl3state.uni3DData.scroll = scroll;
-		updateUni3D = true;
-	}
 	// these surfaces (mostly water and lava, I think?) don't have a lightmap.
 	// rendering water at full brightness looks bad (esp. for water in dark environments)
 	// so default use a factor of 0.5 (ontop of intensity)
 	// but lava should be bright and glowing, so use full brightness there
-	float lightScale = fa->texinfo->image->is_lava ? 1.0f : 0.5f;
-	if(lightScale != gl3state.uni3DData.lightScaleForTurb)
-	{
-		gl3state.uni3DData.lightScaleForTurb = lightScale;
-		updateUni3D = true;
-	}
+	drawCmd.lightScaleForTurb = fa->texinfo->image->is_lava ? 1.0f : 0.5f;
+	drawCmd.flags |= DCFlag_UseLightScaleForTurb;
 
-	if(updateUni3D)
-	{
-		GL3_UpdateUBO3D();
-	}
 
-	GL3_UseProgram(gl3state.si3Dturb.shaderProgram);
 
-	GL3_BindVAO(gl3state.vao3D);
-	GL3_BindVBO(gl3state.vbo3D);
+	drawCmd.shader = &gl3state.si3Dturb;
 
 	for (bp = fa->polys; bp != NULL; bp = bp->next)
 	{
-		GL3_BufferAndDraw3D(bp->vertices, bp->numverts, GL_TRIANGLE_FAN);
+		GL3_BufferAndDraw3D(bp->vertices, bp->numverts, GL_TRIANGLE_FAN, drawCmd);
 	}
 }
 
@@ -696,26 +684,25 @@ GL3_DrawSkyBox(void)
 		}
 	}
 
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(false);
+
 	// glPushMatrix();
-	hmm_mat4 origModelMat = gl3state.uni3DData.transModelMat4;
 
 	// glTranslatef(gl3_origin[0], gl3_origin[1], gl3_origin[2]);
 	hmm_vec3 transl = HMM_Vec3(gl3_origin[0], gl3_origin[1], gl3_origin[2]);
-	hmm_mat4 modMVmat = HMM_MultiplyMat4(origModelMat, HMM_Translate(transl));
+	hmm_mat4 modMVmat = HMM_Translate(transl);
 	if(skyrotate != 0.0f)
 	{
 		// glRotatef(r_newrefdef.time * skyrotate, skyaxis[0], skyaxis[1], skyaxis[2]);
 		hmm_vec3 rotAxis = HMM_Vec3(skyaxis[0], skyaxis[1], skyaxis[2]);
 		modMVmat = HMM_MultiplyMat4(modMVmat, HMM_Rotate(r_newrefdef.time * skyrotate, rotAxis));
 	}
-	gl3state.uni3DData.transModelMat4 = modMVmat;
-	GL3_UpdateUBO3D();
+	drawCmd.transModelMat = modMVmat;
 
-	GL3_UseProgram(gl3state.si3Dsky.shaderProgram);
-	GL3_BindVAO(gl3state.vao3D);
-	GL3_BindVBO(gl3state.vbo3D);
+	drawCmd.shader = &gl3state.si3Dsky;
 
 	// TODO: this could all be done in one drawcall.. but.. whatever, it's <= 6 drawcalls/frame
+	//       also, they use different textures..
 
 	gl3_3D_vtx_t skyVertices[4];
 
@@ -735,17 +722,15 @@ GL3_DrawSkyBox(void)
 			continue;
 		}
 
-		GL3_Bind(sky_images[skytexorder[i]]->texnum);
+		drawCmd.texnum = sky_images[skytexorder[i]]->texnum;
 
 		MakeSkyVec( skymins [ 0 ] [ i ], skymins [ 1 ] [ i ], i, &skyVertices[0] );
 		MakeSkyVec( skymins [ 0 ] [ i ], skymaxs [ 1 ] [ i ], i, &skyVertices[1] );
 		MakeSkyVec( skymaxs [ 0 ] [ i ], skymaxs [ 1 ] [ i ], i, &skyVertices[2] );
 		MakeSkyVec( skymaxs [ 0 ] [ i ], skymins [ 1 ] [ i ], i, &skyVertices[3] );
 
-		GL3_BufferAndDraw3D(skyVertices, 4, GL_TRIANGLE_FAN);
+		GL3_BufferAndDraw3D(skyVertices, 4, GL_TRIANGLE_FAN, drawCmd);
 	}
 
 	// glPopMatrix();
-	gl3state.uni3DData.transModelMat4 = origModelMat;
-	GL3_UpdateUBO3D();
 }

--- a/src/client/refresh/gl3/gl3_warp.c
+++ b/src/client/refresh/gl3/gl3_warp.c
@@ -255,7 +255,7 @@ GL3_EmitWaterPolys(msurface_t *fa, gl3drawCmd_t drawCmd)
 
 
 
-	drawCmd.shader = &gl3state.si3Dturb;
+	GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3Dturb);
 
 	for (bp = fa->polys; bp != NULL; bp = bp->next)
 	{
@@ -699,7 +699,7 @@ GL3_DrawSkyBox(void)
 	}
 	drawCmd.transModelMat = modMVmat;
 
-	drawCmd.shader = &gl3state.si3Dsky;
+	GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3Dsky);
 
 	// TODO: this could all be done in one drawcall.. but.. whatever, it's <= 6 drawcalls/frame
 	//       also, they use different textures..

--- a/src/client/refresh/gl3/gl3_warp.c
+++ b/src/client/refresh/gl3/gl3_warp.c
@@ -253,8 +253,6 @@ GL3_EmitWaterPolys(msurface_t *fa, gl3drawCmd_t drawCmd)
 	drawCmd.lightScaleForTurb = fa->texinfo->image->is_lava ? 1.0f : 0.5f;
 	drawCmd.flags |= DCFlag_UseLightScaleForTurb;
 
-
-
 	GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3Dturb);
 
 	for (bp = fa->polys; bp != NULL; bp = bp->next)
@@ -684,7 +682,7 @@ GL3_DrawSkyBox(void)
 		}
 	}
 
-	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd(false);
+	gl3drawCmd_t drawCmd = GL3_CreateDrawCmd();
 
 	// glPushMatrix();
 
@@ -697,7 +695,8 @@ GL3_DrawSkyBox(void)
 		hmm_vec3 rotAxis = HMM_Vec3(skyaxis[0], skyaxis[1], skyaxis[2]);
 		modMVmat = HMM_MultiplyMat4(modMVmat, HMM_Rotate(r_newrefdef.time * skyrotate, rotAxis));
 	}
-	drawCmd.transModelMat = modMVmat;
+
+	GL3_SetDrawCmdTransMatrix(&drawCmd, modMVmat);
 
 	GL3_SetDrawCmdShader(&drawCmd, &gl3state.si3Dsky);
 

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -104,6 +104,9 @@ static const int gl3_tex_alpha_format = GL_RGBA;
 extern unsigned gl3_rawpalette[256];
 extern unsigned d_8to24table[256];
 
+// for stats
+extern int gl3_num3Ddraws, gl3_num2Ddraws, gl3_numBufferVtxData, gl3_numBufferUniforms;
+
 typedef struct
 {
 	const char *renderer_string;
@@ -388,7 +391,7 @@ extern int GL3_InitContext(void* win);
 extern void GL3_GetDrawableSize(int* width, int* height);
 extern int GL3_PrepareForWindow(void);
 extern qboolean GL3_IsVsyncActive(void);
-extern void GL3_EndFrame(void);
+extern void GL3_SwapWindow(void);
 extern void GL3_SetVsync(void);
 extern void GL3_ShutdownContext(void);
 extern int GL3_GetSDLVersion(void);
@@ -424,6 +427,8 @@ extern void GL3_Draw_Fill(int x, int y, int w, int h, int c);
 extern void GL3_Draw_FadeScreen(void);
 extern void GL3_Draw_Flash(const float color[4], float x, float y, float w, float h);
 extern void GL3_Draw_StretchRaw(int x, int y, int w, int h, int cols, int rows, const byte *data, int bits);
+
+extern void GL3_EndFrame(void);
 
 // gl3_image.c
 
@@ -556,5 +561,6 @@ extern cvar_t *r_palettedtexture;
 extern cvar_t *r_validation;
 
 extern cvar_t *gl3_debugcontext;
+extern cvar_t *gl3_show_draw_stats;
 
 #endif /* SRC_CLIENT_REFRESH_GL3_HEADER_LOCAL_H_ */

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -304,7 +304,7 @@ typedef struct image_s
 	struct msurface_s *texturechain;    /* for sort-by-texture world drawing */
 	GLuint texnum;                      /* gl texture binding */
 	float sl, tl, sh, th;               /* 0,0 - 1,1 unless part of the scrap */
-	// qboolean scrap; // currently unused
+	qboolean scrap;
 	qboolean has_alpha;
 	qboolean is_lava; // DG: added for lava brightness hack
 
@@ -455,6 +455,10 @@ extern void GL3_ShutdownImages(void);
 extern void GL3_FreeUnusedImages(void);
 extern qboolean GL3_ImageHasFreeSpace(void);
 extern void GL3_ImageList_f(void);
+
+extern void GL3_Scrap_Init(void);
+extern void GL3_Scrap_Upload(void);
+extern qboolean gl3_scrap_dirty;
 
 // gl3_light.c
 extern int r_dlightframecount;

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -428,6 +428,7 @@ extern void GL3_Draw_FadeScreen(void);
 extern void GL3_Draw_Flash(const float color[4], float x, float y, float w, float h);
 extern void GL3_Draw_StretchRaw(int x, int y, int w, int h, int cols, int rows, const byte *data, int bits);
 
+extern void GL3_DrawCurrent2Dbatch();
 extern void GL3_EndFrame(void);
 
 // gl3_image.c

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -615,6 +615,7 @@ extern cvar_t *r_videos_unfiltered;
 extern cvar_t *gl_nolerp_list;
 extern cvar_t *r_lerp_list;
 extern cvar_t *gl_nobind;
+extern cvar_t *gl_showtris;
 extern cvar_t *r_lockpvs;
 extern cvar_t *r_novis;
 

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -123,8 +123,6 @@ typedef struct
 	qboolean debug_output; // is GL_ARB_debug_output supported?
 	qboolean stencil; // Do we have a stencil buffer?
 
-	qboolean useBigVBO; // workaround for AMDs windows driver for fewer calls to glBufferData()
-
 	// ----
 
 	float max_anisotropy;
@@ -255,9 +253,6 @@ typedef struct
 	gl3ShaderInfo_t siParticle; // for particles. surprising, right?
 
 	GLuint vao3D, vbo3D, ebo3D; // for brushes etc, using 10 floats and one uint as vertex input (x,y,z, s,t, lms,lmt, normX,normY,normZ ; lightFlags)
-
-	// the next two are for gl3config.useBigVBO == true
-
 	GLuint vaoAlias, vboAlias, eboAlias; // for models, using 9 floats as (x,y,z, s,t, r,g,b,a)
 	GLuint vaoParticle, vboParticle; // for particles, using 9 floats (x,y,z, size,distance, r,g,b,a)
 

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -254,11 +254,9 @@ typedef struct
 	// NOTE: make sure siParticle is always the last shaderInfo (or adapt GL3_ShutdownShaders())
 	gl3ShaderInfo_t siParticle; // for particles. surprising, right?
 
-	GLuint vao3D, vbo3D; // for brushes etc, using 10 floats and one uint as vertex input (x,y,z, s,t, lms,lmt, normX,normY,normZ ; lightFlags)
+	GLuint vao3D, vbo3D, ebo3D; // for brushes etc, using 10 floats and one uint as vertex input (x,y,z, s,t, lms,lmt, normX,normY,normZ ; lightFlags)
 
 	// the next two are for gl3config.useBigVBO == true
-	int vbo3Dsize;
-	int vbo3DcurOffset;
 
 	GLuint vaoAlias, vboAlias, eboAlias; // for models, using 9 floats as (x,y,z, s,t, r,g,b,a)
 	GLuint vaoParticle, vboParticle; // for particles, using 9 floats (x,y,z, size,distance, r,g,b,a)
@@ -276,6 +274,60 @@ typedef struct
 	hmm_mat4 projMat3D;
 	hmm_mat4 viewMat3D;
 } gl3state_t;
+
+
+// drawcommands using gl3_3D_vtx_t, for batching
+typedef struct gl3drawCmd_s {
+	hmm_mat4	transModelMat;
+	gl3ShaderInfo_t* shader;
+
+	GLuint		texnum;
+	int			lmtexnum;
+
+	float		scroll; // for gl3state.uni3DData.scroll
+	float		lightScaleForTurb; // for gl3state.uni3DData.lightScaleForTurb
+	float		alpha; // either part of color or for gl3state.uni3DData.alpha
+	byte		color[3]; // for uniCommonData.color; its alpha chan is in .alpha
+	byte		flags;    // gl3drawCmd_Flags
+	byte		styles[MAXLIGHTMAPS]; // indexes into r_newrefdef.lightstyles[]; 255 means "ignore"
+
+	// the following are set in GL3_BufferAndDraw3D()
+	int			idxBufOffset;
+	int			numElements; // in index buffer
+} gl3drawCmd_t;
+
+// for gl3drawCmd_t::flags
+enum gl3drawCmd_Flags {
+	DCFlag_DisableDepthMask =  1, // glDepthMask() - GL_FALSE if bit is set
+	DCFlag_Blend            =  2, // GL_BLEND (glEnable/glDisable)
+	DCFlag_PolyOffsetFill   =  4, // GL_POLYGON_OFFSET_FILL (glEnable/glDisable) - for gl_zfix
+	DCFlag_UseColor         =  8,
+	DCFlag_UseScroll        = 16,
+	DCFlag_UseLmStyles      = 32,
+	DCFlag_UseLightScaleForTurb = 64,
+	DCFlag_IsIdentityMat    = 128, // avoids comparing the matrix in many cases
+
+	// TODO: DCFlag_SameAsPrevious = 255 for "don't check, just merge into previous command"?
+};
+
+// create an "empty" gl3drawCmd_t with sane defaults
+static inline gl3drawCmd_t
+GL3_CreateDrawCmd(qboolean identityTrans)
+{
+	gl3drawCmd_t ret = {0};
+	if(identityTrans) {
+		ret.transModelMat = gl3_identityMat4;
+		ret.flags = DCFlag_IsIdentityMat;
+	}
+	ret.alpha = 1.0f;
+	ret.styles[0] = 255;
+	ret.lmtexnum = -1;
+	// the other values can remain 0/NULL
+
+	return ret;
+}
+
+
 
 extern gl3config_t gl3config;
 extern gl3state_t gl3state;
@@ -382,9 +434,11 @@ GL3_BindEBO(GLuint ebo)
 	}
 }
 
-extern void GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode);
+extern void GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode, gl3drawCmd_t drawCmd);
+extern void GL3_Draw3DBatchesNow(void);
 
-extern void GL3_RotateForEntity(entity_t *e);
+extern void GL3_RotateUni3DforEntity(entity_t *e);
+extern void GL3_RotateForEntity(entity_t *e, gl3drawCmd_t* drawCmd, qboolean replaceTransModelMat);
 
 // gl3_sdl.c
 extern int GL3_InitContext(void* win);
@@ -480,7 +534,7 @@ extern void GL3_LM_BeginBuildingLightmaps(gl3model_t *m);
 extern void GL3_LM_EndBuildingLightmaps(void);
 
 // gl3_warp.c
-extern void GL3_EmitWaterPolys(msurface_t *fa);
+extern void GL3_EmitWaterPolys(msurface_t *fa, gl3drawCmd_t drawCmd);
 extern void GL3_SubdivideSurface(msurface_t *fa, gl3model_t* loadmodel);
 
 extern void GL3_SetSky(const char *name, float rotate, vec3_t axis);
@@ -492,8 +546,8 @@ extern void GL3_AddSkySurface(msurface_t *fa);
 // gl3_surf.c
 extern void GL3_SurfInit(void);
 extern void GL3_SurfShutdown(void);
-extern void GL3_DrawGLPoly(msurface_t *fa);
-extern void GL3_DrawGLFlowingPoly(msurface_t *fa);
+extern void GL3_DrawGLPoly(msurface_t *fa, gl3drawCmd_t drawCmd);
+extern void GL3_DrawGLFlowingPoly(msurface_t *fa, gl3drawCmd_t drawCmd);
 extern void GL3_DrawTriangleOutlines(void);
 extern void GL3_DrawAlphaSurfaces(void);
 extern void GL3_DrawBrushModel(entity_t *e, gl3model_t *currentmodel);

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -58,6 +58,9 @@
 
 #include "HandmadeMath.h"
 
+#define DG_DYNARR_ASSERT(cond, msg) \
+	((cond) ? (void)0 : Com_Error(ERR_FATAL, "DG_dynarr.h error: %s\n", msg))
+
 #if 0 // only use this for development ..
 #define STUB_ONCE(msg) do { \
 		static int show=1; \

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -278,11 +278,12 @@ typedef struct
 
 // drawcommands using gl3_3D_vtx_t, for batching
 typedef struct gl3drawCmd_s {
-	hmm_mat4	transModelMat;
-
 	GLuint		texnum;
 	signed char	lmtexnum;
 	signed char	shaderIdx;
+
+	// index into gl3_main.c transModelMats; 0 always is identity matrix
+	unsigned short transModelMatIdx;
 
 	float		scroll; // for gl3state.uni3DData.scroll
 	float		lightScaleForTurb; // for gl3state.uni3DData.lightScaleForTurb
@@ -305,20 +306,15 @@ enum gl3drawCmd_Flags {
 	DCFlag_UseScroll        = 16,
 	DCFlag_UseLmStyles      = 32,
 	DCFlag_UseLightScaleForTurb = 64,
-	DCFlag_IsIdentityMat    = 128, // avoids comparing the matrix in many cases
 
 	// TODO: DCFlag_SameAsPrevious = 255 for "don't check, just merge into previous command"?
 };
 
 // create an "empty" gl3drawCmd_t with sane defaults
 static inline gl3drawCmd_t
-GL3_CreateDrawCmd(qboolean identityTrans)
+GL3_CreateDrawCmd(void)
 {
 	gl3drawCmd_t ret = {0};
-	if(identityTrans) {
-		ret.transModelMat = gl3_identityMat4;
-		ret.flags = DCFlag_IsIdentityMat;
-	}
 	ret.alpha = 1.0f;
 	ret.styles[0] = 255;
 	ret.lmtexnum = -1;
@@ -468,9 +464,10 @@ GL3_BindEBO(GLuint ebo)
 
 extern void GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode, gl3drawCmd_t drawCmd);
 extern void GL3_Draw3DBatchesNow(void);
+extern void GL3_SetDrawCmdTransMatrix(gl3drawCmd_t* drawCmd, hmm_mat4 mat);
 
 extern void GL3_RotateUni3DforEntity(entity_t *e);
-extern void GL3_RotateForEntity(entity_t *e, gl3drawCmd_t* drawCmd, qboolean replaceTransModelMat);
+extern void GL3_RotateForEntity(entity_t *e, gl3drawCmd_t* drawCmd);
 
 // gl3_sdl.c
 extern int GL3_InitContext(void* win);

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -56,6 +56,8 @@
 
 #include "../../ref_shared.h"
 
+#include <stddef.h> // offsetof()
+
 #include "HandmadeMath.h"
 
 #define DG_DYNARR_ASSERT(cond, msg) \
@@ -231,7 +233,7 @@ typedef struct
 	GLuint currentShaderProgram;
 	GLuint currentUBO;
 
-	// NOTE: make sure si2D is always the first shaderInfo (or adapt GL3_ShutdownShaders())
+	// NOTE: make sure si2D is always the first shaderInfo (or adapt GL3_ShutdownShaders() and GL3_SetDrawCmdShader())
 	gl3ShaderInfo_t si2D;      // shader for rendering 2D with textures
 	gl3ShaderInfo_t si2Dtinted; // shader for rendering 2D with textures and color tinting
 	gl3ShaderInfo_t si2Dcolor; // shader for rendering 2D with flat colors
@@ -277,10 +279,10 @@ typedef struct
 // drawcommands using gl3_3D_vtx_t, for batching
 typedef struct gl3drawCmd_s {
 	hmm_mat4	transModelMat;
-	gl3ShaderInfo_t* shader;
 
 	GLuint		texnum;
-	int			lmtexnum;
+	signed char	lmtexnum;
+	signed char	shaderIdx;
 
 	float		scroll; // for gl3state.uni3DData.scroll
 	float		lightScaleForTurb; // for gl3state.uni3DData.lightScaleForTurb
@@ -320,15 +322,47 @@ GL3_CreateDrawCmd(qboolean identityTrans)
 	ret.alpha = 1.0f;
 	ret.styles[0] = 255;
 	ret.lmtexnum = -1;
+	ret.shaderIdx = -1;
 	// the other values can remain 0/NULL
 
 	return ret;
 }
 
-
-
 extern gl3config_t gl3config;
 extern gl3state_t gl3state;
+
+enum {
+	_gl3_numShaders = 1 + ((offsetof(gl3state_t, siParticle) - offsetof(gl3state_t, si2D)) / sizeof(gl3ShaderInfo_t))
+};
+
+static inline void
+GL3_SetDrawCmdShader(gl3drawCmd_t* drawCmd, const gl3ShaderInfo_t* shader)
+{
+	if(shader == NULL)
+	{
+		drawCmd->shaderIdx = -1;
+		return;
+	}
+	ptrdiff_t offset = shader - &gl3state.si2D;
+	if( offset >= 0 && offset < _gl3_numShaders)
+	{
+		drawCmd->shaderIdx = offset;
+	}
+	else
+	{
+		assert(0 && "invalid shader!");
+		drawCmd->shaderIdx = -1;
+	}
+}
+
+static inline gl3ShaderInfo_t*
+GL3_GetDrawCmdShader(const gl3drawCmd_t* drawCmd)
+{
+	unsigned shaderIdx = drawCmd->shaderIdx;
+	if(shaderIdx >= _gl3_numShaders) // because it's unsigned this also handles shaderIdx -1
+		return NULL;
+	return &gl3state.si2D + shaderIdx;
+}
 
 extern int gl3_visframecount; /* bumped when going to a new PVS */
 extern int gl3_framecount; /* used for dlight push checking */

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -649,6 +649,10 @@ extern cvar_t *r_fixsurfsky;
 extern cvar_t *r_palettedtexture;
 extern cvar_t *r_validation;
 
+#ifdef YQ2_GL3_GLES
+extern cvar_t *gl_discardfb;
+#endif
+
 extern cvar_t *gl3_debugcontext;
 extern cvar_t *gl3_show_draw_stats;
 

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -462,7 +462,7 @@ GL3_BindEBO(GLuint ebo)
 	}
 }
 
-extern void GL3_BufferAndDraw3D(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode, gl3drawCmd_t drawCmd);
+extern void GL3_Add3DdrawCmdToBatch(const gl3_3D_vtx_t* verts, int numVerts, GLenum drawMode, gl3drawCmd_t drawCmd);
 extern void GL3_Draw3DBatchesNow(void);
 extern void GL3_SetDrawCmdTransMatrix(gl3drawCmd_t* drawCmd, hmm_mat4 mat);
 


### PR DESCRIPTION
.. and some small fixes in the GL1 code that came up

In addition to the batching, GL3 now also has a scrap texture for 2D GUI textures, like GL1.

GL3 now has a `gl3_show_draw_stats` CVar that prints the amount of draw calls and glBufferData() calls.

before:  
<img width="1920" height="1200" alt="q2_before" src="https://github.com/user-attachments/assets/1573a000-cd58-402e-a62d-f9b78918b640" />

<img width="1920" height="1200" alt="q2_0033" src="https://github.com/user-attachments/assets/fc3d5680-200f-4877-9355-dfff95db9895" />

after:  
<img width="1920" height="1200" alt="q2_0034" src="https://github.com/user-attachments/assets/a79658d2-7523-4fb8-a3cd-06b6fd7fa356" />


<img width="1920" height="1200" alt="q2_0032" src="https://github.com/user-attachments/assets/60da3844-caee-4f83-ab4a-9b839194f668" />

marking as a draft because it needs more testing and probably some more cleaning up

(please test!)