### PR TITLE
menu: Fix menu sounds not playing in SDL mode when a game session is active

### DIFF
--- a/src/client/sound/sdl.c
+++ b/src/client/sound/sdl.c
@@ -656,7 +656,7 @@ SDL_Spatialize(channel_t *ch)
 
 	/* Anything coming from the view entity
 	   will always be full volume */
-	if (ch->entnum == cl.playernum + 1)
+	if ((ch->entnum == -1) || (ch->entnum == cl.playernum + 1))
 	{
 		ch->leftvol = ch->master_vol;
 		ch->rightvol = ch->master_vol;


### PR DESCRIPTION
Fixes https://github.com/yquake2/yquake2/issues/1342

`S_StartLocalSound` uses an `entnum` of -1 to indicate a sound event that is not spatial, such as menu sounds. This is a regression I introduced last year when working on BSP sound positioning, if I remember correctly.