### PR TITLE
menu: API refactoring and more bug fixes and stability

### DIFF
--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -65,10 +65,11 @@ typedef struct _tag_menuframework
 	int nitems;
 	void *items[64];
 
+	const char *banner;
 	const char *statusbar;
 
-	void (*draw)(void);
-    	const char *(*key)(struct _tag_menuframework *m, int k);
+	void (*draw)(struct _tag_menuframework *m);
+	const char *(*key)(struct _tag_menuframework *m, int k);
 	void (*cursordraw)(struct _tag_menuframework *m);
 } menuframework_s;
 

--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -153,10 +153,25 @@ qboolean Menu_SelectItem(menuframework_s *s);
 void Menu_SetStatusBar(menuframework_s *s, const char *string);
 qboolean Menu_SlideItem(menuframework_s *s, int dir);
 
+void Menu_DrawCharacter(int cx, int cy, int num);
 void Menu_DrawString(int, int, const char *);
 void Menu_DrawStringDark(int, int, const char *);
 void Menu_DrawStringR2L(int, int, const char *);
 void Menu_DrawStringR2LDark(int, int, const char *);
+
+typedef struct
+{
+	const char *string;
+	int endtime;
+} menupopup_s;
+
+void Menu_DrawTextBox(int x, int y, int width, int lines);
+void Menu_DrawText(int x, int y, const char *str);
+void Menu_DrawPopup(int x, int y, const menupopup_s *pup);
+void Menu_StartPopup(menupopup_s *pup, const char *string, int lifetime);
+
+#define Menu_PopupActive(pup) ((pup)->string && ((pup)->endtime <= 0 || (pup)->endtime >= cls.realtime))
+#define Menu_ClosePopup(pup) (pup)->endtime = cls.realtime - 1
 
 float ClampCvar(float min, float max, float value);
 

--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -68,7 +68,7 @@ typedef struct _tag_menuframework
 	const char *statusbar;
 
 	void (*draw)(void);
-    	const char *(*key)(int k);
+    	const char *(*key)(struct _tag_menuframework *m, int k);
 	void (*cursordraw)(struct _tag_menuframework *m);
 } menuframework_s;
 

--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -142,6 +142,7 @@ typedef struct
 
 void M_PushMenu(menuframework_s* menu);
 
+void Field_InitState(menufield_s *f, const char *s, int len, int vislen);
 void Field_ResetCursor(menuframework_s *m);
 qboolean Field_Key(menufield_s *field, int key);
 

--- a/src/client/menu/header/qmenu.h
+++ b/src/client/menu/header/qmenu.h
@@ -70,6 +70,7 @@ typedef struct _tag_menuframework
 
 	void (*draw)(struct _tag_menuframework *m);
 	const char *(*key)(struct _tag_menuframework *m, int k);
+	void (*close)(struct _tag_menuframework *m);
 	void (*cursordraw)(struct _tag_menuframework *m);
 } menuframework_s;
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -4731,10 +4731,8 @@ StartServer_MenuInit(void)
 		s_capturelimit_field.generic.x = 0;
 		s_capturelimit_field.generic.y = 18;
 		s_capturelimit_field.generic.statusbar = "0 = no limit";
-		s_capturelimit_field.length = 3;
-		s_capturelimit_field.visible_length = 3;
-		Q_strlcpy(s_capturelimit_field.buffer, Cvar_VariableString("capturelimit"),
-			sizeof(s_capturelimit_field.buffer));
+		Field_InitState(&s_capturelimit_field,
+			Cvar_VariableString("capturelimit"), 3, 3);
 	}
 	else
 	{
@@ -4771,10 +4769,8 @@ StartServer_MenuInit(void)
 	s_timelimit_field.generic.x = 0;
 	s_timelimit_field.generic.y = 36;
 	s_timelimit_field.generic.statusbar = "0 = no limit";
-	s_timelimit_field.length = 3;
-	s_timelimit_field.visible_length = 3;
-	Q_strlcpy(s_timelimit_field.buffer, Cvar_VariableString("timelimit"),
-		sizeof(s_timelimit_field.buffer));
+	Field_InitState(&s_timelimit_field,
+		Cvar_VariableString("timelimit"), 3, 3);
 
 	s_fraglimit_field.generic.type = MTYPE_FIELD;
 	s_fraglimit_field.generic.name = "frag limit";
@@ -4782,10 +4778,8 @@ StartServer_MenuInit(void)
 	s_fraglimit_field.generic.x = 0;
 	s_fraglimit_field.generic.y = 54;
 	s_fraglimit_field.generic.statusbar = "0 = no limit";
-	s_fraglimit_field.length = 3;
-	s_fraglimit_field.visible_length = 3;
-	Q_strlcpy(s_fraglimit_field.buffer, Cvar_VariableString("fraglimit"),
-		sizeof(s_fraglimit_field.buffer));
+	Field_InitState(&s_fraglimit_field,
+		Cvar_VariableString("fraglimit"), 3, 3);
 
 	/* maxclients determines the maximum number of players that can join
 	   the game. If maxclients is only "1" then we should default the menu
@@ -4797,18 +4791,8 @@ StartServer_MenuInit(void)
 	s_maxclients_field.generic.x = 0;
 	s_maxclients_field.generic.y = 72;
 	s_maxclients_field.generic.statusbar = NULL;
-	s_maxclients_field.length = 3;
-	s_maxclients_field.visible_length = 3;
-
-	if (Cvar_VariableValue("maxclients") == 1)
-	{
-		strcpy(s_maxclients_field.buffer, "8");
-	}
-	else
-	{
-		Q_strlcpy(s_maxclients_field.buffer, Cvar_VariableString("maxclients"),
-			sizeof(s_maxclients_field.buffer));
-	}
+	Field_InitState(&s_maxclients_field,
+		Cvar_VariableValue("maxclients") == 1 ? "8" : Cvar_VariableString("maxclients"), 3, 3);
 
 	s_hostname_field.generic.type = MTYPE_FIELD;
 	s_hostname_field.generic.name = "hostname";
@@ -4816,11 +4800,8 @@ StartServer_MenuInit(void)
 	s_hostname_field.generic.x = 0;
 	s_hostname_field.generic.y = 90;
 	s_hostname_field.generic.statusbar = NULL;
-	s_hostname_field.length = 12;
-	s_hostname_field.visible_length = 12;
-	Q_strlcpy(s_hostname_field.buffer, Cvar_VariableString("hostname"),
-		sizeof(s_hostname_field.buffer));
-	s_hostname_field.cursor = strlen(s_hostname_field.buffer);
+	Field_InitState(&s_hostname_field,
+		Cvar_VariableString("hostname"), 12, 12);
 
 	s_startserver_dmoptions_action.generic.type = MTYPE_ACTION;
 	s_startserver_dmoptions_action.generic.name = " deathmatch flags";
@@ -5539,12 +5520,7 @@ AddressBook_MenuInit(void)
 		f->generic.x = 0;
 		f->generic.y = i * 18 + 0;
 		f->generic.localdata[0] = i;
-
-		f->length = 60;
-		f->visible_length = 30;
-
-		Q_strlcpy(f->buffer, adr->string, f->length);
-		f->cursor = strlen(f->buffer);
+		Field_InitState(f, adr->string, 60, 30);
 
 		Menu_AddItem(&s_addressbook_menu, f);
 	}
@@ -6316,11 +6292,7 @@ PlayerConfig_MenuInit(void)
 	s_player_name_field.generic.callback = NULL;
 	s_player_name_field.generic.x = 0;
 	s_player_name_field.generic.y = 0;
-	s_player_name_field.length = 20;
-	s_player_name_field.visible_length = 20;
-	Q_strlcpy(s_player_name_field.buffer, name->string,
-		sizeof(s_player_name_field.buffer));
-	s_player_name_field.cursor = strlen(name->string);
+	Field_InitState(&s_player_name_field, name->string, 20, 20);
 
 	s_player_icon_bitmap.generic.type = MTYPE_BITMAP;
 	s_player_icon_bitmap.generic.flags = QMF_INACTIVE;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -65,9 +65,6 @@ static void M_Menu_ControllerAltButtons_f(void);
 static void M_Menu_Quit_f(void);
 void M_Menu_Credits(void);
 
-static void M_DrawTextBox(int x, int y, int width, int lines);
-static void M_Print(int x, int y, const char *str);
-
 qboolean m_entersound; /* play after drawing a frame, so caching won't disrupt the sound */
 
 /* Maximal number of submenus */
@@ -76,68 +73,7 @@ qboolean m_entersound; /* play after drawing a frame, so caching won't disrupt t
 static menuframework_s *m_layers[MAX_MENU_DEPTH];
 static int m_menudepth;
 
-static const char *m_popup_string;
-static int m_popup_endtime;
-
-static void
-M_Popup(void)
-{
-	int width, lines;
-	int n;
-	const char *str;
-
-	if (!m_popup_string)
-	{
-		return;
-	}
-
-	if (m_popup_endtime && m_popup_endtime < cls.realtime)
-	{
-		m_popup_string = NULL;
-		return;
-	}
-
-	if (!R_EndWorldRenderpass())
-	{
-		return;
-	}
-
-	width = lines = n = 0;
-
-	for (str = m_popup_string; *str; str++)
-	{
-		if (*str == '\n')
-		{
-			lines++;
-			n = 0;
-		}
-		else
-		{
-			n++;
-			if (n > width)
-			{
-				width = n;
-			}
-		}
-	}
-
-	if (n)
-	{
-		lines++;
-	}
-
-	if (width)
-	{
-		int x, y;
-		width += 2;
-
-		x = (320 - (width + 2) * 8) / 2;
-		y = (240 - (lines + 2) * 8) / 3;
-
-		M_DrawTextBox(x, y, width, lines);
-		M_Print(x + 16, y + 8, m_popup_string);
-	}
-}
+static menupopup_s m_popup;
 
 static menuframework_s *
 M_GetActiveMenu(void)
@@ -373,9 +309,9 @@ Default_MenuKey(menuframework_s *m, int key)
 	menucommon_s *item;
 	int menu_key;
 
-	if (m_popup_string)
+	if (Menu_PopupActive(&m_popup))
 	{
-		m_popup_string = NULL;
+		Menu_ClosePopup(&m_popup);
 		return NULL;
 	}
 
@@ -439,41 +375,6 @@ Default_MenuKey(menuframework_s *m, int key)
 	return sound;
 }
 
-/*
- * Draws one solid graphics character cx and cy are in 320*240
- * coordinates, and will be centered on higher res screens.
- */
-static void
-M_DrawCharacter(int cx, int cy, int num)
-{
-	float scale = SCR_GetMenuScale();
-	Draw_CharScaled(cx + ((int)(viddef.width - 320 * scale) >> 1), cy + ((int)(viddef.height - 240 * scale) >> 1), num, scale);
-}
-
-static void
-M_Print(int x, int y, const char *str)
-{
-	int cx, cy;
-	float scale = SCR_GetMenuScale();
-
-	cx = x;
-	cy = y;
-	while (*str)
-	{
-		if (*str == '\n')
-		{
-			cx = x;
-			cy += 8;
-		}
-		else
-		{
-			M_DrawCharacter(cx * scale, cy * scale, (*str) + 128);
-			cx += 8;
-		}
-		str++;
-	}
-}
-
 /* Unsused, left for backward compability */
 void
 M_DrawPic(int x, int y, char *pic)
@@ -524,15 +425,15 @@ M_DrawTextBox(int x, int y, int width, int lines)
 	/* draw left side */
 	cx = x;
 	cy = y;
-	M_DrawCharacter(cx * scale, cy * scale, 1);
+	Menu_DrawCharacter(cx * scale, cy * scale, 1);
 
 	for (n = 0; n < lines; n++)
 	{
 		cy += 8;
-		M_DrawCharacter(cx * scale, cy * scale, 4);
+		Menu_DrawCharacter(cx * scale, cy * scale, 4);
 	}
 
-	M_DrawCharacter(cx * scale, cy * scale + 8 * scale, 7);
+	Menu_DrawCharacter(cx * scale, cy * scale + 8 * scale, 7);
 
 	/* draw middle */
 	cx += 8;
@@ -540,30 +441,30 @@ M_DrawTextBox(int x, int y, int width, int lines)
 	while (width > 0)
 	{
 		cy = y;
-		M_DrawCharacter(cx * scale, cy * scale, 2);
+		Menu_DrawCharacter(cx * scale, cy * scale, 2);
 
 		for (n = 0; n < lines; n++)
 		{
 			cy += 8;
-			M_DrawCharacter(cx * scale, cy * scale, 5);
+			Menu_DrawCharacter(cx * scale, cy * scale, 5);
 		}
 
-		M_DrawCharacter(cx * scale, cy *scale + 8 * scale, 8);
+		Menu_DrawCharacter(cx * scale, cy *scale + 8 * scale, 8);
 		width -= 1;
 		cx += 8;
 	}
 
 	/* draw right side */
 	cy = y;
-	M_DrawCharacter(cx * scale, cy * scale, 3);
+	Menu_DrawCharacter(cx * scale, cy * scale, 3);
 
 	for (n = 0; n < lines; n++)
 	{
 		cy += 8;
-		M_DrawCharacter(cx * scale, cy * scale, 6);
+		Menu_DrawCharacter(cx * scale, cy * scale, 6);
 	}
 
-	M_DrawCharacter(cx * scale, cy * scale + 8 * scale, 9);
+	Menu_DrawCharacter(cx * scale, cy * scale + 8 * scale, 9);
 }
 
 /*
@@ -1854,9 +1755,10 @@ CalibrateGyroFunc(void *unused)
 		return;
 	}
 
-	m_popup_string = "Calibrating, please wait...";
-	m_popup_endtime = cls.realtime + 4650;
-	M_Popup();
+	Menu_StartPopup(&m_popup,
+		"Calibrating, please wait...", 4650);
+
+	Menu_DrawPopup(320, 240, &m_popup);
 	R_EndFrame();
 	StartCalibration();
 }
@@ -1865,9 +1767,8 @@ void
 CalibrationFinishedCallback(void)
 {
 	Menu_SetStatusBar(&s_gyro_menu, NULL);
-	m_popup_string = "Calibration complete!";
-	m_popup_endtime = cls.realtime + 1900;
-	M_Popup();
+	Menu_StartPopup(&m_popup, "Calibration complete!", 1900);
+	Menu_DrawPopup(320, 240, &m_popup);
 	R_EndFrame();
 }
 
@@ -2121,7 +2022,7 @@ Gyro_MenuDraw(void)
 {
 	Menu_AdjustCursor(&s_gyro_menu, 1);
 	Menu_Draw(&s_gyro_menu);
-	M_Popup();
+	Menu_DrawPopup(320, 240, &m_popup);
 }
 
 static void
@@ -2614,11 +2515,12 @@ UpdateSoundBackendFunc(void *unused)
 {
 	Cvar_Set("s_openal", (s_options_quality_list.curvalue == 0)? "1":"0" );
 
-	m_popup_string = "Restarting the sound system. This\n"
-					 "could take up to a minute, so\n"
-					 "please be patient.";
-	m_popup_endtime = cls.realtime + 2000;
-	M_Popup();
+	Menu_StartPopup(&m_popup,
+		"Restarting the sound system. This\n"
+		"could take up to a minute, so\n"
+		"please be patient.",
+		2000);
+	Menu_DrawPopup(320, 240, &m_popup);
 
 	/* the text box won't show up unless we do a buffer swap */
 	R_EndFrame();
@@ -2837,7 +2739,7 @@ Options_MenuDraw(void)
 	M_Banner("m_banner_options");
 	Menu_AdjustCursor(&s_options_menu, 1);
 	Menu_Draw(&s_options_menu);
-	M_Popup();
+	Menu_DrawPopup(320, 240, &m_popup);
 }
 
 static void
@@ -3560,7 +3462,7 @@ Mods_MenuDraw(void)
 {
 	Menu_AdjustCursor(&s_mods_menu, 1);
 	Menu_Draw(&s_mods_menu);
-	M_Popup();
+	Menu_DrawPopup(320, 240, &m_popup);
 }
 
 static void
@@ -4101,20 +4003,23 @@ SaveGameCallback(void *self)
 
 	if (a->generic.localdata[0] == -1)
 	{
-		m_popup_string = "This slot is reserved for\n"
-						 "quicksaving, so please select\n"
-						 "another one.";
-		m_popup_endtime = cls.realtime + 2000;
-		M_Popup();
+		Menu_StartPopup(&m_popup,
+			"This slot is reserved for\n"
+			"quicksaving, so please select\n"
+			"another one.",
+			2000);
+		Menu_DrawPopup(320, 240, &m_popup);
 		return;
 	}
-	else if (a->generic.localdata[0] == 0)
+
+	if (a->generic.localdata[0] == 0)
 	{
-		m_popup_string = "This slot is reserved for\n"
-						 "autosaving, so please select\n"
-						 "another one.";
-		m_popup_endtime = cls.realtime + 2000;
-		M_Popup();
+		Menu_StartPopup(&m_popup,
+			"This slot is reserved for\n"
+			"autosaving, so please select\n"
+			"another one.",
+			2000);
+		Menu_DrawPopup(320, 240, &m_popup);
 		return;
 	}
 
@@ -4128,7 +4033,7 @@ SaveGame_MenuDraw(void)
 	M_Banner("m_banner_save_game");
 	Menu_AdjustCursor(&s_savegame_menu, 1);
 	Menu_Draw(&s_savegame_menu);
-	M_Popup();
+	Menu_DrawPopup(320, 240, &m_popup);
 }
 
 static void
@@ -4176,9 +4081,9 @@ SaveGame_MenuKey(menuframework_s *m, int key)
 {
 	int menu_key = Key_GetMenuKey(key);
 
-	if (m_popup_string)
+	if (Menu_PopupActive(&m_popup))
 	{
-		m_popup_string = NULL;
+		Menu_ClosePopup(&m_popup);
 		return NULL;
 	}
 
@@ -4348,11 +4253,12 @@ SearchLocalGames(void)
 		local_server_netadr_strings[i][0] = '\0';
 	}
 
-	m_popup_string = "Searching for local servers. This\n"
-					 "could take up to a minute, so\n"
-					 "please be patient.";
-	m_popup_endtime = cls.realtime + 2000;
-	M_Popup();
+	Menu_StartPopup(&m_popup,
+		"Searching for local servers. This\n"
+		"could take up to a minute, so\n"
+		"please be patient.",
+		2000);
+	Menu_DrawPopup(320, 240, &m_popup);
 
 	/* the text box won't show up unless we do a buffer swap */
 	R_EndFrame();
@@ -4427,7 +4333,7 @@ JoinServer_MenuDraw(void)
 {
 	M_Banner("m_banner_join_server");
 	Menu_Draw(&s_joinserver_menu);
-	M_Popup();
+	Menu_DrawPopup(320, 240, &m_popup);
 }
 
 static void

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -63,8 +63,10 @@ static void M_Menu_Joy_f(void);
 static void M_Menu_ControllerButtons_f(void);
 static void M_Menu_ControllerAltButtons_f(void);
 static void M_Menu_Quit_f(void);
-
 void M_Menu_Credits(void);
+
+static void M_DrawTextBox(int x, int y, int width, int lines);
+static void M_Print(int x, int y, const char *str);
 
 qboolean m_entersound; /* play after drawing a frame, so caching won't disrupt the sound */
 
@@ -73,6 +75,69 @@ qboolean m_entersound; /* play after drawing a frame, so caching won't disrupt t
 
 static menuframework_s *m_layers[MAX_MENU_DEPTH];
 static int m_menudepth;
+
+static const char *m_popup_string;
+static int m_popup_endtime;
+
+static void
+M_Popup(void)
+{
+	int width, lines;
+	int n;
+	const char *str;
+
+	if (!m_popup_string)
+	{
+		return;
+	}
+
+	if (m_popup_endtime && m_popup_endtime < cls.realtime)
+	{
+		m_popup_string = NULL;
+		return;
+	}
+
+	if (!R_EndWorldRenderpass())
+	{
+		return;
+	}
+
+	width = lines = n = 0;
+
+	for (str = m_popup_string; *str; str++)
+	{
+		if (*str == '\n')
+		{
+			lines++;
+			n = 0;
+		}
+		else
+		{
+			n++;
+			if (n > width)
+			{
+				width = n;
+			}
+		}
+	}
+
+	if (n)
+	{
+		lines++;
+	}
+
+	if (width)
+	{
+		int x, y;
+		width += 2;
+
+		x = (320 - (width + 2) * 8) / 2;
+		y = (240 - (lines + 2) * 8) / 3;
+
+		M_DrawTextBox(x, y, width, lines);
+		M_Print(x + 16, y + 8, m_popup_string);
+	}
+}
 
 static menuframework_s *
 M_GetActiveMenu(void)
@@ -308,17 +373,13 @@ Default_MenuKey(menuframework_s *m, int key)
 	menucommon_s *item;
 	int menu_key;
 
-	menu_key = Key_GetMenuKey(key);
-
-	if (!m)
+	if (m_popup_string)
 	{
-		if (menu_key == K_ESCAPE)
-		{
-			M_PopMenu(false);
-		}
-
+		m_popup_string = NULL;
 		return NULL;
 	}
+
+	menu_key = Key_GetMenuKey(key);
 
 	item = Menu_ItemAtCursor(m);
 
@@ -390,7 +451,7 @@ M_DrawCharacter(int cx, int cy, int num)
 }
 
 static void
-M_Print(int x, int y, char *str)
+M_Print(int x, int y, const char *str)
 {
 	int cx, cy;
 	float scale = SCR_GetMenuScale();
@@ -503,67 +564,6 @@ M_DrawTextBox(int x, int y, int width, int lines)
 	}
 
 	M_DrawCharacter(cx * scale, cy * scale + 8 * scale, 9);
-}
-
-static char *m_popup_string;
-static int m_popup_endtime;
-
-static void
-M_Popup(void)
-{
-	int width, lines;
-	int n;
-	char *str;
-
-	if (!m_popup_string)
-	{
-		return;
-	}
-
-	if (m_popup_endtime && m_popup_endtime < cls.realtime)
-	{
-		m_popup_string = NULL;
-		return;
-	}
-
-	if (!R_EndWorldRenderpass())
-	{
-		return;
-	}
-
-	width = lines = n = 0;
-	for (str = m_popup_string; *str; str++)
-	{
-		if (*str == '\n')
-		{
-			lines++;
-			n = 0;
-		}
-		else
-		{
-			n++;
-			if (n > width)
-			{
-				width = n;
-			}
-		}
-	}
-	if (n)
-	{
-		lines++;
-	}
-
-	if (width)
-	{
-		int x, y;
-		width += 2;
-
-		x = (320 - (width + 2) * 8) / 2;
-		y = (240 - (lines + 2) * 8) / 3;
-
-		M_DrawTextBox(x, y, width, lines);
-		M_Print(x + 16, y + 8, m_popup_string);
-	}
 }
 
 /*
@@ -746,18 +746,12 @@ M_Main_Draw(void)
 	}
 }
 
-static const char *
-M_Main_Key(int key)
-{
-	return Default_MenuKey(&s_main, key);
-}
-
 void
 M_Menu_Main_f(void)
 {
 	InitMainMenu();
 	s_main.draw = M_Main_Draw;
-	s_main.key  = M_Main_Key;
+	s_main.key  = Default_MenuKey;
 
 	Menu_AdjustCursor(&s_main, 1);
 
@@ -853,18 +847,12 @@ Multiplayer_MenuInit(void)
 	Menu_Center(&s_multiplayer_menu);
 }
 
-static const char *
-Multiplayer_MenuKey(int key)
-{
-	return Default_MenuKey(&s_multiplayer_menu, key);
-}
-
 static void
 M_Menu_Multiplayer_f(void)
 {
 	Multiplayer_MenuInit();
 	s_multiplayer_menu.draw = Multiplayer_MenuDraw;
-	s_multiplayer_menu.key  = Multiplayer_MenuKey;
+	s_multiplayer_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_multiplayer_menu);
 }
@@ -1102,9 +1090,9 @@ Keys_MenuDraw(void)
 }
 
 static const char *
-Keys_MenuKey(int key)
+Keys_MenuKey(menuframework_s *m, int key)
 {
-	menuaction_s *item = (menuaction_s *)Menu_ItemAtCursor(&s_keys_menu);
+	menuaction_s *item = (menuaction_s *)Menu_ItemAtCursor(m);
 
 	if (menukeyitem_bind)
 	{
@@ -1118,7 +1106,7 @@ Keys_MenuKey(int key)
 			Cbuf_InsertText(cmd);
 		}
 
-		Menu_SetStatusBar(&s_keys_menu, "ENTER to change, BACKSPACE to clear");
+		Menu_SetStatusBar(m, "ENTER to change, BACKSPACE to clear");
 		menukeyitem_bind = false;
 		return menu_out_sound;
 	}
@@ -1133,7 +1121,7 @@ Keys_MenuKey(int key)
 		M_UnbindCommand(bindnames[item->generic.localdata[0]][0], KEYS_KEYBOARD_MOUSE);
 		return menu_out_sound;
 	default:
-		return Default_MenuKey(&s_keys_menu, key);
+		return Default_MenuKey(m, key);
 	}
 }
 
@@ -1254,9 +1242,9 @@ MultiplayerKeys_MenuDraw(void)
 }
 
 static const char *
-MultiplayerKeys_MenuKey(int key)
+MultiplayerKeys_MenuKey(menuframework_s *m, int key)
 {
-	menuaction_s *item = (menuaction_s *)Menu_ItemAtCursor(&s_multiplayer_keys_menu);
+	menuaction_s *item = (menuaction_s *)Menu_ItemAtCursor(m);
 
 	if (menukeyitem_bind)
 	{
@@ -1270,7 +1258,7 @@ MultiplayerKeys_MenuKey(int key)
 			Cbuf_InsertText(cmd);
 		}
 
-		Menu_SetStatusBar(&s_multiplayer_keys_menu, "ENTER to change, BACKSPACE to clear");
+		Menu_SetStatusBar(m, "ENTER to change, BACKSPACE to clear");
 		menukeyitem_bind = false;
 		return menu_out_sound;
 	}
@@ -1285,7 +1273,7 @@ MultiplayerKeys_MenuKey(int key)
 		M_UnbindCommand(multiplayer_key_bindnames[item->generic.localdata[0]][0], KEYS_ALL);
 		return menu_out_sound;
 	default:
-		return Default_MenuKey(&s_multiplayer_keys_menu, key);
+		return Default_MenuKey(m, key);
 	}
 }
 
@@ -1451,9 +1439,9 @@ ControllerButtons_MenuDraw(void)
 }
 
 static const char *
-ControllerButtons_MenuKey(int key)
+ControllerButtons_MenuKey(menuframework_s *m, int key)
 {
-	menuaction_s *item = (menuaction_s *)Menu_ItemAtCursor(&s_controller_buttons_menu);
+	menuaction_s *item = (menuaction_s *)Menu_ItemAtCursor(m);
 
 	if (menukeyitem_bind)
 	{
@@ -1467,7 +1455,7 @@ ControllerButtons_MenuKey(int key)
 			Cbuf_InsertText(cmd);
 		}
 
-		GamepadMenu_StatusPrompt(&s_controller_buttons_menu);
+		GamepadMenu_StatusPrompt(m);
 		menukeyitem_bind = false;
 		return menu_out_sound;
 	}
@@ -1482,7 +1470,7 @@ ControllerButtons_MenuKey(int key)
 			M_UnbindCommand(controller_bindnames[item->generic.localdata[0]][0], KEYS_CONTROLLER);
 			return menu_out_sound;
 		default:
-			return Default_MenuKey(&s_controller_buttons_menu, key);
+			return Default_MenuKey(m, key);
 	}
 }
 
@@ -1624,9 +1612,9 @@ ControllerAltButtons_MenuDraw(void)
 }
 
 static const char *
-ControllerAltButtons_MenuKey(int key)
+ControllerAltButtons_MenuKey(menuframework_s *m, int key)
 {
-	menuaction_s *item = (menuaction_s *)Menu_ItemAtCursor(&s_controller_alt_buttons_menu);
+	menuaction_s *item = (menuaction_s *)Menu_ItemAtCursor(m);
 
 	if (menukeyitem_bind)
 	{
@@ -1641,7 +1629,7 @@ ControllerAltButtons_MenuKey(int key)
 			Cbuf_InsertText(cmd);
 		}
 
-		GamepadMenu_StatusPrompt(&s_controller_alt_buttons_menu);
+		GamepadMenu_StatusPrompt(m);
 		menukeyitem_bind = false;
 		return menu_out_sound;
 	}
@@ -1656,7 +1644,7 @@ ControllerAltButtons_MenuKey(int key)
 			M_UnbindCommand(controller_alt_bindnames[item->generic.localdata[0]][0], KEYS_CONTROLLER_ALT);
 			return menu_out_sound;
 		default:
-			return Default_MenuKey(&s_controller_alt_buttons_menu, key);
+			return Default_MenuKey(m, key);
 	}
 }
 
@@ -1822,18 +1810,12 @@ Stick_MenuDraw(void)
 	Menu_Draw(&s_sticks_config_menu);
 }
 
-static const char *
-Stick_MenuKey(int key)
-{
-	return Default_MenuKey(&s_sticks_config_menu, key);
-}
-
 static void
 M_Menu_Stick_f(void)
 {
 	Stick_MenuInit();
 	s_sticks_config_menu.draw = Stick_MenuDraw;
-	s_sticks_config_menu.key  = Stick_MenuKey;
+	s_sticks_config_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_sticks_config_menu);
 }
@@ -2142,18 +2124,12 @@ Gyro_MenuDraw(void)
 	M_Popup();
 }
 
-static const char *
-Gyro_MenuKey(int key)
-{
-	return Default_MenuKey(&s_gyro_menu, key);
-}
-
 static void
 M_Menu_Gyro_f(void)
 {
 	Gyro_MenuInit();
 	s_gyro_menu.draw = Gyro_MenuDraw;
-	s_gyro_menu.key  = Gyro_MenuKey;
+	s_gyro_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_gyro_menu);
 }
@@ -2416,18 +2392,12 @@ Joy_MenuDraw(void)
 	Menu_Draw(&s_joy_menu);
 }
 
-static const char *
-Joy_MenuKey(int key)
-{
-	return Default_MenuKey(&s_joy_menu, key);
-}
-
 static void
 M_Menu_Joy_f(void)
 {
 	Joy_MenuInit();
 	s_joy_menu.draw = Joy_MenuDraw;
-	s_joy_menu.key  = Joy_MenuKey;
+	s_joy_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_joy_menu);
 }
@@ -2870,23 +2840,12 @@ Options_MenuDraw(void)
 	M_Popup();
 }
 
-static const char *
-Options_MenuKey(int key)
-{
-	if (m_popup_string)
-	{
-		m_popup_string = NULL;
-		return NULL;
-	}
-	return Default_MenuKey(&s_options_menu, key);
-}
-
 static void
 M_Menu_Options_f(void)
 {
 	Options_MenuInit();
 	s_options_menu.draw = Options_MenuDraw;
-	s_options_menu.key  = Options_MenuKey;
+	s_options_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_options_menu);
 }
@@ -3317,7 +3276,7 @@ M_Credits_Draw(void)
 }
 
 static const char *
-M_Credits_Key(int key)
+M_Credits_Key(menuframework_s *m, int key)
 {
 	key = Key_GetMenuKey(key);
 	if (key == K_ESCAPE)
@@ -3604,18 +3563,12 @@ Mods_MenuDraw(void)
 	M_Popup();
 }
 
-static const char *
-Mods_MenuKey(int key)
-{
-	return Default_MenuKey(&s_mods_menu, key);
-}
-
 static void
 M_Menu_Mods_f(void)
 {
 	Mods_MenuInit();
 	s_mods_menu.draw = Mods_MenuDraw;
-	s_mods_menu.key  = Mods_MenuKey;
+	s_mods_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_mods_menu);
 }
@@ -3799,18 +3752,12 @@ Game_MenuDraw(void)
 	Menu_Draw(&s_game_menu);
 }
 
-static const char *
-Game_MenuKey(int key)
-{
-	return Default_MenuKey(&s_game_menu, key);
-}
-
 static void
 M_Menu_Game_f(void)
 {
 	Game_MenuInit();
 	s_game_menu.draw = Game_MenuDraw;
-	s_game_menu.key  = Game_MenuKey;
+	s_game_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_game_menu);
 	m_game_cursor = 1;
@@ -4079,9 +4026,8 @@ LoadGame_MenuDraw(void)
 }
 
 static const char *
-LoadGame_MenuKey(int key)
+LoadGame_MenuKey(menuframework_s *m, int key)
 {
-	static menuframework_s *m = &s_loadgame_menu;
 	int menu_key = Key_GetMenuKey(key);
 
 	if (menukeyitem_delete)
@@ -4226,9 +4172,8 @@ SaveGame_MenuInit(void)
 }
 
 static const char *
-SaveGame_MenuKey(int key)
+SaveGame_MenuKey(menuframework_s *m, int key)
 {
-	static menuframework_s *m = &s_savegame_menu;
 	int menu_key = Key_GetMenuKey(key);
 
 	if (m_popup_string)
@@ -4485,23 +4430,12 @@ JoinServer_MenuDraw(void)
 	M_Popup();
 }
 
-static const char *
-JoinServer_MenuKey(int key)
-{
-	if (m_popup_string)
-	{
-		m_popup_string = NULL;
-		return NULL;
-	}
-	return Default_MenuKey(&s_joinserver_menu, key);
-}
-
 static void
 M_Menu_JoinServer_f(void)
 {
 	JoinServer_MenuInit();
 	s_joinserver_menu.draw = JoinServer_MenuDraw;
-	s_joinserver_menu.key  = JoinServer_MenuKey;
+	s_joinserver_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_joinserver_menu);
 }
@@ -5107,18 +5041,12 @@ StartServer_MenuDraw(void)
 	Menu_Draw(&s_startserver_menu);
 }
 
-static const char *
-StartServer_MenuKey(int key)
-{
-	return Default_MenuKey(&s_startserver_menu, key);
-}
-
 static void
 M_Menu_StartServer_f(void)
 {
 	StartServer_MenuInit();
 	s_startserver_menu.draw = StartServer_MenuDraw;
-	s_startserver_menu.key  = StartServer_MenuKey;
+	s_startserver_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_startserver_menu);
 }
@@ -5595,18 +5523,12 @@ DMOptions_MenuDraw(void)
 	Menu_Draw(&s_dmoptions_menu);
 }
 
-static const char *
-DMOptions_MenuKey(int key)
-{
-	return Default_MenuKey(&s_dmoptions_menu, key);
-}
-
 static void
 M_Menu_DMOptions_f(void)
 {
 	DMOptions_MenuInit();
 	s_dmoptions_menu.draw = DMOptions_MenuDraw;
-	s_dmoptions_menu.key  = DMOptions_MenuKey;
+	s_dmoptions_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_dmoptions_menu);
 }
@@ -5763,18 +5685,12 @@ DownloadOptions_MenuDraw(void)
 	Menu_Draw(&s_downloadoptions_menu);
 }
 
-static const char *
-DownloadOptions_MenuKey(int key)
-{
-	return Default_MenuKey(&s_downloadoptions_menu, key);
-}
-
 static void
 M_Menu_DownloadOptions_f(void)
 {
 	DownloadOptions_MenuInit();
 	s_downloadoptions_menu.draw = DownloadOptions_MenuDraw;
-	s_downloadoptions_menu.key  = DownloadOptions_MenuKey;
+	s_downloadoptions_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_downloadoptions_menu);
 }
@@ -5826,7 +5742,7 @@ AddressBook_MenuInit(void)
 }
 
 static const char *
-AddressBook_MenuKey(int key)
+AddressBook_MenuKey(menuframework_s *m, int key)
 {
 	if (key == K_ESCAPE)
 	{
@@ -5840,7 +5756,7 @@ AddressBook_MenuKey(int key)
 		}
 	}
 
-	return Default_MenuKey(&s_addressbook_menu, key);
+	return Default_MenuKey(m, key);
 }
 
 static void
@@ -6834,7 +6750,7 @@ PlayerConfig_MenuDraw(void)
 }
 
 static const char *
-PlayerConfig_MenuKey(int key)
+PlayerConfig_MenuKey(menuframework_s *m, int key)
 {
 	key = Key_GetMenuKey(key);
 	if (key == K_ESCAPE)
@@ -6857,7 +6773,7 @@ PlayerConfig_MenuKey(int key)
 		PlayerModelFree();          // free player skins, models and directories
 	}
 
-	return Default_MenuKey(&s_player_config_menu, key);
+	return Default_MenuKey(m, key);
 }
 
 static void
@@ -6883,7 +6799,7 @@ M_Menu_PlayerConfig_f(void)
 menuframework_s s_quit_menu;
 
 static const char *
-M_Quit_Key(int key)
+M_Quit_Key(menuframework_s *m, int key)
 {
 	int menu_key = Key_GetMenuKey(key);
 	switch (menu_key)
@@ -7026,7 +6942,7 @@ M_Draw(void)
 void
 M_Keydown(int key)
 {
-	const menuframework_s *menu;
+	menuframework_s *menu;
 
 	menu = M_GetActiveMenu();
 
@@ -7034,7 +6950,7 @@ M_Keydown(int key)
 	{
 		const char *s;
 
-		s = menu->key(key);
+		s = menu->key(menu, key);
 
 		if (s)
 		{

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -287,8 +287,10 @@ Key_GetMenuKey(int key)
 
 		case K_KP_DEL:
 			if (IN_NumpadIsOn() == true) { break; }
-		case K_BACKSPACE:
 		case K_DEL:
+			return K_DEL;
+
+		case K_BACKSPACE:
 		case K_BTN_NORTH:
 			return K_BACKSPACE;
 
@@ -1018,6 +1020,7 @@ Keys_MenuKey(menuframework_s *m, int key)
 	case K_ENTER:
 		KeyBindingFunc(item);
 		return menu_in_sound;
+	case K_DEL:
 	case K_BACKSPACE: /* delete bindings */
 		M_UnbindCommand(bindnames[item->generic.localdata[0]][0], KEYS_KEYBOARD_MOUSE);
 		return menu_out_sound;
@@ -1163,6 +1166,7 @@ MultiplayerKeys_MenuKey(menuframework_s *m, int key)
 	case K_ENTER:
 		MultiplayerKeyBindingFunc(item);
 		return menu_in_sound;
+	case K_DEL:
 	case K_BACKSPACE: /* delete bindings */
 		M_UnbindCommand(multiplayer_key_bindnames[item->generic.localdata[0]][0], KEYS_ALL);
 		return menu_out_sound;
@@ -1353,6 +1357,7 @@ ControllerButtons_MenuKey(menuframework_s *m, int key)
 		case K_ENTER:
 			ControllerButtonBindingFunc(item);
 			return menu_in_sound;
+		case K_DEL:
 		case K_BACKSPACE:
 			M_UnbindCommand(controller_bindnames[item->generic.localdata[0]][0], KEYS_CONTROLLER);
 			return menu_out_sound;
@@ -1520,6 +1525,7 @@ ControllerAltButtons_MenuKey(menuframework_s *m, int key)
 		case K_ENTER:
 			ControllerAltButtonBindingFunc(item);
 			return menu_in_sound;
+		case K_DEL:
 		case K_BACKSPACE:
 			M_UnbindCommand(controller_alt_bindnames[item->generic.localdata[0]][0], KEYS_CONTROLLER_ALT);
 			return menu_out_sound;
@@ -3896,6 +3902,7 @@ LoadGame_MenuKey(menuframework_s *m, int key)
 		LoadGame_MenuInit();
 		return menu_move_sound;
 
+	case K_DEL:
 	case K_BACKSPACE:
 		PromptDeleteSaveFunc(m);
 		return menu_move_sound;
@@ -4043,6 +4050,7 @@ SaveGame_MenuKey(menuframework_s *m, int key)
 		SaveGame_MenuInit();
 		return menu_move_sound;
 
+	case K_DEL:
 	case K_BACKSPACE:
 		PromptDeleteSaveFunc(m);
 		return menu_move_sound;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -71,15 +71,15 @@ qboolean m_entersound; /* play after drawing a frame, so caching won't disrupt t
 /* Maximal number of submenus */
 #define MAX_MENU_DEPTH 8
 
-typedef struct
-{
-	void (*draw)(void);
-	const char *(*key)(int k);
-} menulayer_t;
-
-static menulayer_t m_layers[MAX_MENU_DEPTH];
-static menulayer_t m_active;		/* active menu layer */
+static menuframework_s *m_layers[MAX_MENU_DEPTH];
 static int m_menudepth;
+
+static menuframework_s *
+M_GetActiveMenu(void)
+{
+	return ((m_menudepth > 0) && (m_menudepth < MAX_MENU_DEPTH)) ?
+		m_layers[m_menudepth - 1] : NULL;
+}
 
 static qboolean
 M_IsGame(const char *gamename)
@@ -109,62 +109,39 @@ void
 M_ForceMenuOff(void)
 {
 	cls.key_dest = key_game;
-	m_active.draw = NULL;
-	m_active.key  = NULL;
 	m_menudepth = 0;
 	Key_MarkAllUp();
 	Cvar_Set("paused", "0");
 }
 
 static void
-M_PopMenu(void)
+M_PopMenu(qboolean silent)
 {
-	S_StartLocalSound(menu_out_sound);
-
-	if (m_menudepth < 1)
+	if (m_menudepth <= 0)
 	{
-		Com_Error(ERR_FATAL, "%s: depth < 1", __func__);
+		M_ForceMenuOff();
 		return;
 	}
 
 	m_menudepth--;
 
-	m_active.draw = m_layers[m_menudepth].draw;
-	m_active.key  = m_layers[m_menudepth].key;
+	if (silent)
+	{
+		return;
+	}
+
+	S_StartLocalSound(menu_out_sound);
 
 	if (!m_menudepth)
 	{
 		M_ForceMenuOff();
+
 		/* play music */
 		if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
 				OGG_Status() == PAUSE && cl.attractloop == false)
 		{
 			Cbuf_AddText("ogg toggle\n");
 		}
-	}
-}
-
-// Similar to M_PopMenu but silent and doesn't toggle music or paused state
-static void
-M_PopMenuSilent(void)
-{
-	if (m_menudepth < 1)
-	{
-		Com_Error(ERR_FATAL, "%s: depth < 1", __func__);
-		return;
-	}
-
-	m_menudepth--;
-
-	if (m_menudepth)
-	{
-		m_active.draw = m_layers[m_menudepth].draw;
-		m_active.key  = m_layers[m_menudepth].key;
-	}
-	else
-	{
-		m_active.draw = NULL;
-		m_active.key  = NULL;
 	}
 }
 
@@ -219,9 +196,9 @@ M_PushMenu(menuframework_s* menu)
 
 	/* if this menu is already open (and on top),
 	   close it => toggling behaviour */
-	if ((m_active.draw == menu->draw) && (m_active.key  == menu->key))
+	if (M_GetActiveMenu() == menu)
 	{
-		M_PopMenu();
+		M_PopMenu(false);
 		return;
 	}
 
@@ -229,7 +206,7 @@ M_PushMenu(menuframework_s* menu)
 	   that level to avoid stacking menus by hotkeys */
 	for (i = 0; i < m_menudepth; i++)
 	{
-		if ((m_layers[i].draw == menu->draw) && (m_layers[i].key  == menu->key))
+		if (m_layers[i] == menu)
 		{
 			alreadyPresent = 1;
 			break;
@@ -239,7 +216,7 @@ M_PushMenu(menuframework_s* menu)
 	/* menu was already opened further down the stack */
 	while (alreadyPresent && i <= m_menudepth)
 	{
-		M_PopMenu(); /* decrements m_menudepth */
+		M_PopMenu(false);
 	}
 
 	if (m_menudepth >= MAX_MENU_DEPTH)
@@ -248,12 +225,8 @@ M_PushMenu(menuframework_s* menu)
 		return;
 	}
 
-	m_layers[m_menudepth].draw = m_active.draw;
-	m_layers[m_menudepth].key  = m_active.key;
+	m_layers[m_menudepth] = menu;
 	m_menudepth++;
-
-	m_active.draw = menu->draw;
-	m_active.key  = menu->key;
 
 	m_entersound = true;
 
@@ -341,7 +314,7 @@ Default_MenuKey(menuframework_s *m, int key)
 	{
 		if (menu_key == K_ESCAPE)
 		{
-			M_PopMenu();
+			M_PopMenu(false);
 		}
 
 		return NULL;
@@ -363,7 +336,7 @@ Default_MenuKey(menuframework_s *m, int key)
 	{
 		case K_ESCAPE:
 			Field_ResetCursor(m);
-			M_PopMenu();
+			M_PopMenu(false);
 			break;
 
 		case K_UPARROW:
@@ -1928,7 +1901,7 @@ GyroSpaceFunc(void *unused)
 	Cvar_SetValue("gyro_space", s_gyro_space_box.curvalue);
 
 	// Force the menu to refresh.
-	M_PopMenuSilent();
+	M_PopMenu(true);
 	M_Menu_Gyro_f();
 }
 
@@ -1944,7 +1917,7 @@ GyroAccelerationFunc(void *unused)
 	Cvar_SetValue("gyro_acceleration", s_gyro_acceleration_box.curvalue);
 
 	// Force the menu to refresh.
-	M_PopMenuSilent();
+	M_PopMenu(true);
 	M_Menu_Gyro_f();
 }
 
@@ -2209,7 +2182,7 @@ extern qboolean IN_MatchJoyPreset(void);
 static void
 RefreshJoyMenuFunc(void *unused)
 {
-	M_PopMenuSilent();
+	M_PopMenu(true);
 	M_Menu_Joy_f();
 }
 
@@ -3353,7 +3326,7 @@ M_Credits_Key(int key)
 		{
 			FS_FreeFile(creditsBuffer);
 		}
-		M_PopMenu();
+		M_PopMenu(false);
 	}
 
 	return menu_out_sound;
@@ -6918,7 +6891,7 @@ M_Quit_Key(int key)
 	case K_ESCAPE:
 	case 'n':
 	case 'N':
-		M_PopMenu();
+		M_PopMenu(false);
 		break;
 
 	case K_ENTER:
@@ -7013,6 +6986,8 @@ M_Init(void)
 void
 M_Draw(void)
 {
+	const menuframework_s *menu;
+
 	if (cls.key_dest != key_menu)
 	{
 		return;
@@ -7032,9 +7007,10 @@ M_Draw(void)
 		Draw_FadeScreen();
 	}
 
-	if (m_active.draw)
+	menu = M_GetActiveMenu();
+	if (menu && menu->draw)
 	{
-		m_active.draw();
+		menu->draw();
 	}
 
 	/* delay playing the enter sound until after the
@@ -7050,11 +7026,15 @@ M_Draw(void)
 void
 M_Keydown(int key)
 {
-	if (m_active.key)
+	const menuframework_s *menu;
+
+	menu = M_GetActiveMenu();
+
+	if (menu && menu->key)
 	{
 		const char *s;
 
-		s = m_active.key(key);
+		s = menu->key(key);
 
 		if (s)
 		{

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -3168,12 +3168,13 @@ static const char *
 M_Credits_Key(menuframework_s *m, int key)
 {
 	key = Key_GetMenuKey(key);
+
 	if (key == K_ESCAPE)
 	{
 		M_PopMenu(false);
 	}
 
-	return menu_out_sound;
+	return NULL;
 }
 
 static void

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -4707,6 +4707,8 @@ GetCombinedMapsList(int *nummaps)
 static void
 StartServer_MenuInit(void)
 {
+	int y;
+
 	static const char *dm_coop_names[] =
 	{
 		"deathmatch",
@@ -4740,35 +4742,34 @@ StartServer_MenuInit(void)
 
 	/* initialize the menu stuff */
 	s_startserver_menu.x = (int)(viddef.width * 0.50f);
+	s_startserver_menu.banner = "m_banner_start_server";
 	s_startserver_menu.nitems = 0;
 
+	y = 18;
 	s_startmap_list.generic.type = MTYPE_SPINCONTROL;
 	s_startmap_list.generic.x = 0;
-
-	if (M_IsGame("ctf"))
-		s_startmap_list.generic.y = -8;
-	else
-		s_startmap_list.generic.y = 0;
-
+	s_startmap_list.generic.y = y;
 	s_startmap_list.generic.name = "initial map";
 	s_startmap_list.itemnames = (const char **)mapnames;
 
 	if (M_IsGame("ctf"))
 	{
+		y += 26;
 		s_capturelimit_field.generic.type = MTYPE_FIELD;
 		s_capturelimit_field.generic.name = "capture limit";
 		s_capturelimit_field.generic.flags = QMF_NUMBERSONLY;
 		s_capturelimit_field.generic.x = 0;
-		s_capturelimit_field.generic.y = 18;
+		s_capturelimit_field.generic.y = y;
 		s_capturelimit_field.generic.statusbar = "0 = no limit";
 		Field_InitState(&s_capturelimit_field,
 			Cvar_VariableString("capturelimit"), 3, 3);
 	}
 	else
 	{
+		y += 20;
 		s_rules_box.generic.type = MTYPE_SPINCONTROL;
 		s_rules_box.generic.x = 0;
-		s_rules_box.generic.y = 20;
+		s_rules_box.generic.y = y;
 		s_rules_box.generic.name = "rules";
 
 		/* Ground Zero games only available with rogue game */
@@ -4793,20 +4794,22 @@ StartServer_MenuInit(void)
 		s_rules_box.generic.callback = RulesChangeFunc;
 	}
 
+	y += 18;
 	s_timelimit_field.generic.type = MTYPE_FIELD;
 	s_timelimit_field.generic.name = "time limit";
 	s_timelimit_field.generic.flags = QMF_NUMBERSONLY;
 	s_timelimit_field.generic.x = 0;
-	s_timelimit_field.generic.y = 36;
+	s_timelimit_field.generic.y = y;
 	s_timelimit_field.generic.statusbar = "0 = no limit";
 	Field_InitState(&s_timelimit_field,
 		Cvar_VariableString("timelimit"), 3, 3);
 
+	y += 18;
 	s_fraglimit_field.generic.type = MTYPE_FIELD;
 	s_fraglimit_field.generic.name = "frag limit";
 	s_fraglimit_field.generic.flags = QMF_NUMBERSONLY;
 	s_fraglimit_field.generic.x = 0;
-	s_fraglimit_field.generic.y = 54;
+	s_fraglimit_field.generic.y = y;
 	s_fraglimit_field.generic.statusbar = "0 = no limit";
 	Field_InitState(&s_fraglimit_field,
 		Cvar_VariableString("fraglimit"), 3, 3);
@@ -4815,37 +4818,41 @@ StartServer_MenuInit(void)
 	   the game. If maxclients is only "1" then we should default the menu
 	   option to 8 players, otherwise use whatever its current value is.
 	   Clamping will be done when the server is actually started. */
+	y += 18;
 	s_maxclients_field.generic.type = MTYPE_FIELD;
 	s_maxclients_field.generic.name = "max players";
 	s_maxclients_field.generic.flags = QMF_NUMBERSONLY;
 	s_maxclients_field.generic.x = 0;
-	s_maxclients_field.generic.y = 72;
+	s_maxclients_field.generic.y = y;
 	s_maxclients_field.generic.statusbar = NULL;
 	Field_InitState(&s_maxclients_field,
 		Cvar_VariableValue("maxclients") == 1 ? "8" : Cvar_VariableString("maxclients"), 3, 3);
 
+	y += 18;
 	s_hostname_field.generic.type = MTYPE_FIELD;
 	s_hostname_field.generic.name = "hostname";
 	s_hostname_field.generic.flags = 0;
 	s_hostname_field.generic.x = 0;
-	s_hostname_field.generic.y = 90;
+	s_hostname_field.generic.y = y;
 	s_hostname_field.generic.statusbar = NULL;
 	Field_InitState(&s_hostname_field,
 		Cvar_VariableString("hostname"), 12, 12);
 
+	y += 18;
 	s_startserver_dmoptions_action.generic.type = MTYPE_ACTION;
 	s_startserver_dmoptions_action.generic.name = " deathmatch flags";
 	s_startserver_dmoptions_action.generic.flags = QMF_LEFT_JUSTIFY;
 	s_startserver_dmoptions_action.generic.x = 24 * scale;
-	s_startserver_dmoptions_action.generic.y = 108;
+	s_startserver_dmoptions_action.generic.y = y;
 	s_startserver_dmoptions_action.generic.statusbar = NULL;
 	s_startserver_dmoptions_action.generic.callback = DMOptionsFunc;
 
+	y += 20;
 	s_startserver_start_action.generic.type = MTYPE_ACTION;
 	s_startserver_start_action.generic.name = " begin";
 	s_startserver_start_action.generic.flags = QMF_LEFT_JUSTIFY;
 	s_startserver_start_action.generic.x = 24 * scale;
-	s_startserver_start_action.generic.y = 128;
+	s_startserver_start_action.generic.y = y;
 	s_startserver_start_action.generic.callback = StartServerActionFunc;
 
 	Menu_AddItem(&s_startserver_menu, &s_startmap_list);

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -116,8 +116,21 @@ M_Banner(const char *name)
 void
 M_ForceMenuOff(void)
 {
-	cls.key_dest = key_game;
+	int i;
+
+	for (i = m_menudepth - 1; i >= 0; i--)
+	{
+		menuframework_s *menu = m_layers[i];
+
+		if (menu && menu->close)
+		{
+			menu->close(menu);
+		}
+	}
+
 	m_menudepth = 0;
+
+	cls.key_dest = key_game;
 	Key_MarkAllUp();
 	Cvar_Set("paused", "0");
 }
@@ -125,10 +138,19 @@ M_ForceMenuOff(void)
 static void
 M_PopMenu(qboolean silent)
 {
+	menuframework_s *menu;
+
 	if (m_menudepth <= 0)
 	{
 		M_ForceMenuOff();
 		return;
+	}
+
+	menu = M_GetActiveMenu();
+
+	if (menu && menu->close)
+	{
+		menu->close(menu);
 	}
 
 	m_menudepth--;
@@ -3132,16 +3154,22 @@ M_Credits_Draw(menuframework_s *m)
 	}
 }
 
+static void
+M_Credits_Close(menuframework_s *m)
+{
+	if (creditsBuffer)
+	{
+		FS_FreeFile(creditsBuffer);
+		creditsBuffer = NULL;
+	}
+}
+
 static const char *
 M_Credits_Key(menuframework_s *m, int key)
 {
 	key = Key_GetMenuKey(key);
 	if (key == K_ESCAPE)
 	{
-		if (creditsBuffer)
-		{
-			FS_FreeFile(creditsBuffer);
-		}
 		M_PopMenu(false);
 	}
 
@@ -3221,8 +3249,9 @@ M_Menu_Credits_f(void)
 
 	credits_start_time = cls.realtime;
 
-	s_credits.draw = M_Credits_Draw;
-	s_credits.key  = M_Credits_Key;
+	s_credits.draw  = M_Credits_Draw;
+	s_credits.key   = M_Credits_Key;
+	s_credits.close = M_Credits_Close;
 
 	M_PushMenu(&s_credits);
 }
@@ -5526,30 +5555,27 @@ AddressBook_MenuInit(void)
 	}
 }
 
-static const char *
-AddressBook_MenuKey(menuframework_s *m, int key)
+static void
+AddressBook_MenuClose(menuframework_s *m)
 {
-	if (key == K_ESCAPE)
+	int index;
+
+	for (index = 0; index < NUM_ADDRESSBOOK_ENTRIES; index++)
 	{
-		int index;
 		char buffer[20];
 
-		for (index = 0; index < NUM_ADDRESSBOOK_ENTRIES; index++)
-		{
-			Com_sprintf(buffer, sizeof(buffer), "adr%d", index);
-			Cvar_Set(buffer, s_addressbook_fields[index].buffer);
-		}
+		Com_sprintf(buffer, sizeof(buffer), "adr%d", index);
+		Cvar_Set(buffer, s_addressbook_fields[index].buffer);
 	}
-
-	return Default_MenuKey(m, key);
 }
 
 static void
 M_Menu_AddressBook_f(void)
 {
 	AddressBook_MenuInit();
-	s_addressbook_menu.draw = Default_MenuDraw;
-	s_addressbook_menu.key  = AddressBook_MenuKey;
+	s_addressbook_menu.draw  = Default_MenuDraw;
+	s_addressbook_menu.key   = Default_MenuKey;
+	s_addressbook_menu.close = AddressBook_MenuClose;
 
 	M_PushMenu(&s_addressbook_menu);
 }
@@ -6523,31 +6549,25 @@ PlayerConfig_MenuDraw(menuframework_s *m)
 	}
 }
 
-static const char *
-PlayerConfig_MenuKey(menuframework_s *m, int key)
+static void
+PlayerConfig_MenuClose(menuframework_s *m)
 {
-	key = Key_GetMenuKey(key);
-	if (key == K_ESCAPE)
-	{
-		const char* name = NULL;
-		char skin[MAX_QPATH];
-		char* mdl = NULL;
-		char* img = NULL;
+	const char* name = NULL;
+	char skin[MAX_QPATH];
+	char* mdl = NULL;
+	char* img = NULL;
 
-		name = s_player_name_field.buffer;
-		mdl = s_modelname.data[s_player_model_box.curvalue];
-		img = s_skinnames[s_player_model_box.curvalue].data[s_player_skin_box.curvalue];
+	name = s_player_name_field.buffer;
+	mdl = s_modelname.data[s_player_model_box.curvalue];
+	img = s_skinnames[s_player_model_box.curvalue].data[s_player_skin_box.curvalue];
 
-		Com_sprintf(skin, MAX_QPATH, "%s/%s", mdl, img);
+	Com_sprintf(skin, MAX_QPATH, "%s/%s", mdl, img);
 
-		// set <name> and <model dir>/<skin>
-		Cvar_Set("name", name);
-		Cvar_Set("skin", skin);
+	// set <name> and <model dir>/<skin>
+	Cvar_Set("name", name);
+	Cvar_Set("skin", skin);
 
-		PlayerModelFree();          // free player skins, models and directories
-	}
-
-	return Default_MenuKey(m, key);
+	PlayerModelFree();          // free player skins, models and directories
 }
 
 static void
@@ -6560,8 +6580,9 @@ M_Menu_PlayerConfig_f(void)
 	}
 
 	Menu_SetStatusBar(&s_multiplayer_menu, NULL);
-	s_player_config_menu.draw = PlayerConfig_MenuDraw;
-	s_player_config_menu.key  = PlayerConfig_MenuKey;
+	s_player_config_menu.draw  = PlayerConfig_MenuDraw;
+	s_player_config_menu.key   = Default_MenuKey;
+	s_player_config_menu.close = PlayerConfig_MenuClose;
 
 	M_PushMenu(&s_player_config_menu);
 }

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -96,11 +96,18 @@ M_IsGame(const char *gamename)
 	return false;
 }
 
-void
+static void
 M_Banner(const char *name)
 {
 	int w, h;
-	float scale = SCR_GetMenuScale();
+	float scale;
+
+	if (!name)
+	{
+		return;
+	}
+
+	scale = SCR_GetMenuScale();
 
 	Draw_GetPicSize(&w, &h, name);
 	Draw_PicScaled(viddef.width / 2 - (w * scale) / 2, viddef.height / 2 - (110 * scale), name, scale);
@@ -375,6 +382,14 @@ Default_MenuKey(menuframework_s *m, int key)
 	return sound;
 }
 
+void
+Default_MenuDraw(menuframework_s *m)
+{
+	M_Banner(m->banner);
+	Menu_Draw(m);
+	Menu_DrawPopup(320, 240, &m_popup);
+}
+
 /* Unsused, left for backward compability */
 void
 M_DrawPic(int x, int y, char *pic)
@@ -632,13 +647,13 @@ InitMainMenu(void)
 
 
 static void
-M_Main_Draw(void)
+M_Main_Draw(menuframework_s *m)
 {
-	const menucommon_s * item = NULL;
+	const menucommon_s *item;
 
-	Menu_Draw(&s_main);
+	Menu_Draw(m);
 
-	item = Menu_ItemAtCursor(&s_main);
+	item = Menu_ItemAtCursor(m);
 
 	if (item)
 	{
@@ -668,15 +683,6 @@ static menuaction_s s_join_network_server_action;
 static menuaction_s s_start_network_server_action;
 static menuaction_s s_player_setup_action;
 static menuaction_s s_customize_options_action;
-
-static void
-Multiplayer_MenuDraw(void)
-{
-	M_Banner("m_banner_multiplayer");
-
-	Menu_AdjustCursor(&s_multiplayer_menu, 1);
-	Menu_Draw(&s_multiplayer_menu);
-}
 
 static void
 PlayerSetupFunc(void *unused)
@@ -709,6 +715,7 @@ Multiplayer_MenuInit(void)
 
 	s_multiplayer_menu.x = (int)(viddef.width * 0.50f) - 64 * scale;
 	s_multiplayer_menu.nitems = 0;
+	s_multiplayer_menu.banner = "m_banner_multiplayer";
 
 	s_join_network_server_action.generic.type = MTYPE_ACTION;
 	s_join_network_server_action.generic.flags = QMF_LEFT_JUSTIFY;
@@ -752,7 +759,7 @@ static void
 M_Menu_Multiplayer_f(void)
 {
 	Multiplayer_MenuInit();
-	s_multiplayer_menu.draw = Multiplayer_MenuDraw;
+	s_multiplayer_menu.draw = Default_MenuDraw;
 	s_multiplayer_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_multiplayer_menu);
@@ -983,13 +990,6 @@ Keys_MenuInit(void)
 	Menu_Center(&s_keys_menu);
 }
 
-static void
-Keys_MenuDraw(void)
-{
-	Menu_AdjustCursor(&s_keys_menu, 1);
-	Menu_Draw(&s_keys_menu);
-}
-
 static const char *
 Keys_MenuKey(menuframework_s *m, int key)
 {
@@ -1030,7 +1030,7 @@ static void
 M_Menu_Keys_f(void)
 {
 	Keys_MenuInit();
-	s_keys_menu.draw = Keys_MenuDraw;
+	s_keys_menu.draw = Default_MenuDraw;
 	s_keys_menu.key  = Keys_MenuKey;
 
 	M_PushMenu(&s_keys_menu);
@@ -1135,13 +1135,6 @@ MultiplayerKeys_MenuInit(void)
 	Menu_Center(&s_multiplayer_keys_menu);
 }
 
-static void
-MultiplayerKeys_MenuDraw(void)
-{
-	Menu_AdjustCursor(&s_multiplayer_keys_menu, 1);
-	Menu_Draw(&s_multiplayer_keys_menu);
-}
-
 static const char *
 MultiplayerKeys_MenuKey(menuframework_s *m, int key)
 {
@@ -1182,7 +1175,7 @@ static void
 M_Menu_Multiplayer_Keys_f(void)
 {
 	MultiplayerKeys_MenuInit();
-	s_multiplayer_keys_menu.draw = MultiplayerKeys_MenuDraw;
+	s_multiplayer_keys_menu.draw = Default_MenuDraw;
 	s_multiplayer_keys_menu.key  = MultiplayerKeys_MenuKey;
 
 	M_PushMenu(&s_multiplayer_keys_menu);
@@ -1332,13 +1325,6 @@ ControllerButtons_MenuInit(void)
 	Menu_Center(&s_controller_buttons_menu);
 }
 
-static void
-ControllerButtons_MenuDraw(void)
-{
-	Menu_AdjustCursor(&s_controller_buttons_menu, 1);
-	Menu_Draw(&s_controller_buttons_menu);
-}
-
 static const char *
 ControllerButtons_MenuKey(menuframework_s *m, int key)
 {
@@ -1379,7 +1365,7 @@ static void
 M_Menu_ControllerButtons_f(void)
 {
 	ControllerButtons_MenuInit();
-	s_controller_buttons_menu.draw = ControllerButtons_MenuDraw;
+	s_controller_buttons_menu.draw = Default_MenuDraw;
 	s_controller_buttons_menu.key  = ControllerButtons_MenuKey;
 
 	M_PushMenu(&s_controller_buttons_menu);
@@ -1505,13 +1491,6 @@ ControllerAltButtons_MenuInit(void)
 	Menu_Center(&s_controller_alt_buttons_menu);
 }
 
-static void
-ControllerAltButtons_MenuDraw(void)
-{
-	Menu_AdjustCursor(&s_controller_alt_buttons_menu, 1);
-	Menu_Draw(&s_controller_alt_buttons_menu);
-}
-
 static const char *
 ControllerAltButtons_MenuKey(menuframework_s *m, int key)
 {
@@ -1553,7 +1532,7 @@ static void
 M_Menu_ControllerAltButtons_f(void)
 {
 	ControllerAltButtons_MenuInit();
-	s_controller_alt_buttons_menu.draw = ControllerAltButtons_MenuDraw;
+	s_controller_alt_buttons_menu.draw = Default_MenuDraw;
 	s_controller_alt_buttons_menu.key  = ControllerAltButtons_MenuKey;
 
 	M_PushMenu(&s_controller_alt_buttons_menu);
@@ -1705,17 +1684,10 @@ Stick_MenuInit(void)
 }
 
 static void
-Stick_MenuDraw(void)
-{
-	Menu_AdjustCursor(&s_sticks_config_menu, 1);
-	Menu_Draw(&s_sticks_config_menu);
-}
-
-static void
 M_Menu_Stick_f(void)
 {
 	Stick_MenuInit();
-	s_sticks_config_menu.draw = Stick_MenuDraw;
+	s_sticks_config_menu.draw = Default_MenuDraw;
 	s_sticks_config_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_sticks_config_menu);
@@ -2018,18 +1990,10 @@ Gyro_MenuInit(void)
 }
 
 static void
-Gyro_MenuDraw(void)
-{
-	Menu_AdjustCursor(&s_gyro_menu, 1);
-	Menu_Draw(&s_gyro_menu);
-	Menu_DrawPopup(320, 240, &m_popup);
-}
-
-static void
 M_Menu_Gyro_f(void)
 {
 	Gyro_MenuInit();
-	s_gyro_menu.draw = Gyro_MenuDraw;
+	s_gyro_menu.draw = Default_MenuDraw;
 	s_gyro_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_gyro_menu);
@@ -2287,17 +2251,10 @@ Joy_MenuInit(void)
 }
 
 static void
-Joy_MenuDraw(void)
-{
-	Menu_AdjustCursor(&s_joy_menu, 1);
-	Menu_Draw(&s_joy_menu);
-}
-
-static void
 M_Menu_Joy_f(void)
 {
 	Joy_MenuInit();
-	s_joy_menu.draw = Joy_MenuDraw;
+	s_joy_menu.draw = Default_MenuDraw;
 	s_joy_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_joy_menu);
@@ -2590,6 +2547,7 @@ Options_MenuInit(void)
 	/* configure controls menu and menu items */
 	s_options_menu.x = viddef.width / 2;
 	s_options_menu.y = viddef.height / (2 * scale) - 58;
+	s_options_menu.banner = "m_banner_options";
 	s_options_menu.nitems = 0;
 
 	s_options_sfxvolume_slider.generic.type = MTYPE_SLIDER;
@@ -2734,19 +2692,10 @@ Options_MenuInit(void)
 }
 
 static void
-Options_MenuDraw(void)
-{
-	M_Banner("m_banner_options");
-	Menu_AdjustCursor(&s_options_menu, 1);
-	Menu_Draw(&s_options_menu);
-	Menu_DrawPopup(320, 240, &m_popup);
-}
-
-static void
 M_Menu_Options_f(void)
 {
 	Options_MenuInit();
-	s_options_menu.draw = Options_MenuDraw;
+	s_options_menu.draw = Default_MenuDraw;
 	s_options_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_options_menu);
@@ -3120,7 +3069,7 @@ static const char *roguecredits[] =
 };
 
 static void
-M_Credits_Draw(void)
+M_Credits_Draw(menuframework_s *m)
 {
 	int i, y;
 	float scale = SCR_GetMenuScale();
@@ -3458,18 +3407,10 @@ Mods_MenuInit(void)
 }
 
 static void
-Mods_MenuDraw(void)
-{
-	Menu_AdjustCursor(&s_mods_menu, 1);
-	Menu_Draw(&s_mods_menu);
-	Menu_DrawPopup(320, 240, &m_popup);
-}
-
-static void
 M_Menu_Mods_f(void)
 {
 	Mods_MenuInit();
-	s_mods_menu.draw = Mods_MenuDraw;
+	s_mods_menu.draw = Default_MenuDraw;
 	s_mods_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_mods_menu);
@@ -3569,6 +3510,7 @@ Game_MenuInit(void)
 
 	s_game_menu.x = (int)(viddef.width * 0.50f);
 	s_game_menu.nitems = 0;
+	s_game_menu.banner = "m_banner_game";
 
 	s_easy_game_action.generic.type = MTYPE_ACTION;
 	s_easy_game_action.generic.flags = QMF_LEFT_JUSTIFY;
@@ -3647,18 +3589,10 @@ Game_MenuInit(void)
 }
 
 static void
-Game_MenuDraw(void)
-{
-	M_Banner("m_banner_game");
-	Menu_AdjustCursor(&s_game_menu, 1);
-	Menu_Draw(&s_game_menu);
-}
-
-static void
 M_Menu_Game_f(void)
 {
 	Game_MenuInit();
-	s_game_menu.draw = Game_MenuDraw;
+	s_game_menu.draw = Default_MenuDraw;
 	s_game_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_game_menu);
@@ -3871,6 +3805,7 @@ LoadGame_MenuInit(void)
 
 	s_loadgame_menu.x = viddef.width / 2 - (120 * scale);
 	s_loadgame_menu.y = viddef.height / (2 * scale) - 58;
+	s_loadgame_menu.banner = "m_banner_load_game";
 	s_loadgame_menu.nitems = 0;
 
 	Create_Savestrings();
@@ -3917,14 +3852,6 @@ LoadGame_MenuInit(void)
 	}
 
 	Menu_SetStatusBar(&s_loadgame_menu, m_loadsave_statusbar);
-}
-
-static void
-LoadGame_MenuDraw(void)
-{
-	M_Banner("m_banner_load_game");
-	Menu_AdjustCursor(&s_loadgame_menu, 1);
-	Menu_Draw(&s_loadgame_menu);
 }
 
 static const char *
@@ -3986,7 +3913,7 @@ M_Menu_LoadGame_f(void)
 {
 	LoadSave_AdjustPage(0);
 	LoadGame_MenuInit();
-	s_loadgame_menu.draw = LoadGame_MenuDraw;
+	s_loadgame_menu.draw = Default_MenuDraw;
 	s_loadgame_menu.key  = LoadGame_MenuKey;
 
 	M_PushMenu(&s_loadgame_menu);
@@ -4028,15 +3955,6 @@ SaveGameCallback(void *self)
 }
 
 static void
-SaveGame_MenuDraw(void)
-{
-	M_Banner("m_banner_save_game");
-	Menu_AdjustCursor(&s_savegame_menu, 1);
-	Menu_Draw(&s_savegame_menu);
-	Menu_DrawPopup(320, 240, &m_popup);
-}
-
-static void
 SaveGame_MenuInit(void)
 {
 	int i;
@@ -4044,6 +3962,7 @@ SaveGame_MenuInit(void)
 
 	s_savegame_menu.x = viddef.width / 2 - (120 * scale);
 	s_savegame_menu.y = viddef.height / (2 * scale) - 58;
+	s_savegame_menu.banner = "m_banner_save_game";
 	s_savegame_menu.nitems = 0;
 
 	Create_Savestrings();
@@ -4146,7 +4065,7 @@ M_Menu_SaveGame_f(void)
 
 	LoadSave_AdjustPage(0);
 	SaveGame_MenuInit();
-	s_savegame_menu.draw = SaveGame_MenuDraw;
+	s_savegame_menu.draw = Default_MenuDraw;
 	s_savegame_menu.key  = SaveGame_MenuKey;
 
 	M_PushMenu(&s_savegame_menu);
@@ -4281,6 +4200,7 @@ JoinServer_MenuInit(void)
 
 	s_joinserver_menu.x = (int)(viddef.width * 0.50f) - 120 * scale;
 	s_joinserver_menu.nitems = 0;
+	s_joinserver_menu.banner = "m_banner_join_server";
 
 	s_joinserver_address_book_action.generic.type = MTYPE_ACTION;
 	s_joinserver_address_book_action.generic.name = "address book";
@@ -4329,18 +4249,10 @@ JoinServer_MenuInit(void)
 }
 
 static void
-JoinServer_MenuDraw(void)
-{
-	M_Banner("m_banner_join_server");
-	Menu_Draw(&s_joinserver_menu);
-	Menu_DrawPopup(320, 240, &m_popup);
-}
-
-static void
 M_Menu_JoinServer_f(void)
 {
 	JoinServer_MenuInit();
-	s_joinserver_menu.draw = JoinServer_MenuDraw;
+	s_joinserver_menu.draw = Default_MenuDraw;
 	s_joinserver_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_joinserver_menu);
@@ -4942,16 +4854,10 @@ StartServer_MenuInit(void)
 }
 
 static void
-StartServer_MenuDraw(void)
-{
-	Menu_Draw(&s_startserver_menu);
-}
-
-static void
 M_Menu_StartServer_f(void)
 {
 	StartServer_MenuInit();
-	s_startserver_menu.draw = StartServer_MenuDraw;
+	s_startserver_menu.draw = Default_MenuDraw;
 	s_startserver_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_startserver_menu);
@@ -5424,16 +5330,10 @@ DMOptions_MenuInit(void)
 }
 
 static void
-DMOptions_MenuDraw(void)
-{
-	Menu_Draw(&s_dmoptions_menu);
-}
-
-static void
 M_Menu_DMOptions_f(void)
 {
 	DMOptions_MenuInit();
-	s_dmoptions_menu.draw = DMOptions_MenuDraw;
+	s_dmoptions_menu.draw = Default_MenuDraw;
 	s_dmoptions_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_dmoptions_menu);
@@ -5586,16 +5486,10 @@ DownloadOptions_MenuInit(void)
 }
 
 static void
-DownloadOptions_MenuDraw(void)
-{
-	Menu_Draw(&s_downloadoptions_menu);
-}
-
-static void
 M_Menu_DownloadOptions_f(void)
 {
 	DownloadOptions_MenuInit();
-	s_downloadoptions_menu.draw = DownloadOptions_MenuDraw;
+	s_downloadoptions_menu.draw = Default_MenuDraw;
 	s_downloadoptions_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_downloadoptions_menu);
@@ -5616,6 +5510,7 @@ AddressBook_MenuInit(void)
 
 	s_addressbook_menu.x = viddef.width / 2 - (142 * scale);
 	s_addressbook_menu.y = viddef.height / (2 * scale) - 58;
+	s_addressbook_menu.banner = "m_banner_addressbook";
 	s_addressbook_menu.nitems = 0;
 
 	for (i = 0; i < NUM_ADDRESSBOOK_ENTRIES; i++)
@@ -5666,17 +5561,10 @@ AddressBook_MenuKey(menuframework_s *m, int key)
 }
 
 static void
-AddressBook_MenuDraw(void)
-{
-	M_Banner("m_banner_addressbook");
-	Menu_Draw(&s_addressbook_menu);
-}
-
-static void
 M_Menu_AddressBook_f(void)
 {
 	AddressBook_MenuInit();
-	s_addressbook_menu.draw = AddressBook_MenuDraw;
+	s_addressbook_menu.draw = Default_MenuDraw;
 	s_addressbook_menu.key  = AddressBook_MenuKey;
 
 	M_PushMenu(&s_addressbook_menu);
@@ -6554,7 +6442,7 @@ PlayerConfig_AnimateModel(entity_t *entity, int count, int curTime)
 }
 
 static void
-PlayerConfig_MenuDraw(void)
+PlayerConfig_MenuDraw(menuframework_s *m)
 {
 	refdef_t refdef;
 	float scale = SCR_GetMenuScale();
@@ -6644,7 +6532,7 @@ PlayerConfig_MenuDraw(void)
 		// icon bitmap to draw
 		s_player_icon_bitmap.generic.name = scratch;
 
-		Menu_Draw(&s_player_config_menu);
+		Menu_Draw(m);
 
 		M_DrawTextBox(((int)(refdef.x) * (320.0F / viddef.width) - 8),
 					  (int)((viddef.height / 2) * (240.0F / viddef.height) - 77),
@@ -6731,7 +6619,7 @@ M_Quit_Key(menuframework_s *m, int key)
 }
 
 static void
-M_Quit_Draw(void)
+M_Quit_Draw(menuframework_s *m)
 {
 	int w, h;
 	float scale = SCR_GetMenuScale();
@@ -6808,7 +6696,7 @@ M_Init(void)
 void
 M_Draw(void)
 {
-	const menuframework_s *menu;
+	menuframework_s *menu;
 
 	if (cls.key_dest != key_menu)
 	{
@@ -6832,7 +6720,7 @@ M_Draw(void)
 	menu = M_GetActiveMenu();
 	if (menu && menu->draw)
 	{
-		menu->draw();
+		menu->draw(menu);
 	}
 
 	/* delay playing the enter sound until after the

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5679,33 +5679,6 @@ IconOfSkinExists(const char* skin, char** pcxfiles, int npcxfiles,
 	return false;
 }
 
-// returns true if file is in path
-static qboolean
-ContainsFile(char* path, char* file)
-{
-	int handle = 0;
-	qboolean result = false;
-
-	if (path != 0 && file != 0)
-	{
-		char pathname[MAX_QPATH];
-		int length = 0;
-
-		Com_sprintf(pathname, MAX_QPATH, "%s/%s", path, file);
-
-		length = FS_FOpenFile(pathname, &handle, false);
-
-		// verify the existence of file
-		if (handle != 0 && length != 0)
-		{
-			FS_FCloseFile(handle);
-			result = true;
-		}
-	}
-
-	return result;
-}
-
 // replace characters in string
 static void
 ReplaceCharacters(char* s, char r, char c)
@@ -6075,7 +6048,7 @@ PlayerModelList(void)
 		/* contains triangle .md2 model */
 		s = s_directory.data[i];
 
-		if (ContainsFile(s, "tris.md2") == false)
+		if (!FS_FileExists(s, "tris.md2"))
 		{
 			/* invalid player model */
 			continue;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -128,6 +128,11 @@ M_ForceMenuOff(void)
 		}
 	}
 
+	if (Menu_PopupActive(&m_popup))
+	{
+		Menu_ClosePopup(&m_popup);
+	}
+
 	m_menudepth = 0;
 
 	cls.key_dest = key_game;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5679,30 +5679,6 @@ IconOfSkinExists(const char* skin, char** pcxfiles, int npcxfiles,
 	return false;
 }
 
-// strip file extension
-static void
-StripExtension(char* path)
-{
-	size_t length;
-
-	length = strlen(path) - 1;
-
-	while (length > 0 && path[length] != '.')
-	{
-		length--;
-
-		if (path[length] == '/')
-		{
-			return;         // no extension
-		}
-	}
-
-	if (length)
-	{
-		path[length] = 0;
-	}
-}
-
 // returns true if file is in path
 static qboolean
 ContainsFile(char* path, char* file)
@@ -6184,7 +6160,7 @@ PlayerModelList(void)
 						return false;
 					}
 
-					StripExtension(t);
+					COM_StripExtension2(t);
 					Q_strlcpy(s, t + 1, l);
 
 					data[s_skinnames[mdl].num++] = s;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5679,28 +5679,6 @@ IconOfSkinExists(const char* skin, char** pcxfiles, int npcxfiles,
 	return false;
 }
 
-// replace characters in string
-static void
-ReplaceCharacters(char* s, char r, char c)
-{
-	char* p = s;
-
-	if (p == 0)
-	{
-		return;
-	}
-
-	while (*p != 0)
-	{
-		if (*p == r)
-		{
-			*p = c;
-		}
-
-		p++;
-	}
-}
-
 // qsort directory name compare function
 static int
 dircmp_func(const void* _a, const void* _b)
@@ -5845,14 +5823,12 @@ PlayerDirectoryList(void)
 			break;
 		}
 
-		ReplaceCharacters(list[i], '\\', '/');
-
 		/*
 		 * search slash after "players/" and use only directory name
 		 * pak search does not return directory names, only files in
 		 * directories
 		 */
-		dirsize = strchr(list[i] + listoff, '/');
+		dirsize = Q_strchrs(list[i] + listoff, "/\\");
 		if (dirsize)
 		{
 			int dirnamelen = 0;
@@ -6119,9 +6095,7 @@ PlayerModelList(void)
 				if (IconOfSkinExists(list[k], list, num - 1, "png") ||
 					IconOfSkinExists(list[k], list, num - 1, "pcx"))
 				{
-					ReplaceCharacters(list[k], '\\', '/');
-
-					t = strrchr(list[k], '/');
+					t = Q_strrchrs(list[k], "/\\");
 
 					l = strlen(t) + 1;
 					s = (char*)malloc(l);
@@ -6223,6 +6197,7 @@ PlayerConfig_MenuInit(void)
 	static const char *handedness[] = { "right", "left", "center", NULL};
 	char mdlname[MAX_QPATH];
 	char imgname[MAX_QPATH];
+	char *slash;
 	int mdlindex = 0;
 	int imgindex = 0;
 	int i = 0;
@@ -6234,17 +6209,17 @@ PlayerConfig_MenuInit(void)
 	}
 
 	Q_strlcpy(mdlname, skin->string, sizeof(mdlname));
-	ReplaceCharacters(mdlname, '\\', '/' );
 
-	if (strchr(mdlname, '/'))
+	slash = Q_strchrs(mdlname, "/\\");
+	if (slash)
 	{
-		Q_strlcpy(imgname, strchr(mdlname, '/') + 1, sizeof(imgname));
-		*strchr(mdlname, '/') = 0;
+		Q_strlcpy(imgname, slash + 1, sizeof(imgname));
+		*slash = '\0';
 	}
 	else
 	{
-		strcpy(mdlname, "male\0");
-		strcpy(imgname, "grunt\0");
+		strcpy(mdlname, "male");
+		strcpy(imgname, "grunt");
 	}
 
 	for (i = 0; i < s_modelname.num; i++)

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -129,6 +129,43 @@ Action_Draw(menuaction_s *a)
 	}
 }
 
+void
+Field_InitState(menufield_s *f, const char *s, int len, int vislen)
+{
+	if (len < 1)
+	{
+		len = 1;
+	}
+	else if (len > sizeof(f->buffer))
+	{
+		len = sizeof(f->buffer);
+	}
+
+	if (vislen < 1)
+	{
+		vislen = 1;
+	}
+	else if (vislen > len)
+	{
+		vislen = len;
+	}
+
+	*f->buffer = '\0';
+
+	if (s)
+	{
+		if (((f->generic.flags & QMF_NUMBERSONLY) && !Q_strisnum(s)) ||
+			Q_strlcpy(f->buffer, s, len) >= len)
+		{
+			*f->buffer = '\0';
+		}
+	}
+
+	f->length = len;
+	f->visible_length = vislen;
+	f->cursor = strlen(f->buffer);
+}
+
 static void
 Field_Draw(menufield_s *f)
 {

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -517,6 +517,18 @@ Menu_DrawStatusBar(const char *string)
 	}
 }
 
+/*
+ * Draws one solid graphics character cx and cy are in 320*240
+ * coordinates, and will be centered on higher res screens.
+ */
+void
+Menu_DrawCharacter(int cx, int cy, int num)
+{
+	float scale = SCR_GetMenuScale();
+
+	Draw_CharScaled(cx + ((int)(viddef.width - 320 * scale) >> 1), cy + ((int)(viddef.height - 240 * scale) >> 1), num, scale);
+}
+
 void
 Menu_DrawString(int x, int y, const char *string)
 {
@@ -569,6 +581,162 @@ Menu_DrawStringR2LDark(int x, int y, const char *string)
 	{
 		Draw_CharScaled(x - i * 8 * scale, y * scale, string[slen - i - 1] + 128, scale);
 	}
+}
+
+void
+Menu_DrawTextBox(int x, int y, int width, int lines)
+{
+	int cx, cy;
+	int n;
+	float scale = SCR_GetMenuScale();
+
+	/* draw left side */
+	cx = x;
+	cy = y;
+	Menu_DrawCharacter(cx * scale, cy * scale, 1);
+
+	for (n = 0; n < lines; n++)
+	{
+		cy += 8;
+		Menu_DrawCharacter(cx * scale, cy * scale, 4);
+	}
+
+	Menu_DrawCharacter(cx * scale, cy * scale + 8 * scale, 7);
+
+	/* draw middle */
+	cx += 8;
+
+	while (width > 0)
+	{
+		cy = y;
+		Menu_DrawCharacter(cx * scale, cy * scale, 2);
+
+		for (n = 0; n < lines; n++)
+		{
+			cy += 8;
+			Menu_DrawCharacter(cx * scale, cy * scale, 5);
+		}
+
+		Menu_DrawCharacter(cx * scale, cy *scale + 8 * scale, 8);
+		width -= 1;
+		cx += 8;
+	}
+
+	/* draw right side */
+	cy = y;
+	Menu_DrawCharacter(cx * scale, cy * scale, 3);
+
+	for (n = 0; n < lines; n++)
+	{
+		cy += 8;
+		Menu_DrawCharacter(cx * scale, cy * scale, 6);
+	}
+
+	Menu_DrawCharacter(cx * scale, cy * scale + 8 * scale, 9);
+}
+
+void
+Menu_DrawText(int x, int y, const char *str)
+{
+	int cx, cy;
+	float scale;
+
+	scale = SCR_GetMenuScale();
+	cx = x;
+	cy = y;
+
+	for (; *str != '\0'; str++)
+	{
+		if (*str == '\n')
+		{
+			cx = x;
+			cy += 8;
+		}
+		else
+		{
+			Menu_DrawCharacter(cx * scale, cy * scale, (*str) + 128);
+			cx += 8;
+		}
+	}
+}
+
+static void
+GetString2DSize(const char *s, int *w_out, int *h_out)
+{
+	int n, w, h;
+
+	n = 0;
+	w = 0;
+	h = 0;
+
+	for (; *s != '\0'; s++)
+	{
+		if (*s == '\n')
+		{
+			h++;
+			n = 0;
+		}
+		else
+		{
+			n++;
+
+			if (n > w)
+			{
+				w = n;
+			}
+		}
+	}
+
+	if (n)
+	{
+		h++;
+	}
+
+	*w_out = w;
+	*h_out = h;
+}
+
+void
+Menu_DrawPopup(int x, int y, const menupopup_s *pup)
+{
+	int w, h;
+
+	if (!pup->string)
+	{
+		return;
+	}
+
+	if (pup->endtime > 0 && pup->endtime < cls.realtime)
+	{
+		return;
+	}
+
+	if (!R_EndWorldRenderpass())
+	{
+		return;
+	}
+
+	GetString2DSize(pup->string, &w, &h);
+
+	if (w)
+	{
+		int cx, cy;
+
+		w += 2;
+
+		cx = (x - (w + 2) * 8) / 2;
+		cy = (y - (h + 2) * 8) / 3;
+
+		Menu_DrawTextBox(cx, cy, w, h);
+		Menu_DrawText(cx + 16, cy + 8, pup->string);
+	}
+}
+
+void
+Menu_StartPopup(menupopup_s *pup, const char *string, int lifetime)
+{
+	pup->string = string;
+	pup->endtime = (lifetime <= 0) ? 0 : (cls.realtime + lifetime);
 }
 
 void *
@@ -871,4 +1039,3 @@ SpinControl_Draw(menulist_s *s)
 			y, buffer);
 	}
 }
-

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -375,10 +375,10 @@ Field_Key(menufield_s *f, int key)
 void
 Menu_AddItem(menuframework_s *menu, void *item)
 {
-	if (menu->nitems < MAXMENUITEMS)
+	if ((menu->nitems >= 0) && (menu->nitems < MAXMENUITEMS))
 	{
 		menu->items[menu->nitems] = item;
-		((menucommon_s *)menu->items[menu->nitems])->parent = menu;
+		((menucommon_s *)item)->parent = menu;
 		menu->nitems++;
 	}
 }

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -979,12 +979,6 @@ VID_MenuDraw(void)
 	Menu_Draw(&s_opengl_menu);
 }
 
-const char *
-VID_MenuKey(int key)
-{
-	return Default_MenuKey(&s_opengl_menu, key);
-}
-
 /*
  * VIDEO MENU
  */
@@ -994,7 +988,7 @@ M_Menu_Video_f(void)
 {
 	VID_MenuInit();
 	s_opengl_menu.draw = VID_MenuDraw;
-	s_opengl_menu.key  = VID_MenuKey;
+	s_opengl_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_opengl_menu);
 }

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -29,9 +29,9 @@
 #include "../../client/menu/header/qmenu.h"
 #include "header/qmenu.h"
 
-extern void M_Banner(const char *name);
 extern void M_ForceMenuOff(void);
 extern const char *Default_MenuKey(menuframework_s *m, int key);
+extern void Default_MenuDraw(menuframework_s *m);
 
 static cvar_t *r_mode;
 static cvar_t *vid_displayindex;
@@ -612,6 +612,7 @@ VID_MenuInit(void)
 
 	s_opengl_menu.x = viddef.width * 0.50;
 	s_opengl_menu.nitems = 0;
+	s_opengl_menu.banner = "m_banner_video";
 
 	s_renderer_list.generic.type = MTYPE_SPINCONTROL;
 	s_renderer_list.generic.name = "renderer";
@@ -971,14 +972,6 @@ VID_MenuInit(void)
 	s_opengl_menu.x -= 8;
 }
 
-void
-VID_MenuDraw(void)
-{
-	M_Banner("m_banner_video");
-	Menu_AdjustCursor(&s_opengl_menu, 1);
-	Menu_Draw(&s_opengl_menu);
-}
-
 /*
  * VIDEO MENU
  */
@@ -987,7 +980,7 @@ void
 M_Menu_Video_f(void)
 {
 	VID_MenuInit();
-	s_opengl_menu.draw = VID_MenuDraw;
+	s_opengl_menu.draw = Default_MenuDraw;
 	s_opengl_menu.key  = Default_MenuKey;
 
 	M_PushMenu(&s_opengl_menu);

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -367,6 +367,43 @@ FS_FCloseFile(fileHandle_t f)
 	memset(handle, 0, sizeof(*handle));
 }
 
+qboolean
+FS_FileExists(const char *path, const char *file)
+{
+	char pathname[MAX_QPATH];
+	fileHandle_t handle;
+	int len;
+
+	if (!file)
+	{
+		return false;
+	}
+
+	if (!path)
+	{
+		path = file;
+	}
+	else
+	{
+		if (snprintf(pathname, sizeof(pathname), "%s/%s",
+			path, file) >= sizeof(pathname))
+		{
+			return false;
+		}
+
+		path = pathname;
+	}
+
+	len = FS_FOpenFile(path, &handle, false);
+
+	if (handle)
+	{
+		FS_FCloseFile(handle);
+	}
+
+	return (handle && len >= 0) ? true : false;
+}
+
 static int
 FS_SortPackCompare(const void *p1, const void *p2)
 {
@@ -427,6 +464,8 @@ FS_FOpenFile(const char *rawname, fileHandle_t *f, qboolean gamedir_only)
 	fsPack_t *pack;
 	fsSearchPath_t *search;
 	int input, output;
+
+	*f = 0;
 
 	// Remove self references and empty dirs from the requested path.
 	// ZIPs and PAKs don't support them, but they may be hardcoded in

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -701,6 +701,7 @@ typedef enum
 void FS_DPrintf(const char *format, ...);
 int FS_FOpenFile(const char *name, fileHandle_t *f, qboolean gamedir_only);
 void FS_FCloseFile(fileHandle_t f);
+qboolean FS_FileExists(const char *path, const char *file);
 int FS_Read(void *buffer, int size, fileHandle_t f);
 int FS_FRead(void *buffer, int size, int count, fileHandle_t f);
 

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -325,6 +325,7 @@ void RotatePointAroundVector(vec3_t dst,
 
 const char *COM_SkipPath(const char *pathname);
 void COM_StripExtension(const char *in, char *out);
+char *COM_StripExtension2(char *path);
 YQ2_ATTR_RETURNS_NONNULL const char *COM_FileExtension(const char *in);
 void COM_FileBase(const char *in, char *out);
 void COM_FilePath(const char *in, char *out);

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -372,11 +372,12 @@ qboolean Q_strisnum(const char *s);
 /* fix backslashes in path */
 void Q_replacebackslash(char *curr);
 
-/* A strchr that can search for multiple characters
+/* A strchr / strrchr that can search for multiple characters
  * chrs is a string of characters to search for
- * If found, returns a pointer to that char inside s, NULL otherwise
+ * Returns pointer to first / last char in s if found, NULL otherwise
  */
-const char *Q_strchrs(const char *s, const char *chrs);
+char *Q_strchrs(const char *s, const char *chrs);
+char *Q_strrchrs(const char *s, const char *chrs);
 
 /* Returns a pointer to c in s if found
  * Otherwise returns a pointer to the null-terminator at the end of s

--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -764,6 +764,33 @@ COM_StripExtension(const char *in, char *out)
 	*out = 0;
 }
 
+char *
+COM_StripExtension2(char *path)
+{
+	char *s ;
+
+	if (*path == '\0')
+	{
+		return NULL;
+	}
+
+	s = path + (strlen(path) - 1);
+
+	if (*s != '.')
+	{
+		for (; s > path && *s != '/' && *s != '\\'; s--)
+		{
+			if (*s == '.')
+			{
+				*s = '\0';
+				return s + 1;
+			}
+		}
+	}
+
+	return NULL;
+}
+
 const char *
 COM_FileExtension(const char *in)
 {

--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -1404,17 +1404,30 @@ Q_strisnum(const char *s)
 	return true;
 }
 
-const char *
+char *
 Q_strchrs(const char *s, const char *chrs)
 {
-	const char *hit;
-
-	for (; *chrs != '\0'; chrs++)
+	for (; *s != '\0'; s++)
 	{
-		hit = strchr(s, *chrs);
-		if (hit)
+		if (strchr(chrs, *s))
 		{
-			return hit;
+			return (char *)s;
+		}
+	}
+
+	return NULL;
+}
+
+char *
+Q_strrchrs(const char *s, const char *chrs)
+{
+	const char *curr;
+
+	for (curr = s + (strlen(s) - 1); curr >= s; curr--)
+	{
+		if (strchr(chrs, *curr))
+		{
+			return (char *)curr;
 		}
 	}
 


### PR DESCRIPTION

This PR is a 3rd round of stability improvements and fixes for the menu system. Also ncludes some API refactoring.

Simplified menu layer code
* Replaced `m_active` variable with `M_GetActiveMenu` function
* Removed `menulayer_t` struct and made `m_layers` an array of `menuframework_s *`

menuframework_s refactoring
* Added `banner` string member
* `->draw` and `->key` callbacks now take a self-pointer as argument
* Removed a large amount of `*_MenuKey` and `_MenuDraw` in favor of reworked `Default_MenuKey` and `Default_MenuDraw` functions
* Added `Default_MenuDraw` that provides baseline menu drawing behavior (banner, menu and popup)
* `Default_MenuKey` is now called directly by the callback and it includes popup closing
* Added a `->close` callback which is now used by credits, address book and player config menus. This callback is called from within `M_ForceMenuOff` and `M_PopMenu` functions

Popup API
* Added `menupopup_s` struct and `m_popup` variable
* Reworked `M_Popup` into `Menu_DrawPopup` and added `Menu_StartPopup` functions
* Added `Menu_PopupActive` and `Menu_ClosePopup` macros
* Moved some utility code to `qmenu.c`

Misc refactoring
* Delete and backspace are no longer treated the same in `Key_GetMenuKey`
* Added `case K_DEL:` to keep old behavior in key binding / savegame / etc. menus
* Start server menu elements now positioned relatively rather than absolutely and `capture limit` option now pushes down instead of up
* Moved `StripExtension` to shared, renamed it `COM_StripExtension2` and made it smarter and return the extension part
* Moved `ContainsFile` to filesystem, renamed it `FS_FileExists` and made it more robust and path arg can be NULL
* Removed `ReplacedCharacters` and added `Q_strrchrs` to shared that looks for the last instance of one of the specified characters

Stability
* `Field_InitBuffer` function for setting up input field state
* Make sure `menu->nitems >= 0` in `Menu_AddItem`
* `f` is now initialized to 0 at the start of `Fs_FOpenFile` to ensure it is defined after returning

Bug fixes
* Fixed possible resource leaks or discarded changes if a menu is closed without pressing Escape
* Fixed delete key not working correctly in input fields. It was behaving like backspace
* Fixed credits menu playing a louder menu closing sound. It was calling `S_StartLocalSound` twice
* Fixed popup state not being cleared when menu is forced off
* (maybe a bug) Fixed start server menu banner missing
* Fixed `Q_strchrs` not always returning the earliest instance of one of the specified characters

Since this is refactoring core API logic, more people testing this would be welcome.

I might get more ideas for refactoring or discover more issues, but what is currently here seems stable during my testing.