### PR TITLE
Strlist API and major code simplication and cleanup

### DIFF
--- a/src/client/cl_download.c
+++ b/src/client/cl_download.c
@@ -553,7 +553,7 @@ CL_DownloadFileName(char *dest, int destlen, char *fn)
 static qboolean
 CL_DownloadFilter(const char *filename)
 {
-	if (FS_LoadFile((char *) filename, NULL) != -1)
+	if (FS_FileExists(filename))
 	{
 		/* it exists, no need to download */
 		return true;

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -1040,5 +1040,5 @@ CL_Shutdown(void)
 	VID_Shutdown();
 
 	CL_ClearEntities();
-	Mods_NamesFinish();
+	M_Free();
 }

--- a/src/client/curl/download.c
+++ b/src/client/curl/download.c
@@ -553,7 +553,7 @@ static void CL_ReVerifyHTTPQueue (void)
 		dlqueue_t *next = q->next;
 		if (q->state == DLQ_STATE_NOT_STARTED)
 		{
-			if (FS_LoadFile (q->quakePath, NULL) != -1)
+			if (FS_FileExists(q->quakePath))
 			{
 				CL_RemoveFromQueue(q);
 			}

--- a/src/client/header/client.h
+++ b/src/client/header/client.h
@@ -532,6 +532,7 @@ void CL_EntityEvent (entity_state_t *ent);
 void CL_TrapParticles (entity_t *ent);
 
 void M_Init (void);
+void M_Free (void);
 void M_Keydown (int key);
 void M_Draw (void);
 void M_Menu_Main_f (void);

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5584,15 +5584,23 @@ ModelCallback(void *self)
 
 // returns true if icon .pcx exists for skin .pcx
 static qboolean
-IconOfSkinExists(const char* skin, strlist_t *files, const char *ext)
+IconOfSkinExists(const char *skin, const strlist_t *files, const char *ext)
 {
+	char scratch[MAX_QPATH];
 	int i;
-	char scratch[1024];
 
-	Q_strlcpy(scratch, skin, sizeof(scratch));
-	*strrchr(scratch, '.') = 0;
-	Q_strlcat(scratch, "_i.", sizeof(scratch));
-	Q_strlcat(scratch, ext, sizeof(scratch));
+	if (Q_strlcpy(scratch, skin, sizeof(scratch)) >= sizeof(scratch))
+	{
+		return false;
+	}
+
+	COM_StripExtension2(scratch);
+
+	if (Q_strlcat(scratch, "_i.", sizeof(scratch)) >= sizeof(scratch) ||
+		Q_strlcat(scratch, ext, sizeof(scratch)) >= sizeof(scratch))
+	{
+		return false;
+	}
 
 	for (i = 0; i < files->num; i++)
 	{

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5493,6 +5493,9 @@ static int rate_tbl[] = {2500, 3200, 5000, 10000, 25000};
 static const char *rate_names[] = {"28.8 Modem", "33.6 Modem", "Single ISDN",
 								   "Dual ISDN/Cable", "T1/LAN", "User defined", NULL};
 
+static const cvar_t *model_preview_start = NULL;
+static const cvar_t *model_preview_end = NULL;
+
 static void
 SelectedModelSkin(const char **mdl, const char **img)
 {
@@ -5646,6 +5649,9 @@ PlayerModelFree()
 
 	s_player_model_box.itemnames = NULL;
 	s_player_skin_box.itemnames = NULL;
+
+	model_preview_start = NULL;
+	model_preview_end = NULL;
 }
 
 // list all player model directories.
@@ -6057,19 +6063,26 @@ extern float CalcFov(float fov_x, float w, float h);
 static void
 PlayerConfig_AnimateModel(entity_t *entity, int count, int curTime)
 {
-	const cvar_t *cl_start_frame, *cl_end_frame;
 	int startFrame, endFrame;
 
-	cl_start_frame = Cvar_Get("cl_model_preview_start", "84", CVAR_ARCHIVE);
-	cl_end_frame = Cvar_Get("cl_model_preview_end", "94", CVAR_ARCHIVE);
-	startFrame = cl_start_frame->value;
-	endFrame = cl_end_frame->value;
+	if (!model_preview_start)
+	{
+		model_preview_start = Cvar_Get("cl_model_preview_start", "84", CVAR_ARCHIVE);
+	}
+
+	if (!model_preview_end)
+	{
+		model_preview_end = Cvar_Get("cl_model_preview_end", "94", CVAR_ARCHIVE);
+	}
+
+	startFrame = model_preview_start->value;
+	endFrame = model_preview_end->value;
 
 	if (startFrame >= 0 && endFrame > startFrame)
 	{
 		int i;
 
-		for (i = 0; i < count; i ++)
+		for (i = 0; i < count; i++)
 		{
 			/* salute male 84..94 frame */
 			entity[i].frame = (curTime / 100) % (endFrame - startFrame) + startFrame;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5489,10 +5489,9 @@ static strlist_t s_skinnames[MAX_PLAYERMODELS];
 static strlist_t s_modelname;
 static char player_icon_path[MAX_QPATH];
 
-static int rate_tbl[] = {2500, 3200, 5000, 10000, 25000, 0};
+static int rate_tbl[] = {2500, 3200, 5000, 10000, 25000};
 static const char *rate_names[] = {"28.8 Modem", "33.6 Modem", "Single ISDN",
 								   "Dual ISDN/Cable", "T1/LAN", "User defined", NULL};
-
 
 static void
 SelectedModelSkin(const char **mdl, const char **img)
@@ -5537,11 +5536,13 @@ HandednessCallback(void *unused)
 }
 
 static void
-RateCallback(void *unused)
+RateCallback(void *self)
 {
-	if (s_player_rate_box.curvalue != ARRLEN(rate_tbl) - 1)
+	const menulist_s *r = self;
+
+	if (r->curvalue >= 0 && r->curvalue != ARRLEN(rate_tbl))
 	{
-		Cvar_SetValue("rate", (float)rate_tbl[s_player_rate_box.curvalue]);
+		Cvar_SetValue("rate", rate_tbl[r->curvalue]);
 	}
 }
 
@@ -5880,6 +5881,24 @@ ListModels_f(void)
 	PlayerModelFree();
 }
 
+static int
+CurrentRateIndex(void)
+{
+	int i, curr_rate;
+
+	curr_rate = Cvar_VariableValue("rate");
+
+	for (i = 0; i < ARRLEN(rate_tbl); i++)
+	{
+		if (rate_tbl[i] == curr_rate)
+		{
+			break;
+		}
+	}
+
+	return i;
+}
+
 static qboolean
 PlayerConfig_MenuInit(void)
 {
@@ -5888,11 +5907,9 @@ PlayerConfig_MenuInit(void)
 	cvar_t *hand = Cvar_Get( "hand", "0", CVAR_USERINFO | CVAR_ARCHIVE );
 	static const char *handedness[] = { "right", "left", "center", NULL};
 	char mdlname[MAX_QPATH];
-	char imgname[MAX_QPATH];
+	const char *imgname;
 	char *slash;
-	int mdlindex = 0;
-	int imgindex = 0;
-	int i = 0;
+	int mdlindex, imgindex;
 	float scale = SCR_GetMenuScale();
 
 	if (!PlayerConfig_ScanDirectories())
@@ -5906,32 +5923,25 @@ PlayerConfig_MenuInit(void)
 	slash = Q_strchrs(mdlname, "/\\");
 	if (slash)
 	{
-		Q_strlcpy(imgname, slash + 1, sizeof(imgname));
 		*slash = '\0';
+		imgname = slash + 1;
 	}
 	else
 	{
 		strcpy(mdlname, "male");
-		strcpy(imgname, "grunt");
+		imgname = "grunt";
 	}
 
-	for (i = 0; i < s_modelname.num; i++)
+	mdlindex = StrList_Find(&s_modelname, Q_stricmp, mdlname);
+	if (mdlindex >= s_modelname.num)
 	{
-		if (Q_stricmp(s_modelname.data[i], mdlname) == 0)
-		{
-			mdlindex = i;
-			break;
-		}
+		mdlindex = 0;
 	}
 
-	for (i = 0; i < s_skinnames[mdlindex].num; i++)
+	imgindex = StrList_Find(&s_skinnames[mdlindex], Q_stricmp, imgname);
+	if (imgindex >= s_skinnames[mdlindex].num)
 	{
-		const char* names = s_skinnames[mdlindex].data[i];
-		if (Q_stricmp(names, imgname) == 0)
-		{
-			imgindex = i;
-			break;
-		}
+		imgindex = 0;
 	}
 
 	if (hand->value < 0 || hand->value > 2)
@@ -6002,14 +6012,6 @@ PlayerConfig_MenuInit(void)
 	s_player_handedness_box.curvalue = ClampCvar(0, 2, hand->value);
 	s_player_handedness_box.itemnames = handedness;
 
-	for (i = 0; i < ARRLEN(rate_tbl) - 1; i++)
-	{
-		if (Cvar_VariableValue("rate") == rate_tbl[i])
-		{
-			break;
-		}
-	}
-
 	s_player_rate_title.generic.type = MTYPE_SEPARATOR;
 	s_player_rate_title.generic.name = "connect speed";
 	s_player_rate_title.generic.x = 56 * scale;
@@ -6021,7 +6023,7 @@ PlayerConfig_MenuInit(void)
 	s_player_rate_box.generic.name = NULL;
 	s_player_rate_box.generic.cursor_offset = -48;
 	s_player_rate_box.generic.callback = RateCallback;
-	s_player_rate_box.curvalue = i;
+	s_player_rate_box.curvalue = CurrentRateIndex();
 	s_player_rate_box.itemnames = rate_names;
 
 	s_player_download_action.generic.type = MTYPE_ACTION;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5696,7 +5696,7 @@ PlayerModelList(const strlist_t *dirs)
 
 		s = dirs->data[i];
 
-		if (!s || !FS_FileExists(s, "tris.md2"))
+		if (!s || !FS_FileExists(va("%s/tris.md2", s)))
 		{
 			continue;
 		}

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5561,12 +5561,21 @@ SkinCallback(void *unused)
 }
 
 static void
-ModelCallback(void *unused)
+ModelCallback(void *self)
 {
-	s_player_skin_box.itemnames = (const char **)s_skinnames[s_player_model_box.curvalue].data;
-	s_player_skin_box.curvalue = 0;
+	const menulist_s *m = self;
+	menulist_s *s = &s_player_skin_box;
+	const char **skinnames;
 
-	SkinCallback(&s_player_skin_box);
+	skinnames = (const char **)s_skinnames[m->curvalue].data;
+
+	if (s->itemnames != skinnames)
+	{
+		s->itemnames = skinnames;
+		s->curvalue = 0;
+
+		SkinCallback(s);
+	}
 }
 
 // returns true if icon .pcx exists for skin .pcx

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -3265,17 +3265,68 @@ M_Menu_Credits_f(void)
  * MODS MENU
  */
 
+#define MODS_MAX_DISPNAMELEN 15
+
 static menuframework_s s_mods_menu;
 static menulist_s s_mods_list;
 static menuaction_s s_mods_apply_action;
 static char mods_statusbar[64];
 
 static strlist_t modnames;
+static strlist_t moddispnames;
 
 void
 Mods_NamesFinish(void)
 {
 	StrList_Free(&modnames);
+	StrList_Free(&moddispnames);
+
+	s_mods_list.itemnames = NULL;
+}
+
+/* create array of bracketed display names from folder names - TG626 */
+static strlist_t
+Mods_DisplayNamesInit(const strlist_t *mods)
+{
+	strlist_t list;
+	int i;
+
+	StrList_Init(&list, 0);
+
+	for (i = 0; i < mods->num; i++)
+	{
+		const char *m;
+		char dispname[MODS_MAX_DISPNAMELEN + 3];
+		int len;
+
+		strcpy(dispname, "[");
+
+		m = mods->data[i];
+		len = strlen(m);
+
+		if (len <= MODS_MAX_DISPNAMELEN)
+		{
+			int j;
+
+			strcat(dispname, m);
+
+			for (j = 0; j < (MODS_MAX_DISPNAMELEN - len); j++)
+			{
+				strcat(dispname, " ");
+			}
+		}
+		else
+		{
+			strncat(dispname, m, MODS_MAX_DISPNAMELEN - 3);
+			strcat(dispname, "...");
+		}
+
+		strcat(dispname, "]");
+
+		StrList_Append(&list, dispname);
+	}
+
+	return list;
 }
 
 static void
@@ -3285,125 +3336,106 @@ Mods_NamesInit(void)
 	if (!modnames.num)
 	{
 		modnames = FS_ListMods();
+		moddispnames = Mods_DisplayNamesInit(&modnames);
+
+		StrList_Compress(&modnames);
+		StrList_Compress(&moddispnames);
 	}
 }
 
 static void
 ModsListFunc(void *unused)
 {
-	if (strcmp(BASEDIRNAME, modnames.data[s_mods_list.curvalue]) == 0)
+	const char *m, *sb;
+	int i;
+
+	i = s_mods_list.curvalue;
+
+	if ((i < 0) || (i >= modnames.num))
 	{
-		strcpy(mods_statusbar, "Quake II");
+		strcpy(mods_statusbar, "(invalid)");
+		return;
 	}
-	else if (strcmp("ctf", modnames.data[s_mods_list.curvalue]) == 0)
+
+	m = modnames.data[i];
+
+	if (!strcmp(BASEDIRNAME, m))
 	{
-		strcpy(mods_statusbar, "Quake II Capture The Flag");
+		sb = "Quake II";
 	}
-	else if (strcmp("rogue", modnames.data[s_mods_list.curvalue]) == 0)
+	else if (!strcmp("ctf", m))
 	{
-		strcpy(mods_statusbar, "Quake II Mission Pack: Ground Zero");
+		sb = "Quake II Capture The Flag";
 	}
-	else if (strcmp("xatrix", modnames.data[s_mods_list.curvalue]) == 0)
+	else if (!strcmp("rogue", m))
 	{
-		strcpy(mods_statusbar, "Quake II Mission Pack: The Reckoning");
+		sb = "Quake II Mission Pack: Ground Zero";
+	}
+	else if (!strcmp("xatrix", m))
+	{
+		sb = "Quake II Mission Pack: The Reckoning";
 	}
 	else
 	{
-		strcpy(mods_statusbar, "\0");
+		sb = "";
 	}
+
+	strcpy(mods_statusbar, sb);
 }
 
 static void
 ModsApplyActionFunc(void *unused)
 {
-	if (!M_IsGame(modnames.data[s_mods_list.curvalue]))
+	int i = s_mods_list.curvalue;
+
+	if ((i < 0) || (i >= modnames.num))
 	{
-		if(Com_ServerState())
-		{
-			// equivalent to "killserver" cmd, but avoids cvar latching below
-			SV_Shutdown("Server is changing games.\n", false);
-			NET_Config(false);
-		}
-
-		// called via command buffer so that any running server has time to shutdown
-		Cbuf_AddText(va("game %s\n", modnames.data[s_mods_list.curvalue]));
-
-		// start the demo cycle in the new game directory
-		menu_startdemoloop = true;
-
-		M_ForceMenuOff();
+		return;
 	}
+
+	if (M_IsGame(modnames.data[i]))
+	{
+		return;
+	}
+
+	if (Com_ServerState())
+	{
+		// equivalent to "killserver" cmd, but avoids cvar latching below
+		SV_Shutdown("Server is changing games.\n", false);
+		NET_Config(false);
+	}
+
+	// called via command buffer so that any running server has time to shutdown
+	Cbuf_AddText(va("game %s\n", modnames.data[i]));
+
+	// start the demo cycle in the new game directory
+	menu_startdemoloop = true;
+
+	M_ForceMenuOff();
+}
+
+static int
+Mods_CurrentModIndex(void)
+{
+	int m;
+
+	for (m = 0; m < modnames.num; m++)
+	{
+		if (M_IsGame(modnames.data[m]))
+		{
+			return m;
+		}
+	}
+
+	return 0;
 }
 
 static void
 Mods_MenuInit(void)
 {
-	int currentmod, x = 0, y = 0, i;
-	char modname[MAX_QPATH]; /* TG626 */
-	char **displaynames, **ptr;
-
-	displaynames = ptr = (char **)s_mods_list.itemnames;
-
-	if (ptr)
-	{
-		while (*ptr)
-		{
-			free(*ptr);
-			ptr ++;
-		}
-
-		free(displaynames);
-	}
+	int x = 0, y = 0;
 
 	Mods_NamesInit();
-
-	/* create array of bracketed display names from folder names - TG626 */
-	displaynames = malloc(sizeof(*displaynames) * (modnames.num + 1));
-	YQ2_COM_CHECK_OOM(displaynames, "malloc()", sizeof(*displaynames) * (modnames.num + 1))
-	if (!displaynames)
-	{
-		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-		return;
-	}
-
-	for (i = 0; i < modnames.num; i++)
-	{
-		strcpy(modname, "[");
-		if (strlen(modnames.data[i]) < 16)
-		{
-			strcat(modname, modnames.data[i]);
-			for (int j=0; j < 15 - strlen(modnames.data[i]); j++)
-			{
-				strcat(modname, " ");
-			}
-		}
-		else
-		{
-			strncat(modname, modnames.data[i], 12);
-			strcat(modname, "...");
-		}
-		strcat(modname, "]");
-
-		displaynames[i] = strdup(modname);
-		YQ2_COM_CHECK_OOM(displaynames[i], "strdup()", strlen(modname) + 1)
-		if (!displaynames[i])
-		{
-			/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-			return;
-		}
-	}
-
-	displaynames[modnames.num] = NULL;
-	/* end TG626 */
-
-	/* pre-select the current mod for display in the list */
-	for (currentmod = 0; currentmod < modnames.num; currentmod++)
-	{
-		if (M_IsGame(modnames.data[currentmod]))
-		{
-			break;
-		}
-	}
 
 	s_mods_menu.x = viddef.width * 0.50;
 	s_mods_menu.nitems = 0;
@@ -3413,8 +3445,8 @@ Mods_MenuInit(void)
 	s_mods_list.generic.x = x;
 	s_mods_list.generic.y = y;
 	s_mods_list.generic.callback = ModsListFunc;
-	s_mods_list.itemnames = (const char **)displaynames;
-	s_mods_list.curvalue = currentmod < modnames.num ? currentmod : 0;
+	s_mods_list.itemnames = (const char **)moddispnames.data;
+	s_mods_list.curvalue = Mods_CurrentModIndex();
 
 	y += 20;
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -3270,52 +3270,40 @@ static menulist_s s_mods_list;
 static menuaction_s s_mods_apply_action;
 static char mods_statusbar[64];
 
-static char **modnames = NULL;
-static int nummods;
+static strlist_t modnames;
 
 void
 Mods_NamesFinish(void)
 {
-	if (modnames)
-	{
-		int i;
-
-		for (i = 0; i < nummods; i ++)
-		{
-			free(modnames[i]);
-		}
-
-		free(modnames);
-		modnames = NULL;
-	}
+	StrList_Free(&modnames);
 }
 
 static void
 Mods_NamesInit(void)
 {
 	/* initialize list of mods once, reuse it afterwards */
-	if (modnames == NULL)
+	if (!modnames.num)
 	{
-		modnames = FS_ListMods(&nummods);
+		modnames = FS_ListMods();
 	}
 }
 
 static void
 ModsListFunc(void *unused)
 {
-	if (strcmp(BASEDIRNAME, modnames[s_mods_list.curvalue]) == 0)
+	if (strcmp(BASEDIRNAME, modnames.data[s_mods_list.curvalue]) == 0)
 	{
 		strcpy(mods_statusbar, "Quake II");
 	}
-	else if (strcmp("ctf", modnames[s_mods_list.curvalue]) == 0)
+	else if (strcmp("ctf", modnames.data[s_mods_list.curvalue]) == 0)
 	{
 		strcpy(mods_statusbar, "Quake II Capture The Flag");
 	}
-	else if (strcmp("rogue", modnames[s_mods_list.curvalue]) == 0)
+	else if (strcmp("rogue", modnames.data[s_mods_list.curvalue]) == 0)
 	{
 		strcpy(mods_statusbar, "Quake II Mission Pack: Ground Zero");
 	}
-	else if (strcmp("xatrix", modnames[s_mods_list.curvalue]) == 0)
+	else if (strcmp("xatrix", modnames.data[s_mods_list.curvalue]) == 0)
 	{
 		strcpy(mods_statusbar, "Quake II Mission Pack: The Reckoning");
 	}
@@ -3328,7 +3316,7 @@ ModsListFunc(void *unused)
 static void
 ModsApplyActionFunc(void *unused)
 {
-	if (!M_IsGame(modnames[s_mods_list.curvalue]))
+	if (!M_IsGame(modnames.data[s_mods_list.curvalue]))
 	{
 		if(Com_ServerState())
 		{
@@ -3338,7 +3326,7 @@ ModsApplyActionFunc(void *unused)
 		}
 
 		// called via command buffer so that any running server has time to shutdown
-		Cbuf_AddText(va("game %s\n", modnames[s_mods_list.curvalue]));
+		Cbuf_AddText(va("game %s\n", modnames.data[s_mods_list.curvalue]));
 
 		// start the demo cycle in the new game directory
 		menu_startdemoloop = true;
@@ -3370,28 +3358,28 @@ Mods_MenuInit(void)
 	Mods_NamesInit();
 
 	/* create array of bracketed display names from folder names - TG626 */
-	displaynames = malloc(sizeof(*displaynames) * (nummods + 1));
-	YQ2_COM_CHECK_OOM(displaynames, "malloc()", sizeof(*displaynames) * (nummods + 1))
+	displaynames = malloc(sizeof(*displaynames) * (modnames.num + 1));
+	YQ2_COM_CHECK_OOM(displaynames, "malloc()", sizeof(*displaynames) * (modnames.num + 1))
 	if (!displaynames)
 	{
 		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
 		return;
 	}
 
-	for (i = 0; i < nummods; i++)
+	for (i = 0; i < modnames.num; i++)
 	{
 		strcpy(modname, "[");
-		if (strlen(modnames[i]) < 16)
+		if (strlen(modnames.data[i]) < 16)
 		{
-			strcat(modname, modnames[i]);
-			for (int j=0; j < 15 - strlen(modnames[i]); j++)
+			strcat(modname, modnames.data[i]);
+			for (int j=0; j < 15 - strlen(modnames.data[i]); j++)
 			{
 				strcat(modname, " ");
 			}
 		}
 		else
 		{
-			strncat(modname, modnames[i], 12);
+			strncat(modname, modnames.data[i], 12);
 			strcat(modname, "...");
 		}
 		strcat(modname, "]");
@@ -3405,13 +3393,13 @@ Mods_MenuInit(void)
 		}
 	}
 
-	displaynames[nummods] = NULL;
+	displaynames[modnames.num] = NULL;
 	/* end TG626 */
 
 	/* pre-select the current mod for display in the list */
-	for (currentmod = 0; currentmod < nummods; currentmod++)
+	for (currentmod = 0; currentmod < modnames.num; currentmod++)
 	{
-		if (M_IsGame(modnames[currentmod]))
+		if (M_IsGame(modnames.data[currentmod]))
 		{
 			break;
 		}
@@ -3426,7 +3414,7 @@ Mods_MenuInit(void)
 	s_mods_list.generic.y = y;
 	s_mods_list.generic.callback = ModsListFunc;
 	s_mods_list.itemnames = (const char **)displaynames;
-	s_mods_list.curvalue = currentmod < nummods ? currentmod : 0;
+	s_mods_list.curvalue = currentmod < modnames.num ? currentmod : 0;
 
 	y += 20;
 
@@ -3612,7 +3600,7 @@ Game_MenuInit(void)
 	Menu_AddItem(&s_game_menu, (void *)&s_save_game_action);
 	Menu_AddItem(&s_game_menu, (void *)&s_credits_action);
 
-	if(nummods > 1)
+	if(modnames.num > 1)
 	{
 		s_mods_action.generic.type = MTYPE_ACTION;
 		s_mods_action.generic.flags = QMF_LEFT_JUSTIFY;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5616,7 +5616,6 @@ static menuaction_s s_player_download_action;
 // player model info
 static strlist_t s_skinnames[MAX_PLAYERMODELS];
 static strlist_t s_modelname;
-static strlist_t s_directory;
 
 static int rate_tbl[] = {2500, 3200, 5000, 10000, 25000, 0};
 static const char *rate_names[] = {"28.8 Modem", "33.6 Modem", "Single ISDN",
@@ -5714,7 +5713,6 @@ PlayerModelFree()
 	}
 
 	StrList_Free(&s_modelname);
-	StrList_Free(&s_directory);
 
 	s_player_model_box.itemnames = NULL;
 	s_player_skin_box.itemnames = NULL;
@@ -5723,31 +5721,19 @@ PlayerModelFree()
 // list all player model directories.
 // directory names are stored players/<modelname>.
 // directory number never exceeds MAX_PLAYERMODELS
-static qboolean
+static strlist_t
 PlayerDirectoryList(void)
 {
-	strlist_t list;
+	strlist_t dirs, list;
 	const char *findname = "players/*";
-	int i, num;
+	int i;
 	size_t listoff = strlen(findname);
 
-	list = FS_ListFilesx2(findname, 0, 0);
-	num = list.num;
+	StrList_Init(&list, 0);
 
-	if (!num)
-	{
-		return false;
-	}
+	dirs = FS_ListFilesx2(findname, 0, 0);
 
-	if (num > MAX_PLAYERMODELS)
-	{
-		Com_Printf("Too many player models (%d)!\n", num);
-		num = MAX_PLAYERMODELS;
-	}
-
-	StrList_Init(&s_directory, 3);
-
-	for (i = 0; i < num; ++i)
+	for (i = 0; i < dirs.num; ++i)
 	{
 		char *slash;
 
@@ -5756,27 +5742,33 @@ PlayerDirectoryList(void)
 		 * pak search does not return directory names, only files in
 		 * directories
 		 */
-		slash = Q_strchrs(list.data[i] + listoff, "/\\");
+		slash = Q_strchrs(dirs.data[i] + listoff, "/\\");
 		if (slash)
 		{
 			*slash = '\0';
 		}
 
-		if (!StrList_Contains(&s_directory, list.data[i]))
+		if (!StrList_Contains(&list, dirs.data[i]))
 		{
-			StrList_Append(&s_directory, list.data[i]);
+			if (list.num >= MAX_PLAYERMODELS)
+			{
+				Com_Printf("Too many player models\n");
+				break;
+			}
+
+			StrList_Append(&list, dirs.data[i]);
 		}
 	}
 
-	StrList_Free(&list);
+	StrList_Free(&dirs);
 
 	/* sort them male, female, alphabetical */
-	if (s_directory.num > 2)
+	if (list.num > 2)
 	{
-		qsort(s_directory.data, s_directory.num - 1, sizeof(char*), dircmp_func);
+		qsort(list.data, list.num - 1, sizeof(char*), dircmp_func);
 	}
 
-	return true;
+	return list;
 }
 
 static void
@@ -5818,20 +5810,20 @@ SkinsInDir(strlist_t *sl, const char *dirname, const char *ext)
  * model names is always allocated MAX_PLAYERMODELS
  */
 static qboolean
-PlayerModelList(void)
+PlayerModelList(const strlist_t *dirs)
 {
 	int i;
 
 	StrList_Init(&s_modelname, 3);
 
 	/* verify the existence of at least one pcx skin */
-	for (i = 0; i < s_directory.num; ++i)
+	for (i = 0; i < dirs->num; ++i)
 	{
 		strlist_t list, *sl;
-		char *s, *t;
+		const char *s, *mdl;
 		int k;
 
-		s = s_directory.data[i];
+		s = dirs->data[i];
 
 		if (!s || !FS_FileExists(s, "tris.md2"))
 		{
@@ -5853,6 +5845,8 @@ PlayerModelList(void)
 
 		for (k = 0; k < list.num; ++k)
 		{
+			char *t;
+
 			if (strstr(list.data[k], "_i.png") ||
 				strstr(list.data[k], "_i.pcx"))
 			{
@@ -5885,19 +5879,20 @@ PlayerModelList(void)
 			qsort(sl->data, sl->num, sizeof(char*), Q_sort_stricmp);
 		}
 
+
 		StrList_Compress(sl);
 
-		t = strrchr(s, '/');
-		if (!t)
+		mdl = strrchr(s, '/');
+		if (!mdl)
 		{
-			t = s;
+			mdl = s;
 		}
 		else
 		{
-			t++;
+			mdl++;
 		}
 
-		StrList_Append(&s_modelname, t);
+		StrList_Append(&s_modelname, mdl);
 
 		StrList_Free(&list);
 	}
@@ -5916,23 +5911,26 @@ PlayerModelList(void)
 static qboolean
 PlayerConfig_ScanDirectories(void)
 {
-	qboolean result = false;
+	strlist_t dirs;
+	qboolean result;
 
 	// directory names
-	result = PlayerDirectoryList();
-
-	if (result == false)
+	dirs = PlayerDirectoryList();
+	if (!dirs.num)
 	{
 		Com_Printf("No valid player directories found.\n");
+		return false;
 	}
 
 	// valid models
-	result = PlayerModelList();
+	result = PlayerModelList(&dirs);
 
-	if (result == false)
+	if (!result)
 	{
 		Com_Printf("No valid player models found.\n");
 	}
+
+	StrList_Free(&dirs);
 
 	return result;
 }

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -6071,11 +6071,20 @@ PlayerConfig_AnimateModel(entity_t *entity, int count, int curTime)
 }
 
 static void
-PlayerConfig_MenuDraw(menuframework_s *m)
+PlayerConfig_ModelDraw(void)
 {
 	refdef_t refdef;
 	float scale = SCR_GetMenuScale();
+	entity_t entities[2];
+	char scratch[MAX_QPATH];
+	int i, curTime;
 	const char *mdlname, *imgname;
+
+	SelectedModelSkin(&mdlname, &imgname);
+	if (!mdlname || !imgname)
+	{
+		return;
+	}
 
 	memset(&refdef, 0, sizeof(refdef));
 
@@ -6087,81 +6096,77 @@ PlayerConfig_MenuDraw(menuframework_s *m)
 	refdef.fov_y = CalcFov(refdef.fov_x, (float)refdef.width, (float)refdef.height);
 	refdef.time = cls.realtime * 0.001f;
 
-	SelectedModelSkin(&mdlname, &imgname);
+	memset(&entities, 0, sizeof(entities));
 
-	if (mdlname && imgname)
+	Com_sprintf(scratch, sizeof(scratch), "players/%s/tris.md2", mdlname);
+	entities[0].model = R_RegisterModel(scratch);
+
+	Com_sprintf(scratch, sizeof(scratch), "players/%s/%s.pcx", mdlname,
+		imgname);
+	entities[0].skin = R_RegisterSkin(scratch);
+
+	curTime = Sys_Milliseconds();
+
+	/* multiplayer weapons loaded */
+	if (num_cl_weaponmodels)
 	{
-		entity_t entities[2];
-		char scratch[MAX_QPATH];
-		int i, curTime;
+		int weapon_id;
 
-		memset(&entities, 0, sizeof(entities));
+		/* change weapon every 3 rounds */
+		weapon_id = curTime / 9000;
 
-		Com_sprintf(scratch, sizeof(scratch), "players/%s/tris.md2", mdlname);
-		entities[0].model = R_RegisterModel(scratch);
-
-		Com_sprintf(scratch, sizeof(scratch), "players/%s/%s.pcx", mdlname,
-			imgname);
-		entities[0].skin = R_RegisterSkin(scratch);
-
-		curTime = Sys_Milliseconds();
-
-		/* multiplayer weapons loaded */
-		if (num_cl_weaponmodels)
-		{
-			int weapon_id;
-
-			/* change weapon every 3 rounds */
-			weapon_id = curTime / 9000;
-
-			weapon_id = weapon_id % num_cl_weaponmodels;
-			/* show weapon also */
-			Com_sprintf(scratch, sizeof(scratch),
-				"players/%s/%s", mdlname, cl_weaponmodels[weapon_id]);
-			entities[1].model = R_RegisterModel(scratch);
-		}
-
-		/* no such weapon model */
-		if (!entities[1].model)
-		{
-			/* show weapon also */
-			Com_sprintf(scratch, sizeof(scratch),
-				"players/%s/weapon.md2", mdlname);
-			entities[1].model = R_RegisterModel(scratch);
-		}
-
-		curTime = curTime % 3000;
-		for (i = 0; i < 2; i++)
-		{
-			entities[i].flags = RF_FULLBRIGHT;
-			entities[i].origin[0] = 80;
-			entities[i].origin[1] = 0;
-			entities[i].origin[2] = 0;
-			VectorCopy(entities[i].origin, entities[i].oldorigin);
-			entities[i].frame = 0;
-			entities[i].oldframe = 0;
-			entities[i].backlerp = 0.0;
-			// one full turn is 3s = 3000ms => 3000/360 deg per millisecond
-			entities[i].angles[1] = (float)curTime/(3000.0f/360.0f);
-		}
-
-		PlayerConfig_AnimateModel(entities, 2, curTime);
-
-		refdef.areabits = 0;
-		refdef.num_entities = (entities[1].model) ? 2 : 1;
-		refdef.entities = entities;
-		refdef.lightstyles = NULL;
-		refdef.rdflags = RDF_NOWORLDMODEL;
-
-		Menu_Draw(m);
-
-		M_DrawTextBox(((int)(refdef.x) * (320.0F / viddef.width) - 8),
-					  (int)((viddef.height / 2) * (240.0F / viddef.height) - 77),
-					  refdef.width / (8 * scale), refdef.height / (8 * scale));
-		refdef.height += 4 * scale;
-
-		R_RenderFrame(&refdef);
+		weapon_id = weapon_id % num_cl_weaponmodels;
+		/* show weapon also */
+		Com_sprintf(scratch, sizeof(scratch),
+			"players/%s/%s", mdlname, cl_weaponmodels[weapon_id]);
+		entities[1].model = R_RegisterModel(scratch);
 	}
+
+	/* no such weapon model */
+	if (!entities[1].model)
+	{
+		/* show weapon also */
+		Com_sprintf(scratch, sizeof(scratch),
+			"players/%s/weapon.md2", mdlname);
+		entities[1].model = R_RegisterModel(scratch);
+	}
+
+	curTime = curTime % 3000;
+	for (i = 0; i < 2; i++)
+	{
+		entities[i].flags = RF_FULLBRIGHT;
+		entities[i].origin[0] = 80;
+		entities[i].origin[1] = 0;
+		entities[i].origin[2] = 0;
+		VectorCopy(entities[i].origin, entities[i].oldorigin);
+		entities[i].frame = 0;
+		entities[i].oldframe = 0;
+		entities[i].backlerp = 0.0;
+		// one full turn is 3s = 3000ms => 3000/360 deg per millisecond
+		entities[i].angles[1] = (float)curTime/(3000.0f/360.0f);
+	}
+
+	PlayerConfig_AnimateModel(entities, 2, curTime);
+
+	refdef.areabits = 0;
+	refdef.num_entities = (entities[1].model) ? 2 : 1;
+	refdef.entities = entities;
+	refdef.lightstyles = NULL;
+	refdef.rdflags = RDF_NOWORLDMODEL;
+
+	M_DrawTextBox(((int)(refdef.x) * (320.0F / viddef.width) - 8),
+	  (int)((viddef.height / 2) * (240.0F / viddef.height) - 77),
+	  refdef.width / (8 * scale), refdef.height / (8 * scale));
+	refdef.height += 4 * scale;
+
+	R_RenderFrame(&refdef);
+}
+
+static void
+PlayerConfig_MenuDraw(menuframework_s *m)
+{
+	PlayerConfig_ModelDraw();
+	Default_MenuDraw(m);
 }
 
 static void

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -4545,7 +4545,7 @@ GetMapsInFolderList(int *nummaps)
 	char **mapnames = NULL;
 	int i;
 
-	list = FS_ListFilesx2("maps/*.bsp", 0, 0);
+	list = FS_ListFiles2("maps/*.bsp", 0, 0);
 	if (!list.num)
 	{
 		Com_Printf("couldn't find maps/*.bsp\n");
@@ -5719,7 +5719,7 @@ PlayerDirectoryList(void)
 
 	StrList_Init(&list, 0);
 
-	dirs = FS_ListFilesx2(findname, 0, 0);
+	dirs = FS_ListFiles2(findname, 0, 0);
 
 	for (i = 0; i < dirs.num; ++i)
 	{
@@ -5773,7 +5773,7 @@ SkinsInDir(strlist_t *sl, const char *dirname, const char *ext)
 		return;
 	}
 
-	list = FS_ListFilesx2(findname, 0, 0);
+	list = FS_ListFiles2(findname, 0, 0);
 	dirname_size = strlen(dirname) + 1;
 
 	StrList_Expand(sl, sl->num + list.num);

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5546,10 +5546,27 @@ RateCallback(void *unused)
 }
 
 static void
+SkinCallback(void *unused)
+{
+	const char *mdl, *img;
+
+	SelectedModelSkin(&mdl, &img);
+
+	if (!mdl || !img ||
+		snprintf(player_icon_path, sizeof(player_icon_path),
+			"/players/%s/%s_i.pcx", mdl,img) >= sizeof(player_icon_path))
+	{
+		*player_icon_path = '\0';
+	}
+}
+
+static void
 ModelCallback(void *unused)
 {
 	s_player_skin_box.itemnames = (const char **)s_skinnames[s_player_model_box.curvalue].data;
 	s_player_skin_box.curvalue = 0;
+
+	SkinCallback(&s_player_skin_box);
 }
 
 // returns true if icon .pcx exists for skin .pcx
@@ -5953,10 +5970,13 @@ PlayerConfig_MenuInit(void)
 	s_player_skin_box.generic.x = -56 * scale;
 	s_player_skin_box.generic.y = 94;
 	s_player_skin_box.generic.name = NULL;
-	s_player_skin_box.generic.callback = NULL;
+	s_player_skin_box.generic.callback = SkinCallback;
 	s_player_skin_box.generic.cursor_offset = -48;
 	s_player_skin_box.curvalue = imgindex;
 	s_player_skin_box.itemnames = (const char **)s_skinnames[mdlindex].data;
+
+	/* initialize player icon */
+	SkinCallback(&s_player_skin_box);
 
 	s_player_hand_title.generic.type = MTYPE_SEPARATOR;
 	s_player_hand_title.generic.name = "handedness";
@@ -6132,9 +6152,6 @@ PlayerConfig_MenuDraw(menuframework_s *m)
 		refdef.entities = entities;
 		refdef.lightstyles = NULL;
 		refdef.rdflags = RDF_NOWORLDMODEL;
-
-		Com_sprintf(player_icon_path, sizeof(player_icon_path),
-			"/players/%s/%s_i.pcx", mdlname, imgname);
 
 		Menu_Draw(m);
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5727,11 +5727,10 @@ static qboolean
 PlayerDirectoryList(void)
 {
 	strlist_t list;
-	const char* findname = "players/*";
-	int num, dirnum = 0;
+	const char *findname = "players/*";
+	int i, num;
 	size_t listoff = strlen(findname);
 
-	/* get a list of "players" subdirectories or files */
 	list = FS_ListFilesx2(findname, 0, 0);
 	num = list.num;
 
@@ -5746,71 +5745,29 @@ PlayerDirectoryList(void)
 		num = MAX_PLAYERMODELS;
 	}
 
-	// malloc directories
-	char** data = (char**)calloc(num + 1, sizeof(char*));
-	YQ2_COM_CHECK_OOM(data, "calloc()", num * sizeof(char*))
-	if (!data)
+	StrList_Init(&s_directory, 3);
+
+	for (i = 0; i < num; ++i)
 	{
-		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-		return false;
-	}
-
-	s_directory.data = data;
-
-	for (int i = 0; i < num; ++i)
-	{
-		char dirname[MAX_QPATH];
-		const char *dirsize;
-		int j;
-
-		// last element of FS_FileList maybe null
-		if (list.data[i] == 0)
-		{
-			break;
-		}
+		char *slash;
 
 		/*
 		 * search slash after "players/" and use only directory name
 		 * pak search does not return directory names, only files in
 		 * directories
 		 */
-		dirsize = Q_strchrs(list.data[i] + listoff, "/\\");
-		if (dirsize)
+		slash = Q_strchrs(list.data[i] + listoff, "/\\");
+		if (slash)
 		{
-			int dirnamelen = 0;
-
-			dirnamelen = dirsize - list.data[i];
-			memcpy(dirname, list.data[i], dirnamelen);
-			dirname[dirnamelen] = 0;
-		}
-		else
-		{
-			Q_strlcpy(dirname, list.data[i], sizeof(dirname));
+			*slash = '\0';
 		}
 
-		for (j = 0; j < dirnum; j++)
+		if (!StrList_Contains(&s_directory, list.data[i]))
 		{
-			if (!strcmp(dirname, data[j]))
-			{
-				break;
-			}
-		}
-
-		if (j == dirnum)
-		{
-			char* s = (char*)malloc(MAX_QPATH);
-
-			YQ2_COM_CHECK_OOM(s, "malloc()", MAX_QPATH * sizeof(char))
-
-			Q_strlcpy(s, dirname, MAX_QPATH);
-			data[dirnum] = s;
-			dirnum ++;
+			StrList_Append(&s_directory, list.data[i]);
 		}
 	}
 
-	s_directory.num = dirnum;
-
-	// free file list
 	StrList_Free(&list);
 
 	/* sort them male, female, alphabetical */

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5895,9 +5895,10 @@ PlayerConfig_MenuInit(void)
 	int i = 0;
 	float scale = SCR_GetMenuScale();
 
-	if (PlayerConfig_ScanDirectories() == false)
+	if (!PlayerConfig_ScanDirectories())
 	{
-		return false;
+		Menu_StartPopup(&m_popup,
+			"No player models\nwere found", 3000);
 	}
 
 	Q_strlcpy(mdlname, skin->string, sizeof(mdlname));
@@ -6035,13 +6036,8 @@ PlayerConfig_MenuInit(void)
 	Menu_AddItem(&s_player_config_menu, &s_player_icon_bitmap);
 	Menu_AddItem(&s_player_config_menu, &s_player_model_title);
 	Menu_AddItem(&s_player_config_menu, &s_player_model_box);
-
-	if (s_player_skin_box.itemnames)
-	{
-		Menu_AddItem(&s_player_config_menu, &s_player_skin_title);
-		Menu_AddItem(&s_player_config_menu, &s_player_skin_box);
-	}
-
+	Menu_AddItem(&s_player_config_menu, &s_player_skin_title);
+	Menu_AddItem(&s_player_config_menu, &s_player_skin_box);
 	Menu_AddItem(&s_player_config_menu, &s_player_hand_title);
 	Menu_AddItem(&s_player_config_menu, &s_player_handedness_box);
 	Menu_AddItem(&s_player_config_menu, &s_player_rate_title);

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5611,12 +5611,6 @@ static menuaction_s s_player_download_action;
 
 #define MAX_PLAYERMODELS 1024
 
-typedef struct _strlist
-{
-	char** data;
-	int num;
-} strlist_t;
-
 // player model info
 static strlist_t s_skinnames[MAX_PLAYERMODELS];
 static strlist_t s_modelname;

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5487,6 +5487,7 @@ static menuaction_s s_player_download_action;
 // player model info
 static strlist_t s_skinnames[MAX_PLAYERMODELS];
 static strlist_t s_modelname;
+static char player_icon_path[MAX_QPATH];
 
 static int rate_tbl[] = {2500, 3200, 5000, 10000, 25000, 0};
 static const char *rate_names[] = {"28.8 Modem", "33.6 Modem", "Single ISDN",
@@ -5895,7 +5896,7 @@ PlayerConfig_MenuInit(void)
 	s_player_icon_bitmap.generic.flags = QMF_INACTIVE;
 	s_player_icon_bitmap.generic.x = ((viddef.width / scale - 95) / 2) - 87;
 	s_player_icon_bitmap.generic.y = ((viddef.height / (2 * scale))) - 72;
-	s_player_icon_bitmap.generic.name = NULL;
+	s_player_icon_bitmap.generic.name = player_icon_path;
 	s_player_icon_bitmap.generic.callback = NULL;
 	s_player_icon_bitmap.focuspic = 0;
 
@@ -6103,11 +6104,8 @@ PlayerConfig_MenuDraw(menuframework_s *m)
 		refdef.lightstyles = NULL;
 		refdef.rdflags = RDF_NOWORLDMODEL;
 
-		Com_sprintf(scratch, sizeof(scratch), "/players/%s/%s_i.pcx", mdlname,
-			imgname);
-
-		// icon bitmap to draw
-		s_player_icon_bitmap.generic.name = scratch;
+		Com_sprintf(player_icon_path, sizeof(player_icon_path),
+			"/players/%s/%s_i.pcx", mdlname, imgname);
 
 		Menu_Draw(m);
 

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5493,6 +5493,37 @@ static int rate_tbl[] = {2500, 3200, 5000, 10000, 25000, 0};
 static const char *rate_names[] = {"28.8 Modem", "33.6 Modem", "Single ISDN",
 								   "Dual ISDN/Cable", "T1/LAN", "User defined", NULL};
 
+
+static void
+SelectedModelSkin(const char **mdl, const char **img)
+{
+	int mi = s_player_model_box.curvalue;
+	int si = s_player_skin_box.curvalue;
+
+	if (mdl)
+	{
+		*mdl = NULL;
+	}
+
+	if (img)
+	{
+		*img = NULL;
+	}
+
+	if (mi >= 0 && mi < s_modelname.num)
+	{
+		if (mdl)
+		{
+			*mdl = s_modelname.data[mi];
+		}
+
+		if (img && si >= 0 && si < s_skinnames[mi].num)
+		{
+			*img = s_skinnames[mi].data[si];
+		}
+	}
+}
+
 static void
 DownloadOptionsFunc(void *self)
 {
@@ -6024,6 +6055,7 @@ PlayerConfig_MenuDraw(menuframework_s *m)
 {
 	refdef_t refdef;
 	float scale = SCR_GetMenuScale();
+	const char *mdlname, *imgname;
 
 	memset(&refdef, 0, sizeof(refdef));
 
@@ -6035,15 +6067,12 @@ PlayerConfig_MenuDraw(menuframework_s *m)
 	refdef.fov_y = CalcFov(refdef.fov_x, (float)refdef.width, (float)refdef.height);
 	refdef.time = cls.realtime * 0.001f;
 
-	// could remove this, there should be a valid set of models
-	if ((s_player_model_box.curvalue >= 0 && s_player_model_box.curvalue < s_modelname.num)
-		&& (s_player_skin_box.curvalue >= 0
-		&& s_player_skin_box.curvalue < s_skinnames[s_player_model_box.curvalue].num))
+	SelectedModelSkin(&mdlname, &imgname);
+
+	if (mdlname && imgname)
 	{
 		entity_t entities[2];
 		char scratch[MAX_QPATH];
-		char* mdlname = s_modelname.data[s_player_model_box.curvalue];
-		char* imgname = s_skinnames[s_player_model_box.curvalue].data[s_player_skin_box.curvalue];
 		int i, curTime;
 
 		memset(&entities, 0, sizeof(entities));
@@ -6121,20 +6150,21 @@ PlayerConfig_MenuDraw(menuframework_s *m)
 static void
 PlayerConfig_MenuClose(menuframework_s *m)
 {
-	const char* name = NULL;
-	char skin[MAX_QPATH];
-	char* mdl = NULL;
-	char* img = NULL;
+	const char* name;
+	const char *mdl, *img;
 
 	name = s_player_name_field.buffer;
-	mdl = s_modelname.data[s_player_model_box.curvalue];
-	img = s_skinnames[s_player_model_box.curvalue].data[s_player_skin_box.curvalue];
-
-	Com_sprintf(skin, MAX_QPATH, "%s/%s", mdl, img);
-
-	// set <name> and <model dir>/<skin>
 	Cvar_Set("name", name);
-	Cvar_Set("skin", skin);
+
+	SelectedModelSkin(&mdl, &img);
+	if (mdl && img)
+	{
+		char skin[MAX_QPATH];
+
+		Com_sprintf(skin, sizeof(skin), "%s/%s", mdl, img);
+
+		Cvar_Set("skin", skin);
+	}
 
 	PlayerModelFree();          // free player skins, models and directories
 }

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5706,69 +5706,18 @@ dircmp_func(const void* _a, const void* _b)
 static void
 PlayerModelFree()
 {
-	char* s = NULL;
+	int i;
 
-	// there should be no valid skin names if there is no valid model
-	if (s_modelname.num != 0)
+	for (i = 0; i < MAX_PLAYERMODELS; i++)
 	{
-		while (s_modelname.num-- > 0)
-		{
-			// skins
-			while (s_skinnames[s_modelname.num].num-- > 0)
-			{
-				s = s_skinnames[s_modelname.num].data[s_skinnames[s_modelname.num].num];
-				if (s != NULL)
-				{
-					free(s);
-				}
-			}
-
-			s = (char*)s_skinnames[s_modelname.num].data;
-
-			if (s != NULL)
-			{
-				free(s);
-			}
-
-			s_skinnames[s_modelname.num].data = 0;
-			s_skinnames[s_modelname.num].num = 0;
-
-			// models
-			s = s_modelname.data[s_modelname.num];
-			if (s != NULL)
-			{
-				free(s);
-			}
-		}
+		StrList_Free(&s_skinnames[i]);
 	}
 
-	s = (char*)s_modelname.data;
-	if (s != NULL)
-	{
-		free(s);
-	}
+	StrList_Free(&s_modelname);
+	StrList_Free(&s_directory);
 
-	s_modelname.data = 0;
-	s_modelname.num = 0;
-
-	// directories
-	while (s_directory.num-- > 0)
-	{
-		s = s_directory.data[s_directory.num];
-		if (s != NULL)
-		{
-			free(s);
-		}
-	}
-
-	s = (char*)s_directory.data;
-	if (s != NULL)
-	{
-		free(s);
-	}
-
-	s_directory.data = 0;
-	s_directory.num = 0;
+	s_player_model_box.itemnames = NULL;
+	s_player_skin_box.itemnames = NULL;
 }
 
 // list all player model directories.

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -5779,7 +5779,7 @@ PlayerDirectoryList(void)
 	return true;
 }
 
-void
+static void
 SkinsInDir(strlist_t *sl, const char *dirname, const char *ext)
 {
 	strlist_t list;
@@ -5820,165 +5820,97 @@ SkinsInDir(strlist_t *sl, const char *dirname, const char *ext)
 static qboolean
 PlayerModelList(void)
 {
-	strlist_t list;
-	char** data = NULL;
 	int i;
-	int mdl = 0;
-	qboolean result = true;
 
-	// malloc models
-	data = (char**)calloc(MAX_PLAYERMODELS, sizeof(char*));
-	YQ2_COM_CHECK_OOM(data, "calloc()", MAX_PLAYERMODELS * sizeof(char*))
-	if (!data)
-	{
-		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-		return false;
-	}
-
-	s_modelname.data = data;
-	s_modelname.num = 0;
+	StrList_Init(&s_modelname, 3);
 
 	/* verify the existence of at least one pcx skin */
 	for (i = 0; i < s_directory.num; ++i)
 	{
-		char* s = NULL;
-		char* t = NULL;
-		int l;
+		strlist_t list, *sl;
+		char *s, *t;
+		int k;
 
-		if (s_directory.data[i] == 0)
-		{
-			continue;
-		}
-
-		/* contains triangle .md2 model */
 		s = s_directory.data[i];
 
-		if (!FS_FileExists(s, "tris.md2"))
+		if (!s || !FS_FileExists(s, "tris.md2"))
 		{
-			/* invalid player model */
 			continue;
 		}
-
 
 		StrList_Init(&list, 0);
 
 		SkinsInDir(&list, s, "pcx");
 		SkinsInDir(&list, s, "png");
 
-		/* get a list of pcx files */
 		if (!list.num)
 		{
 			continue;
 		}
 
-		/* count valid skins, which consist of a skin with a matching "_i" icon */
-		s_skinnames[mdl].num = 0;
+		sl = &s_skinnames[s_modelname.num];
+		StrList_Init(sl, 0);
 
-		for (int j = 0; j < list.num; j++)
+		for (k = 0; k < list.num; ++k)
 		{
-			/* last element of FS_FileList maybe null */
-			if (list.data[j] == 0)
+			if (strstr(list.data[k], "_i.png") ||
+				strstr(list.data[k], "_i.pcx"))
 			{
-				break;
+				continue;
 			}
 
-			if (!strstr(list.data[j], "_i.png") ||
-				!strstr(list.data[j], "_i.pcx"))
+			if (!IconOfSkinExists(list.data[k], &list, "png") &&
+				!IconOfSkinExists(list.data[k], &list, "pcx"))
 			{
-				if (IconOfSkinExists(list.data[j], &list, "png") ||
-					IconOfSkinExists(list.data[j], &list, "pcx"))
-				{
-					s_skinnames[mdl].num++;
-				}
-			}
-		}
-
-		if (s_skinnames[mdl].num == 0)
-		{
-			StrList_Free(&list);
-			continue;
-		}
-
-		/* malloc skinnames */
-		data = (char**)malloc((s_skinnames[mdl].num + 1) * sizeof(char*));
-		YQ2_COM_CHECK_OOM(data, "malloc()", (s_skinnames[mdl].num + 1) * sizeof(char*))
-		if (!data)
-		{
-			/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-			return false;
-		}
-
-		memset(data, 0, (s_skinnames[mdl].num + 1) * sizeof(char*));
-
-		s_skinnames[mdl].data = data;
-		s_skinnames[mdl].num = 0;
-
-		/* duplicate strings */
-		for (int k = 0; k < list.num; ++k)
-		{
-			/* last element of FS_FileList maybe null */
-			if (list.data[k] == 0)
-			{
-				break;
+				continue;
 			}
 
-			if (!strstr(list.data[k], "_i.png") ||
-				!strstr(list.data[k], "_i.pcx"))
+			t = Q_strrchrs(list.data[k], "/\\");
+			if (!t)
 			{
-				if (IconOfSkinExists(list.data[k], &list, "png") ||
-					IconOfSkinExists(list.data[k], &list, "pcx"))
-				{
-					t = Q_strrchrs(list.data[k], "/\\");
-
-					l = strlen(t) + 1;
-					s = (char*)malloc(l);
-
-					YQ2_COM_CHECK_OOM(s, "malloc()", l * sizeof(char))
-					if (!s)
-					{
-						/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-						return false;
-					}
-
-					COM_StripExtension2(t);
-					Q_strlcpy(s, t + 1, l);
-
-					data[s_skinnames[mdl].num++] = s;
-				}
+				t = list.data[k];
 			}
+			else
+			{
+				t++;
+			}
+
+			COM_StripExtension2(t);
+
+			StrList_Append(sl, t);
 		}
 
-		/* sort skin names alphabetically */
-		qsort(s_skinnames[mdl].data, s_skinnames[mdl].num, sizeof(char*), Q_sort_stricmp);
-
-		/* at this point we have a valid player model */
-		t = strrchr(s_directory.data[i], '/');
-		l = strlen(t) + 1;
-		s = (char*)malloc(l);
-
-		YQ2_COM_CHECK_OOM(s, "malloc()", l * sizeof(char))
-		if (!s)
+		if (sl->num > 1)
 		{
-			/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-			return false;
+			qsort(sl->data, sl->num, sizeof(char*), Q_sort_stricmp);
 		}
 
-		Q_strlcpy(s, t + 1, l);
+		StrList_Compress(sl);
 
-		s_modelname.data[s_modelname.num++] = s;
-		mdl = s_modelname.num;
+		t = strrchr(s, '/');
+		if (!t)
+		{
+			t = s;
+		}
+		else
+		{
+			t++;
+		}
 
-		/* free file list */
+		StrList_Append(&s_modelname, t);
+
 		StrList_Free(&list);
 	}
 
-	if (s_modelname.num == 0)
+	if (!s_modelname.num)
 	{
 		PlayerModelFree();
-		result = false;
+		return false;
 	}
 
-	return result;
+	StrList_Compress(&s_modelname);
+
+	return true;
 }
 
 static qboolean

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -4293,8 +4293,7 @@ M_Menu_JoinServer_f(void)
  */
 
 static menuframework_s s_startserver_menu;
-static char **mapnames = NULL;
-static int nummaps;
+static strlist_t maplist;
 
 static menuaction_s s_startserver_start_action;
 static menuaction_s s_startserver_dmoptions_action;
@@ -4369,7 +4368,12 @@ StartServerActionFunc(void *self)
 	float fraglimit;
 	float maxclients;
 
-	startmap = strchr(mapnames[s_startmap_list.curvalue], '\n');
+	if (s_startmap_list.curvalue >= maplist.num)
+	{
+		return;
+	}
+
+	startmap = strchr(maplist.data[s_startmap_list.curvalue], '\n');
 
 	if (!startmap)
 	{
@@ -4435,267 +4439,112 @@ StartServerActionFunc(void *self)
 void
 CleanCachedMapsList(void)
 {
-	if (mapnames != NULL)
-	{
-		size_t i;
+	StrList_Free(&maplist);
 
-		for (i = 0; i < nummaps; i++)
-		{
-			free(mapnames[i]);
-		}
-
-		free(mapnames);
-		mapnames = NULL;
-	}
+	s_startmap_list.itemnames = NULL;
 }
 
-static char**
-GetMapsList(int *num)
+static strlist_t
+MapsInLst(void)
 {
-	int length;
+	strlist_t list;
 	char *buffer;
 
-	/* load the list of map names */
-	if ((length = FS_LoadFile("maps.lst", (void **)&buffer)) != -1)
+	StrList_Init(&list, 0);
+
+	if (FS_LoadFile("maps.lst", (void **)&buffer) > 0)
 	{
-		char **mapnames = NULL;
-		size_t nummapslen;
-		int i, nummaps = 0;
+		char *bufpos;
 
-		char *s;
+		bufpos = buffer;
 
-		s = buffer;
-		i = 0;
-
-		while (i < length)
+		while (bufpos)
 		{
-			if (s[i] == '\n')
+			char shortname[64];
+			char scratch[128];
+			const char *s;
+
+			s = COM_Parse(&bufpos);
+			if (!s || *s == '\0')
 			{
-				nummaps++;
+				break;
 			}
 
-			i++;
-		}
-
-		if (nummaps == 0)
-		{
-			Com_Printf("no maps in maps.lst\n");
-			/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-			return NULL;
-		}
-
-		nummapslen = sizeof(char *) * (nummaps + 1);
-		mapnames = malloc(nummapslen);
-
-		YQ2_COM_CHECK_OOM(mapnames, "malloc(sizeof(char *) * (nummaps + 1))", nummapslen)
-		if (!mapnames)
-		{
-			/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-			return NULL;
-		}
-
-		memset(mapnames, 0, nummapslen);
-
-		s = buffer;
-
-		for (i = 0; i < nummaps; i++)
-		{
-			char shortname[MAX_TOKEN_CHARS];
-			char longname[MAX_TOKEN_CHARS];
-			char scratch[200];
-			size_t j, l;
-
-			Q_strlcpy(shortname, COM_Parse(&s), sizeof(shortname));
-			l = strlen(shortname);
-
-			for (j = 0; j < l; j++)
-			{
-				shortname[j] = toupper((unsigned char)shortname[j]);
-			}
-
-			Q_strlcpy(longname, COM_Parse(&s), sizeof(longname));
-			Com_sprintf(scratch, sizeof(scratch), "%s\n%s", longname, shortname);
-
-			mapnames[i] = strdup(scratch);
-			YQ2_COM_CHECK_OOM(mapnames[i], "strdup(scratch)", strlen(scratch)+1)
-			if (!mapnames[i])
-			{
-				free(mapnames);
-				/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-				return NULL;
-			}
-		}
-
-		mapnames[nummaps] = NULL;
-		FS_FreeFile(buffer);
-
-		*num = nummaps;
-		return mapnames;
-	}
-
-	return NULL;
-}
-
-static char**
-GetMapsInFolderList(int *nummaps)
-{
-	/* Generate list by bsp files in maps/ directory */
-	strlist_t list;
-	size_t nummapslen;
-	char **mapnames = NULL;
-	int i;
-
-	list = FS_ListFiles2("maps/*.bsp", 0, 0);
-	if (!list.num)
-	{
-		Com_Printf("couldn't find maps/*.bsp\n");
-		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-		return NULL;
-	}
-
-	nummapslen = sizeof(char *) * (list.num + 1);
-	mapnames = malloc(nummapslen);
-	YQ2_COM_CHECK_OOM(mapnames, "malloc(sizeof(char *) * (num))", nummapslen)
-	if (!mapnames)
-	{
-		StrList_Free(&list);
-		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-		return NULL;
-	}
-
-	memset(mapnames, 0, nummapslen);
-
-	for (i = 0; i < list.num; i++)
-	{
-		char scratch[200], shortname[MAX_QPATH];
-		int len;
-
-		len = strlen(list.data[i]);
-		if (len > 9 && len < MAX_QPATH)
-		{
-			/* maps/ + .bsp */
-			Q_strlcpy(shortname, list.data[i] + 5, sizeof(shortname));
-			shortname[len - 9]  = 0;
-
-			Com_sprintf(scratch, sizeof(scratch), "%s\n%s", shortname, shortname);
-
-			mapnames[i] = strdup(scratch);
-			YQ2_COM_CHECK_OOM(mapnames[i], "strdup(scratch)", strlen(scratch)+1)
-			if (!mapnames[i])
-			{
-				/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-				return NULL;
-			}
-		}
-	}
-
-	mapnames[list.num] = NULL;
-
-	/* sort maps names alphabetically */
-	qsort(mapnames, list.num, sizeof(char*), Q_sort_stricmp);
-
-	*nummaps = list.num;
-
-	/* free file list */
-	StrList_Free(&list);
-
-	return mapnames;
-}
-
-static char**
-GetCombinedMapsList(int *nummaps)
-{
-	char **mapnames_list = NULL, **mapnames_folder = NULL, **mapnames = NULL;
-	int nummaps_list = 0, nummaps_folder = 0;
-	size_t nummapslen, currpos;
-
-	mapnames_folder = GetMapsInFolderList(&nummaps_folder);
-	if (!mapnames_folder)
-	{
-		/* no maps at all? */
-		return NULL;
-	}
-
-	mapnames_list = GetMapsList(&nummaps_list);
-	if (!mapnames_list)
-	{
-		/* no maps in list? */
-		*nummaps = nummaps_folder;
-		return mapnames_folder;
-	}
-
-	/* we have maps in file and in folder */
-	nummapslen = sizeof(char *) * (nummaps_list + nummaps_folder + 1);
-	mapnames = malloc(nummapslen);
-	YQ2_COM_CHECK_OOM(mapnames, "malloc(sizeof(char *) * (num))", nummapslen)
-	if (!mapnames)
-	{
-		size_t i;
-
-		for (i = 0; i < nummaps_list; i++)
-		{
-			free(mapnames_list[i]);
-		}
-
-		free(mapnames_list);
-		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-		*nummaps = nummaps_folder;
-		return mapnames_folder;
-	}
-
-	memset(mapnames, 0, nummapslen);
-	memcpy(mapnames, mapnames_list, sizeof(char *) * nummaps_list);
-	*nummaps = nummaps_list;
-	free(mapnames_list);
-
-	for (currpos = 0; currpos < nummaps_folder; currpos ++)
-	{
-		qboolean found;
-		char *foldername;
-		size_t i;
-
-		foldername = strchr(mapnames_folder[currpos], '\n');
-		if (!foldername)
-		{
-			free(mapnames_folder[currpos]);
-			continue;
-		}
-		foldername++;
-
-		found = false;
-		for (i = 0; i < *nummaps; i++)
-		{
-			char *currname;
-
-			currname = strchr(mapnames[i], '\n');
-			if (!currname)
+			if (Q_strlcpy(shortname, s,
+				sizeof(shortname)) >= sizeof(shortname))
 			{
 				continue;
 			}
-			currname++;
 
-			if (!Q_stricmp(currname, foldername))
+			Q_strupr(shortname);
+
+			s = COM_Parse(&bufpos);
+			if (!s || *s == '\0')
 			{
-				found = true;
 				break;
 			}
-		}
 
-		if (!found)
-		{
-			mapnames[*nummaps] = mapnames_folder[currpos];
-			(*nummaps) ++;
-		}
-		else
-		{
-			free(mapnames_folder[currpos]);
+			if (snprintf(scratch, sizeof(scratch),
+				"%.*s\n%s",
+				63, s, shortname) < sizeof(scratch))
+			{
+				StrList_Append(&list, scratch);
+			}
 		}
 	}
 
-	mapnames[*nummaps] = NULL;
+	FS_FreeFile(buffer);
 
-	free(mapnames_folder);
-	return mapnames;
+	return list;
+}
+
+static int
+ls_mapeq(const char *list_s, const char *targ_s)
+{
+	const char *slash = strchr(list_s, '\n');
+
+	return (!slash) ? 0 : Q_stricmp(targ_s, slash + 1);
+}
+
+/* Add bsp files in maps/ dir to list */
+static void
+MapsInFolder(strlist_t *maps)
+{
+	strlist_t list;
+	int i;
+
+	list = FS_ListFiles2("maps/*.bsp", 0, 0);
+
+	for (i = 0; i < list.num; i++)
+	{
+		char scratch[128];
+		const char *s;
+		size_t len;
+
+		len = strlen(list.data[i]);
+		/* maps/ + .bsp */
+		if (len <= 9 || len > (63+9))
+		{
+			continue;
+		}
+
+		list.data[i][len - 4]  = '\0';
+
+		s = list.data[i] + 5;
+
+		if (StrList_Contains2(maps, ls_mapeq, s))
+		{
+			continue;
+		}
+
+		if (snprintf(scratch, sizeof(scratch), "%s\n%s",
+			s, s) < sizeof(scratch))
+		{
+			StrList_Append(maps, scratch);
+		}
+	}
+
+	StrList_Free(&list);
 }
 
 static void
@@ -4720,17 +4569,19 @@ StartServer_MenuInit(void)
 	float scale = SCR_GetMenuScale();
 
 	/* initialize list of maps once, reuse it afterwards (=> it isn't freed unless the game dir is changed) */
-	if (mapnames == NULL)
+	if (!maplist.num)
 	{
-		nummaps = 0;
 		s_startmap_list.curvalue = 0;
 
-		mapnames = GetCombinedMapsList(&nummaps);
+		maplist = MapsInLst();
 
-		if (!mapnames || !nummaps)
+		MapsInFolder(&maplist);
+
+		StrList_Compress(&maplist);
+
+		if (!maplist.num)
 		{
-			Com_Error(ERR_DROP, "no maps in maps.lst\n");
-			return;
+			Menu_StartPopup(&m_popup, "No maps were found\nin maps.lst or folders", 2000);
 		}
 	}
 
@@ -4744,7 +4595,7 @@ StartServer_MenuInit(void)
 	s_startmap_list.generic.x = 0;
 	s_startmap_list.generic.y = y;
 	s_startmap_list.generic.name = "initial map";
-	s_startmap_list.itemnames = (const char **)mapnames;
+	s_startmap_list.itemnames = (const char **)maplist.data;
 
 	if (M_IsGame("ctf"))
 	{

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -3275,7 +3275,7 @@ static char mods_statusbar[64];
 static strlist_t modnames;
 static strlist_t moddispnames;
 
-void
+static void
 Mods_NamesFinish(void)
 {
 	StrList_Free(&modnames);
@@ -6323,4 +6323,12 @@ M_Keydown(int key)
 			S_StartLocalSound(s);
 		}
 	}
+}
+
+void
+M_Free(void)
+{
+	Mods_NamesFinish();
+	CleanCachedMapsList();
+	PlayerModelFree();
 }

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -4552,40 +4552,41 @@ static char**
 GetMapsInFolderList(int *nummaps)
 {
 	/* Generate list by bsp files in maps/ directory */
+	strlist_t list;
 	size_t nummapslen;
-	char **list = NULL, **mapnames = NULL;
-	int num = 0, i;
+	char **mapnames = NULL;
+	int i;
 
-	list = FS_ListFiles2("maps/*.bsp", &num, 0, 0);
-	if (!list)
+	list = FS_ListFilesx2("maps/*.bsp", 0, 0);
+	if (!list.num)
 	{
 		Com_Printf("couldn't find maps/*.bsp\n");
 		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
 		return NULL;
 	}
 
-	nummapslen = sizeof(char *) * (num);
+	nummapslen = sizeof(char *) * (list.num + 1);
 	mapnames = malloc(nummapslen);
 	YQ2_COM_CHECK_OOM(mapnames, "malloc(sizeof(char *) * (num))", nummapslen)
 	if (!mapnames)
 	{
-		FS_FreeList(list, num);
+		StrList_Free(&list);
 		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
 		return NULL;
 	}
 
 	memset(mapnames, 0, nummapslen);
 
-	for (i = 0; i < num - 1; i++)
+	for (i = 0; i < list.num; i++)
 	{
 		char scratch[200], shortname[MAX_QPATH];
 		int len;
 
-		len = strlen(list[i]);
+		len = strlen(list.data[i]);
 		if (len > 9 && len < MAX_QPATH)
 		{
 			/* maps/ + .bsp */
-			Q_strlcpy(shortname, list[i] + 5, sizeof(shortname));
+			Q_strlcpy(shortname, list.data[i] + 5, sizeof(shortname));
 			shortname[len - 9]  = 0;
 
 			Com_sprintf(scratch, sizeof(scratch), "%s\n%s", shortname, shortname);
@@ -4600,14 +4601,15 @@ GetMapsInFolderList(int *nummaps)
 		}
 	}
 
-	mapnames[num - 1] = NULL;
+	mapnames[list.num] = NULL;
 
 	/* sort maps names alphabetically */
-	qsort(mapnames, num - 1, sizeof(char*), Q_sort_stricmp);
+	qsort(mapnames, list.num, sizeof(char*), Q_sort_stricmp);
+
+	*nummaps = list.num;
 
 	/* free file list */
-	FS_FreeList(list, num);
-	*nummaps = num - 1;
+	StrList_Free(&list);
 
 	return mapnames;
 }
@@ -5650,8 +5652,7 @@ ModelCallback(void *unused)
 
 // returns true if icon .pcx exists for skin .pcx
 static qboolean
-IconOfSkinExists(const char* skin, char** pcxfiles, int npcxfiles,
-	const char *ext)
+IconOfSkinExists(const char* skin, strlist_t *files, const char *ext)
 {
 	int i;
 	char scratch[1024];
@@ -5661,9 +5662,9 @@ IconOfSkinExists(const char* skin, char** pcxfiles, int npcxfiles,
 	Q_strlcat(scratch, "_i.", sizeof(scratch));
 	Q_strlcat(scratch, ext, sizeof(scratch));
 
-	for (i = 0; i < npcxfiles; i++)
+	for (i = 0; i < files->num; i++)
 	{
-		if (strcmp(pcxfiles[i], scratch) == 0)
+		if (strcmp(files->data[i], scratch) == 0)
 		{
 			return true;
 		}
@@ -5776,13 +5777,16 @@ PlayerModelFree()
 static qboolean
 PlayerDirectoryList(void)
 {
+	strlist_t list;
 	const char* findname = "players/*";
-	char** list = NULL;
-	int num = 0, dirnum = 0;
+	int num, dirnum = 0;
 	size_t listoff = strlen(findname);
 
 	/* get a list of "players" subdirectories or files */
-	if ((list = FS_ListFiles2(findname, &num, 0, 0)) == NULL)
+	list = FS_ListFilesx2(findname, 0, 0);
+	num = list.num;
+
+	if (!num)
 	{
 		return false;
 	}
@@ -5790,11 +5794,11 @@ PlayerDirectoryList(void)
 	if (num > MAX_PLAYERMODELS)
 	{
 		Com_Printf("Too many player models (%d)!\n", num);
-		num = MAX_PLAYERMODELS - 1;
+		num = MAX_PLAYERMODELS;
 	}
 
 	// malloc directories
-	char** data = (char**)calloc(num, sizeof(char*));
+	char** data = (char**)calloc(num + 1, sizeof(char*));
 	YQ2_COM_CHECK_OOM(data, "calloc()", num * sizeof(char*))
 	if (!data)
 	{
@@ -5811,7 +5815,7 @@ PlayerDirectoryList(void)
 		int j;
 
 		// last element of FS_FileList maybe null
-		if (list[i] == 0)
+		if (list.data[i] == 0)
 		{
 			break;
 		}
@@ -5821,18 +5825,18 @@ PlayerDirectoryList(void)
 		 * pak search does not return directory names, only files in
 		 * directories
 		 */
-		dirsize = Q_strchrs(list[i] + listoff, "/\\");
+		dirsize = Q_strchrs(list.data[i] + listoff, "/\\");
 		if (dirsize)
 		{
 			int dirnamelen = 0;
 
-			dirnamelen = dirsize - list[i];
-			memcpy(dirname, list[i], dirnamelen);
+			dirnamelen = dirsize - list.data[i];
+			memcpy(dirname, list.data[i], dirnamelen);
 			dirname[dirnamelen] = 0;
 		}
 		else
 		{
-			Q_strlcpy(dirname, list[i], sizeof(dirname));
+			Q_strlcpy(dirname, list.data[i], sizeof(dirname));
 		}
 
 		for (j = 0; j < dirnum; j++)
@@ -5858,7 +5862,7 @@ PlayerDirectoryList(void)
 	s_directory.num = dirnum;
 
 	// free file list
-	FS_FreeList(list, num);
+	StrList_Free(&list);
 
 	/* sort them male, female, alphabetical */
 	if (s_directory.num > 2)
@@ -5869,110 +5873,37 @@ PlayerDirectoryList(void)
 	return true;
 }
 
-static char**
-HasSkinInDir(const char *dirname, const char *ext, int *num)
+void
+SkinsInDir(strlist_t *sl, const char *dirname, const char *ext)
 {
+	strlist_t list;
 	char findname[MAX_QPATH];
-
-	snprintf(findname, sizeof(findname), "%s/*.%s", dirname, ext);
-
-	return FS_ListFiles2(findname, num, 0, 0);
-}
-
-static char**
-HasSkinsInDir(const char *dirname, int *num)
-{
-	char **list_png, **list_pcx;
-	char **curr = NULL, **list = NULL;
-	int num_png, num_pcx;
 	size_t dirname_size;
+	int i;
 
-	*num = 0;
-	/* dir name size plus one for skip slash */
+	if (snprintf(findname, sizeof(findname), "%s/*.%s",
+		dirname, ext) >= sizeof(findname))
+	{
+		return;
+	}
+
+	list = FS_ListFilesx2(findname, 0, 0);
 	dirname_size = strlen(dirname) + 1;
 
-	list_png = HasSkinInDir(dirname, "png", &num_png);
-	if (list_png)
-	{
-		*num += num_png - 1;
-	}
+	StrList_Expand(sl, sl->num + list.num);
 
-	list_pcx = HasSkinInDir(dirname, "pcx", &num_pcx);
-	if (list_pcx)
+	for (i = 0; i < list.num && sl->num < sl->cap; i++)
 	{
-		*num += num_pcx - 1;
-	}
-
-	if (*num)
-	{
-		curr = list = malloc(sizeof(char *) * (*num + 1));
-		YQ2_COM_CHECK_OOM(list, "malloc()", (size_t)sizeof(char *) * (*num + 1))
-		if (!list)
+		if (!strchr(list.data[i] + dirname_size, '/'))
 		{
-			/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-			return false;
+			sl->data[sl->num] = list.data[i];
+			sl->num++;
+
+			list.data[i] = NULL;
 		}
-
-		if (list_png && num_png)
-		{
-			int j;
-
-			for (j = 0; j < num_png; j ++)
-			{
-				if (list_png[j])
-				{
-					if (!strchr(list_png[j] + dirname_size, '/'))
-					{
-						*curr = list_png[j];
-						curr++;
-					}
-					else
-					{
-						/* unused in final response */
-						free(list_png[j]);
-					}
-				}
-			}
-		}
-
-		if (list_pcx && num_pcx)
-		{
-			int j;
-
-			for (j = 0; j < num_pcx; j ++)
-			{
-				if (list_pcx[j])
-				{
-					if (!strchr(list_pcx[j] + dirname_size, '/'))
-					{
-						*curr = list_pcx[j];
-						curr++;
-					}
-					else
-					{
-						/* unused in final response */
-						free(list_pcx[j]);
-					}
-				}
-			}
-		}
-
-		*curr = NULL;
-		curr++;
-		*num = curr - list;
 	}
 
-	if (list_png)
-	{
-		free(list_png);
-	}
-
-	if (list_pcx)
-	{
-		free(list_pcx);
-	}
-
-	return list;
+	StrList_Free(&list);
 }
 
 /*
@@ -5983,10 +5914,9 @@ HasSkinsInDir(const char *dirname, int *num)
 static qboolean
 PlayerModelList(void)
 {
-	char** list = NULL;
+	strlist_t list;
 	char** data = NULL;
 	int i;
-	int num = 0;
 	int mdl = 0;
 	qboolean result = true;
 
@@ -6023,9 +5953,14 @@ PlayerModelList(void)
 			continue;
 		}
 
-		list = HasSkinsInDir(s_directory.data[i], &num);
+
+		StrList_Init(&list, 0);
+
+		SkinsInDir(&list, s, "pcx");
+		SkinsInDir(&list, s, "png");
+
 		/* get a list of pcx files */
-		if (!num || !list)
+		if (!list.num)
 		{
 			continue;
 		}
@@ -6033,19 +5968,19 @@ PlayerModelList(void)
 		/* count valid skins, which consist of a skin with a matching "_i" icon */
 		s_skinnames[mdl].num = 0;
 
-		for (int j = 0; j < num; j++)
+		for (int j = 0; j < list.num; j++)
 		{
 			/* last element of FS_FileList maybe null */
-			if (list[j] == 0)
+			if (list.data[j] == 0)
 			{
 				break;
 			}
 
-			if (!strstr(list[j], "_i.png") ||
-				!strstr(list[j], "_i.pcx"))
+			if (!strstr(list.data[j], "_i.png") ||
+				!strstr(list.data[j], "_i.pcx"))
 			{
-				if (IconOfSkinExists(list[j], list, num - 1, "png") ||
-					IconOfSkinExists(list[j], list, num - 1, "pcx"))
+				if (IconOfSkinExists(list.data[j], &list, "png") ||
+					IconOfSkinExists(list.data[j], &list, "pcx"))
 				{
 					s_skinnames[mdl].num++;
 				}
@@ -6054,8 +5989,7 @@ PlayerModelList(void)
 
 		if (s_skinnames[mdl].num == 0)
 		{
-			FS_FreeList(list, num);
-
+			StrList_Free(&list);
 			continue;
 		}
 
@@ -6074,21 +6008,21 @@ PlayerModelList(void)
 		s_skinnames[mdl].num = 0;
 
 		/* duplicate strings */
-		for (int k = 0; k < num; ++k)
+		for (int k = 0; k < list.num; ++k)
 		{
 			/* last element of FS_FileList maybe null */
-			if (list[k] == 0)
+			if (list.data[k] == 0)
 			{
 				break;
 			}
 
-			if (!strstr(list[k], "_i.png") ||
-				!strstr(list[k], "_i.pcx"))
+			if (!strstr(list.data[k], "_i.png") ||
+				!strstr(list.data[k], "_i.pcx"))
 			{
-				if (IconOfSkinExists(list[k], list, num - 1, "png") ||
-					IconOfSkinExists(list[k], list, num - 1, "pcx"))
+				if (IconOfSkinExists(list.data[k], &list, "png") ||
+					IconOfSkinExists(list.data[k], &list, "pcx"))
 				{
-					t = Q_strrchrs(list[k], "/\\");
+					t = Q_strrchrs(list.data[k], "/\\");
 
 					l = strlen(t) + 1;
 					s = (char*)malloc(l);
@@ -6129,7 +6063,7 @@ PlayerModelList(void)
 		mdl = s_modelname.num;
 
 		/* free file list */
-		FS_FreeList(list, num);
+		StrList_Free(&list);
 	}
 
 	if (s_modelname.num == 0)

--- a/src/client/menu/qmenu.c
+++ b/src/client/menu/qmenu.c
@@ -66,21 +66,24 @@ Bitmap_Draw
 static void
 Bitmap_Draw(menubitmap_s * item)
 {
-	float scale = SCR_GetMenuScale();
-	int x = 0;
-	int y = 0;
+	const char *pic;
 
-	x = item->generic.x;
-	y = item->generic.y;
-
-	if (((item->generic.flags & QMF_HIGHLIGHT_IF_FOCUS) &&
-		(Menu_ItemAtCursor(item->generic.parent) == item)))
+	if ((item->generic.flags & QMF_HIGHLIGHT_IF_FOCUS) &&
+		(Menu_ItemAtCursor(item->generic.parent) == item))
 	{
-		Draw_PicScaled(x * scale, y * scale, item->focuspic, scale);
+		pic = item->focuspic;
 	}
-	else if (item->generic.name)
+	else
 	{
-		Draw_PicScaled(x * scale, y * scale, ( char * )item->generic.name, scale);
+		pic = item->generic.name;
+	}
+
+	if (pic && *pic != '\0')
+	{
+		float scale = SCR_GetMenuScale();
+
+		Draw_PicScaled(item->generic.x * scale, item->generic.y * scale,
+			pic, scale);
 	}
 }
 

--- a/src/client/sound/sound.c
+++ b/src/client/sound/sound.c
@@ -786,12 +786,8 @@ S_RegisterSexedSound(const entity_state_t *ent, const char *base)
 
 	if (!sfx)
 	{
-		int len;
-
 		/* no, so see if it exists */
-		len = FS_LoadFile(&sexedFilename[1], NULL);
-
-		if (len != -1)
+		if (FS_FileExists(&sexedFilename[1]))
 		{
 			/* yes, close the file and register it */
 			sfx = S_RegisterSound(sexedFilename);

--- a/src/common/cmdparser.c
+++ b/src/common/cmdparser.c
@@ -940,7 +940,7 @@ Cmd_CompleteMapCommand(const char *partial)
 {
 	strlist_t mapNames;
 
-	mapNames = FS_ListFilesx2("maps/*.bsp", 0, 0);
+	mapNames = FS_ListFiles2("maps/*.bsp", 0, 0);
 
 	if (mapNames.num)
 	{

--- a/src/common/cmdparser.c
+++ b/src/common/cmdparser.c
@@ -938,10 +938,11 @@ Cmd_CompleteCommand(const char *partial)
 const char *
 Cmd_CompleteMapCommand(const char *partial)
 {
-	char **mapNames;
-	int nMaps;
+	strlist_t mapNames;
 
-	if ((mapNames = FS_ListFiles2("maps/*.bsp", &nMaps, 0, 0)) != NULL)
+	mapNames = FS_ListFilesx2("maps/*.bsp", 0, 0);
+
+	if (mapNames.num)
 	{
 		size_t len;
 		int i, j, k, nbMatches;
@@ -953,24 +954,24 @@ Cmd_CompleteMapCommand(const char *partial)
 		nbMatches = 0;
 		memset(retval, 0, sizeof(retval));
 
-		pmatch = malloc(nMaps * sizeof(char*));
-		YQ2_COM_CHECK_OOM(pmatch, "malloc()", nMaps * sizeof(char*))
+		pmatch = malloc(mapNames.num * sizeof(char*));
+		YQ2_COM_CHECK_OOM(pmatch, "malloc()", (mapNames.num + 1) * sizeof(char*))
 		if (!pmatch)
 		{
 			/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-			FS_FreeList(mapNames, nMaps);
+			StrList_Free(&mapNames);
 			return retval;
 		}
 
-		for (i = 0; i < nMaps - 1; i++)
+		for (i = 0; i < mapNames.num; i++)
 		{
-			if ((lastsep = strrchr(mapNames[i], '/')))
+			if ((lastsep = strrchr(mapNames.data[i], '/')))
 			{
 				mapName = lastsep + 1;
 			}
 			else
 			{
-				mapName = mapNames[i];
+				mapName = mapNames.data[i];
 			}
 
 			mapName = strtok(mapName, ".");
@@ -1030,7 +1031,7 @@ Cmd_CompleteMapCommand(const char *partial)
 		}
 
 		free(pmatch);
-		FS_FreeList(mapNames, nMaps);
+		StrList_Free(&mapNames);
 	}
 
 	return retval;

--- a/src/common/cmdparser.c
+++ b/src/common/cmdparser.c
@@ -364,7 +364,7 @@ Cbuf_AddLateCommands(void)
 static void
 Cmd_Exec_f(void)
 {
-	char *f, *f2;
+	char *f;
 	int len;
 
 	if (Cmd_Argc() != 2)
@@ -373,7 +373,7 @@ Cmd_Exec_f(void)
 		return;
 	}
 
-	len = FS_LoadFile(Cmd_Argv(1), (void **)&f);
+	len = FS_LoadFile2(Cmd_Argv(1), (void **)&f, 2);
 
 	if (!f)
 	{
@@ -383,16 +383,11 @@ Cmd_Exec_f(void)
 
 	Com_Printf("execing %s.\n", Cmd_Argv(1));
 
-	/* the file doesn't have a trailing 0, so we need to copy it off */
-	/* we also add a newline */
-	f2 = Z_Malloc(len + 2);
-	memcpy(f2, f, len);
-	f2[len] = '\n'; // make sure last line has a newline
-	f2[len+1] = '\0';
+	f[len] = '\n'; // make sure last line has a newline
+	f[len+1] = '\0';
 
-	Cbuf_InsertText(f2);
+	Cbuf_InsertText(f);
 
-	Z_Free(f2);
 	FS_FreeFile(f);
 }
 

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -1952,13 +1952,12 @@ static char* basename( char* n )
 #endif // _MSC_VER
 
 static void
-FS_AddDirToSearchPath(char *dir, qboolean create) {
+FS_AddDirToSearchPath(char *dir, qboolean create)
+{
 	char *file;
-	char **list;
 	char path[MAX_OSPATH];
 	char *tmp;
 	int i, j, k;
-	int nfiles;
 	fsPack_t *pack = NULL;
 	fsSearchPath_t *search;
 	qboolean nextpak;
@@ -2040,15 +2039,13 @@ FS_AddDirToSearchPath(char *dir, qboolean create) {
 	// this, since it might break existing installations.
 	for (i = 0; i < ARRLEN(fs_packtypes); i++)
 	{
+		strlist_t list;
+
 		Com_sprintf(path, sizeof(path), "%s/*.%s", dir, fs_packtypes[i].suffix);
 
-		// Nothing here, next pak type please.
-		if ((list = FS_ListFiles(path, &nfiles, 0, 0)) == NULL)
-		{
-			continue;
-		}
+		list = FS_ListFilesx(path, 0, 0);
 
-		for (j = 0; j < nfiles - 1; j++)
+		for (j = 0; j < list.num; j++)
 		{
 			// Sort out numbered paks. This is as inefficient as
 			// it can be, but it doesn't matter. This is done only
@@ -2059,7 +2056,7 @@ FS_AddDirToSearchPath(char *dir, qboolean create) {
 			{
 				// basename() may alter the given string.
 				// We need to work around that...
-				tmp = strdup(list[j]);
+				tmp = strdup(list.data[j]);
 				file = basename(tmp);
 
 				Com_sprintf(path, sizeof(path), "pak%d.%s", k, fs_packtypes[i].suffix);
@@ -2082,10 +2079,10 @@ FS_AddDirToSearchPath(char *dir, qboolean create) {
 			switch (fs_packtypes[i].format)
 			{
 				case PAK:
-					pack = FS_LoadPAK(list[j]);
+					pack = FS_LoadPAK(list.data[j]);
 					break;
 				case PK3:
-					pack = FS_LoadPK3(list[j]);
+					pack = FS_LoadPK3(list.data[j]);
 					break;
 			}
 
@@ -2104,7 +2101,7 @@ FS_AddDirToSearchPath(char *dir, qboolean create) {
 			fs_searchPaths = search;
 		}
 
-		FS_FreeList(list, nfiles);
+		StrList_Free(&list);
 	}
 }
 

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -1761,13 +1761,12 @@ FS_ListMods(void)
 static void
 FS_Dir_f(void)
 {
-	char **dirnames; /* File list. */
+	strlist_t dirs;
 	char findname[1024]; /* File search path and pattern. */
 	const char *path = NULL; /* Search path. */
 	char *lastsep;
 	char wildcard[1024] = "*.*"; /* File pattern. */
 	int i; /* Loop counter. */
-	int ndirs; /* Number of files in list. */
 
 	/* Check for pattern in arguments. */
 	if (Cmd_Argc() != 1)
@@ -1782,23 +1781,22 @@ FS_Dir_f(void)
 		Com_Printf("Directory of '%s'.\n", findname);
 		Com_Printf("----\n");
 
-		if ((dirnames = FS_ListFiles(findname, &ndirs, 0, 0)) != 0)
-		{
-			for (i = 0; i < ndirs - 1; i++)
-			{
-				lastsep = strrchr(dirnames[i], '/');
-				if (lastsep)
-				{
-					Com_Printf("%s\n", lastsep + 1);
-				}
-				else
-				{
-					Com_Printf("%s\n", dirnames[i]);
-				}
-			}
+		dirs = FS_ListFilesx(findname, 0, 0);
 
-			FS_FreeList(dirnames, ndirs);
+		for (i = 0; i < dirs.num; i++)
+		{
+			lastsep = strrchr(dirs.data[i], '/');
+			if (lastsep)
+			{
+				Com_Printf("%s\n", lastsep + 1);
+			}
+			else
+			{
+				Com_Printf("%s\n", dirs.data[i]);
+			}
 		}
+
+		StrList_Free(&dirs);
 
 		Com_Printf("\n");
 	}

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -1266,6 +1266,32 @@ FS_ListFiles(const char *findname, int *numfiles,
 	return list;
 }
 
+strlist_t
+FS_ListFilesx(const char *findname,
+		unsigned musthave, unsigned canthave)
+{
+	strlist_t list;
+	const char *s;
+
+	StrList_Init(&list, 0);
+
+	s = Sys_FindFirst(findname, musthave, canthave);
+
+	while (s)
+	{
+		if (s[strlen(s) - 1] != '.')
+		{
+			StrList_Append(&list, s);
+		}
+
+		s = Sys_FindNext(musthave, canthave);
+	}
+
+	Sys_FindClose();
+
+	return list;
+}
+
 /*
  * Compare file attributes (musthave and canthave) in packed files. If
  * "output" is not NULL, "size" is greater than zero and the file matches the
@@ -1508,6 +1534,70 @@ FS_ListFiles2(const char *findname, int *numfiles,
 	}
 
 	*numfiles = nfiles;
+
+	return list;
+}
+
+strlist_t
+FS_ListFilesx2(const char *findname,
+		unsigned musthave, unsigned canthave)
+{
+	strlist_t list;
+	fsSearchPath_t *search;
+
+	StrList_Init(&list, 0);
+
+	for (search = fs_searchPaths; search != NULL; search = search->next)
+	{
+		strlist_t tmplist;
+		char path[MAX_OSPATH];
+		size_t splen;
+		int i;
+
+		if (search->pack)
+		{
+			if (canthave & SFF_INPACK)
+			{
+				continue;
+			}
+
+			for (i = 0; i < search->pack->numFiles; i++)
+			{
+				if (ComparePackFiles(findname, search->pack->files[i].name,
+							musthave, canthave, path, sizeof(path)))
+				{
+					if (!StrList_Contains(&list, path))
+					{
+						StrList_Append(&list, path);
+					}
+				}
+			}
+		}
+
+		if ((musthave & SFF_INPACK) ||
+			(*search->path == '\0'))
+		{
+			continue;
+		}
+
+		/* files from host filesystem */
+		Com_sprintf(path, sizeof(path), "%s/%s", search->path, findname);
+		tmplist = FS_ListFilesx(path, musthave, canthave);
+
+		splen = strlen(search->path);
+
+		for (i = 0; i < tmplist.num; i++)
+		{
+			const char *s = tmplist.data[i] + splen + 1;
+
+			if (!StrList_Contains(&list, s))
+			{
+				StrList_Append(&list, s);
+			}
+		}
+
+		StrList_Free(&tmplist);
+	}
 
 	return list;
 }

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -1460,23 +1460,18 @@ FS_ListMods(void)
 static void
 FS_Dir_f(void)
 {
-	strlist_t dirs;
-	char findname[1024]; /* File search path and pattern. */
-	const char *path = NULL; /* Search path. */
-	char *lastsep;
-	char wildcard[1024] = "*.*"; /* File pattern. */
-	int i; /* Loop counter. */
+	const char *path, *wildcard;
 
-	/* Check for pattern in arguments. */
-	if (Cmd_Argc() != 1)
-	{
-		Q_strlcpy(wildcard, Cmd_Argv(1), sizeof(wildcard));
-	}
+	wildcard = (Cmd_Argc() > 1) ? Cmd_Argv(1) : "*.*";
 
-	/* Scan search paths and list files. */
-	while ((path = FS_NextPath(path)) != NULL)
+	for (path = FS_NextPath(NULL); path; path = FS_NextPath(path))
 	{
+		strlist_t dirs;
+		char findname[MAX_OSPATH];
+		int i;
+
 		Com_sprintf(findname, sizeof(findname), "%s/%s", path, wildcard);
+
 		Com_Printf("Directory of '%s'.\n", findname);
 		Com_Printf("----\n");
 
@@ -1484,15 +1479,12 @@ FS_Dir_f(void)
 
 		for (i = 0; i < dirs.num; i++)
 		{
+			const char *lastsep;
+
 			lastsep = strrchr(dirs.data[i], '/');
-			if (lastsep)
-			{
-				Com_Printf("%s\n", lastsep + 1);
-			}
-			else
-			{
-				Com_Printf("%s\n", dirs.data[i]);
-			}
+
+			Com_Printf("%s\n",
+				lastsep ? lastsep + 1 : dirs.data[i]);
 		}
 
 		StrList_Free(&dirs);

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -1201,73 +1201,8 @@ FS_Link_f(void)
 /*
  * Create a list of files that match a criteria.
  */
-char **
-FS_ListFiles(const char *findname, int *numfiles,
-		unsigned musthave, unsigned canthave)
-{
-	char **list; /* List of files. */
-	char *s; /* Next file in list. */
-	int nfiles; /* Number of files in list. */
-
-	/* Initialize variables. */
-	list = NULL;
-	nfiles = 0;
-
-	/* Count the number of matches. */
-	s = Sys_FindFirst(findname, musthave, canthave);
-
-	while (s != NULL)
-	{
-		if (s[strlen(s) - 1] != '.')
-		{
-			nfiles++;
-		}
-
-		s = Sys_FindNext(musthave, canthave);
-	}
-
-	Sys_FindClose();
-
-	/* Check if there are matches. */
-	if (nfiles == 0)
-	{
-		return NULL;
-	}
-
-	nfiles++; /* Add space for a guard. */
-	*numfiles = nfiles;
-
-	/* Allocate the list. */
-	list = calloc(nfiles, sizeof(char *));
-	YQ2_COM_CHECK_OOM(list, "calloc()", (size_t)nfiles*sizeof(char*))
-	if (!list)
-	{
-		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-		return NULL;
-	}
-
-	/* Fill the list. */
-	s = Sys_FindFirst(findname, musthave, canthave);
-	nfiles = 0;
-
-	while (s)
-	{
-		if (s[strlen(s) - 1] != '.')
-		{
-			list[nfiles] = strdup(s);
-			nfiles++;
-		}
-
-		s = Sys_FindNext(musthave, canthave);
-	}
-
-	Sys_FindClose();
-
-	return list;
-}
-
 strlist_t
-FS_ListFilesx(const char *findname,
+FS_ListFiles(const char *findname,
 		unsigned musthave, unsigned canthave)
 {
 	strlist_t list;
@@ -1359,187 +1294,8 @@ ComparePackFiles(const char *findname, const char *name, unsigned musthave,
  * Searchs are relative to the game directory and use all the search paths
  * including .pak and .pk3 files.
  */
-char **
-FS_ListFiles2(const char *findname, int *numfiles,
-		unsigned musthave, unsigned canthave)
-{
-	fsSearchPath_t *search; /* Search path. */
-	int i, j; /* Loop counters. */
-	int nfiles; /* Number of files found. */
-	int tmpnfiles; /* Temp number of files. */
-	char **tmplist; /* Temporary list of files. */
-	char **list; /* List of files found. */
-	char path[MAX_OSPATH]; /* Temporary path. */
-
-	nfiles = 0;
-	list = malloc(sizeof(char *));
-	YQ2_COM_CHECK_OOM(list, "malloc()", sizeof(char*))
-	if (!list)
-	{
-		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-		return NULL;
-	}
-
-	for (search = fs_searchPaths; search != NULL; search = search->next)
-	{
-		if (search->pack != NULL)
-		{
-			char **tmp;
-
-			if (canthave & SFF_INPACK)
-			{
-				continue;
-			}
-
-			for (i = 0, j = 0; i < search->pack->numFiles; i++)
-			{
-				if (ComparePackFiles(findname, search->pack->files[i].name,
-							musthave, canthave, NULL, 0))
-				{
-					j++;
-				}
-			}
-
-			if (j == 0)
-			{
-				continue;
-			}
-
-			nfiles += j;
-			tmp = realloc(list, nfiles * sizeof(char *));
-			if (!tmp)
-			{
-				free(list);
-				YQ2_COM_CHECK_OOM(tmp, "realloc()", (size_t)nfiles*sizeof(char*))
-				/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-				return NULL;
-			}
-
-			list = tmp;
-
-			for (i = 0, j = nfiles - j; i < search->pack->numFiles; i++)
-			{
-				if (ComparePackFiles(findname, search->pack->files[i].name,
-							musthave, canthave, path, sizeof(path)))
-				{
-					list[j++] = strdup(path);
-				}
-			}
-		}
-
-		if (musthave & SFF_INPACK)
-		{
-			continue;
-		}
-
-		Com_sprintf(path, sizeof(path), "%s/%s", search->path, findname);
-		tmplist = FS_ListFiles(path, &tmpnfiles, musthave, canthave);
-
-		if (tmplist != NULL)
-		{
-			char **tmp;
-
-			tmpnfiles--;
-			nfiles += tmpnfiles;
-			tmp = realloc(list, nfiles * sizeof(char *));
-			if (!tmp)
-			{
-				FS_FreeList(tmplist, tmpnfiles + 1);
-				free(list);
-				YQ2_COM_CHECK_OOM(tmp, "2nd realloc()", (size_t)nfiles*sizeof(char*))
-				/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-				return NULL;
-			}
-
-			list = tmp;
-
-			for (i = 0, j = nfiles - tmpnfiles; i < tmpnfiles; i++, j++)
-			{
-				list[j] = strdup(tmplist[i] + strlen(search->path) + 1);
-			}
-
-			FS_FreeList(tmplist, tmpnfiles + 1);
-		}
-	}
-
-	/* Delete duplicates. */
-	tmpnfiles = 0;
-
-	for (i = 0; i < nfiles; i++)
-	{
-		if (list[i] == NULL)
-		{
-			continue;
-		}
-
-		for (j = i + 1; j < nfiles; j++)
-		{
-			if ((list[j] != NULL) &&
-				(strcmp(list[i], list[j]) == 0))
-			{
-				free(list[j]);
-				list[j] = NULL;
-				tmpnfiles++;
-			}
-		}
-	}
-
-	if (tmpnfiles > 0)
-	{
-		nfiles -= tmpnfiles;
-		tmplist = malloc(nfiles * sizeof(char *));
-		if (!tmplist)
-		{
-			free(list);
-			YQ2_COM_CHECK_OOM(tmplist, "malloc()", (size_t)nfiles*sizeof(char*))
-			/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-			return NULL;
-		}
-
-		for (i = 0, j = 0; i < nfiles + tmpnfiles; i++)
-		{
-			if (list[i] != NULL)
-			{
-				tmplist[j++] = list[i];
-			}
-		}
-
-		free(list);
-		list = tmplist;
-	}
-
-	/* Add a guard. */
-	if (nfiles > 0)
-	{
-		char **tmp;
-
-		nfiles++;
-		tmp = realloc(list, nfiles * sizeof(char *));
-		if (!tmp)
-		{
-			free(list);
-			YQ2_COM_CHECK_OOM(tmp, "3rd realloc()", (size_t)nfiles*sizeof(char*))
-			/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-			return NULL;
-		}
-
-		list = tmp;
-		list[nfiles - 1] = NULL;
-	}
-
-	else
-	{
-		free(list);
-		list = NULL;
-	}
-
-	*numfiles = nfiles;
-
-	return list;
-}
-
 strlist_t
-FS_ListFilesx2(const char *findname,
+FS_ListFiles2(const char *findname,
 		unsigned musthave, unsigned canthave)
 {
 	strlist_t list;
@@ -1582,7 +1338,7 @@ FS_ListFilesx2(const char *findname,
 
 		/* files from host filesystem */
 		Com_sprintf(path, sizeof(path), "%s/%s", search->path, findname);
-		tmplist = FS_ListFilesx(path, musthave, canthave);
+		tmplist = FS_ListFiles(path, musthave, canthave);
 
 		splen = strlen(search->path);
 
@@ -1600,27 +1356,6 @@ FS_ListFilesx2(const char *findname,
 	}
 
 	return list;
-}
-
-/*
- * Free list of files created by FS_ListFiles().
- */
-void
-FS_FreeList(char **list, int nfiles)
-{
-	int i;
-
-	if (!list)
-	{
-		return;
-	}
-
-	for (i = 0; i < nfiles - 1; i++)
-	{
-		free(list[i]);
-	}
-
-	free(list);
 }
 
 /*
@@ -1673,7 +1408,7 @@ HasValidPack(const char *dir)
 		Com_sprintf(findnamepattern, sizeof(findnamepattern), "%s/*.%s",
 			dir, pkt->suffix);
 
-		packs = FS_ListFilesx(findnamepattern, 0, 0);
+		packs = FS_ListFiles(findnamepattern, 0, 0);
 		npacks = packs.num;
 		StrList_Free(&packs);
 
@@ -1718,7 +1453,7 @@ FS_ListMods(void)
 			path = search->path;
 		}
 
-		dirchildren = FS_ListFilesx(path, 0, 0);
+		dirchildren = FS_ListFiles(path, 0, 0);
 
 		// iterate over the children of this Raw path (unless we've already got enough mods)
 		for (i = 0; i < dirchildren.num && list.num < MAX_MODS; i++)
@@ -1781,7 +1516,7 @@ FS_Dir_f(void)
 		Com_Printf("Directory of '%s'.\n", findname);
 		Com_Printf("----\n");
 
-		dirs = FS_ListFilesx(findname, 0, 0);
+		dirs = FS_ListFiles(findname, 0, 0);
 
 		for (i = 0; i < dirs.num; i++)
 		{
@@ -2043,7 +1778,7 @@ FS_AddDirToSearchPath(char *dir, qboolean create)
 
 		Com_sprintf(path, sizeof(path), "%s/*.%s", dir, fs_packtypes[i].suffix);
 
-		list = FS_ListFilesx(path, 0, 0);
+		list = FS_ListFiles(path, 0, 0);
 
 		for (j = 0; j < list.num; j++)
 		{

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -1653,115 +1653,6 @@ Q_sort_modcmp(const void *p1, const void *p2)
  * Combs all Raw search paths to find game dirs containing PAK/PK2/PK3 files.
  * Returns an alphabetized array of unique relative dir names.
  */
-char**
-FS_ListMods(int *nummods)
-{
-	int nmods = 0, numdirchildren, numpacksinchilddir;
-	size_t searchpathlength;
-	char findnamepattern[MAX_OSPATH], modname[MAX_QPATH], searchpath[MAX_OSPATH];
-	char **dirchildren, **packsinchilddir, **modnames;
-
-	modnames = malloc((MAX_QPATH + 1) * (MAX_MODS + 1));
-	if (!modnames)
-	{
-		YQ2_COM_CHECK_OOM(modnames, "malloc()", (MAX_QPATH + 1) * (MAX_MODS + 1))
-		/* unaware about YQ2_ATTR_NORETURN_FUNCPTR? */
-		return NULL;
-	}
-	memset(modnames, 0, (MAX_QPATH + 1) * (MAX_MODS + 1));
-
-	// iterate over all Raw paths
-	for (fsRawPath_t *search = fs_rawPath; search; search = search->next)
-	{
-		searchpathlength = strlen(search->path);
-		if(!searchpathlength)
-		{
-			continue;
-		}
-
-		// make sure this Raw path ends with a '/' otherwise FS_ListFiles will open its parent dir
-		if(search->path[searchpathlength - 1] != '/')
-		{
-			Com_sprintf(searchpath, sizeof(searchpath), "%s/*", search->path);
-		}
-		else
-		{
-			Com_sprintf(searchpath, sizeof(searchpath), "%s*", search->path);
-		}
-
-		dirchildren = FS_ListFiles(searchpath, &numdirchildren, 0, 0);
-
-		if (dirchildren == NULL)
-		{
-			continue;
-		}
-
-		// iterate over the children of this Raw path (unless we've already got enough mods)
-		for (int i = 0; i < numdirchildren && nmods < MAX_MODS; i++)
-		{
-			if(dirchildren[i] == NULL)
-			{
-				continue;
-			}
-
-			numpacksinchilddir = 0;
-
-			// iterate over supported pack types, but ignore ZIP files (they cause false positives)
-			for (int j = 0; j < ARRLEN(fs_packtypes); j++)
-			{
-				if (strcmp("zip", fs_packtypes[j].suffix) != 0)
-				{
-					Com_sprintf(findnamepattern, sizeof(findnamepattern), "%s/*.%s", dirchildren[i], fs_packtypes[j].suffix);
-
-					packsinchilddir = FS_ListFiles(findnamepattern, &numpacksinchilddir, 0, 0);
-					FS_FreeList(packsinchilddir, numpacksinchilddir);
-
-					// if this dir has some pack files, add it if not already in the list
-					if (numpacksinchilddir > 0)
-					{
-						qboolean matchfound = false;
-
-						Com_sprintf(modname, sizeof(modname), "%s", strrchr(dirchildren[i], '/') + 1);
-
-						for (int k = 0; k < nmods; k++)
-						{
-							if (strcmp(modname, modnames[k]) == 0)
-							{
-								matchfound = true;
-								break;
-							}
-						}
-
-						if (!matchfound)
-						{
-							modnames[nmods] = malloc(strlen(modname) + 1);
-							if (!modnames[nmods])
-							{
-								break;
-							}
-
-							strcpy(modnames[nmods], modname);
-
-							nmods++;
-						}
-
-						break;
-					}
-				}
-			}
-		}
-
-		FS_FreeList(dirchildren, numdirchildren);
-	}
-
-	modnames[nmods] = 0;
-
-	qsort(modnames, nmods, sizeof(modnames[0]), Q_sort_modcmp);
-
-	*nummods = nmods;
-	return modnames;
-}
-
 static qboolean
 HasValidPack(const char *dir)
 {
@@ -1796,7 +1687,7 @@ HasValidPack(const char *dir)
 }
 
 strlist_t
-FS_ListModsx(void)
+FS_ListMods(void)
 {
 	strlist_t list;
 

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -1762,6 +1762,108 @@ FS_ListMods(int *nummods)
 	return modnames;
 }
 
+static qboolean
+HasValidPack(const char *dir)
+{
+	const fsPackTypes_t *pkt;
+
+	// iterate over supported pack types, but ignore ZIP files (they cause false positives)
+	for (pkt = fs_packtypes; pkt < ARREND(fs_packtypes); pkt++)
+	{
+		strlist_t packs;
+		char findnamepattern[MAX_OSPATH];
+		int npacks;
+
+		if (!strcmp("zip", pkt->suffix))
+		{
+			continue;
+		}
+
+		Com_sprintf(findnamepattern, sizeof(findnamepattern), "%s/*.%s",
+			dir, pkt->suffix);
+
+		packs = FS_ListFilesx(findnamepattern, 0, 0);
+		npacks = packs.num;
+		StrList_Free(&packs);
+
+		if (npacks)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+strlist_t
+FS_ListModsx(void)
+{
+	strlist_t list;
+
+	StrList_Init(&list, 0);
+
+	for (fsRawPath_t *search = fs_rawPath; search; search = search->next)
+	{
+		strlist_t dirchildren;
+		const char *path;
+		char searchpath[MAX_OSPATH];
+		size_t splen;
+		int i;
+
+		splen = strlen(search->path);
+		if (!splen)
+		{
+			continue;
+		}
+
+		// make sure this Raw path ends with a '/' otherwise FS_ListFiles will open its parent dir
+		if (search->path[splen - 1] != '/')
+		{
+			Com_sprintf(searchpath, sizeof(searchpath), "%s/*", search->path);
+			path = searchpath;
+		}
+		else
+		{
+			path = search->path;
+		}
+
+		dirchildren = FS_ListFilesx(path, 0, 0);
+
+		// iterate over the children of this Raw path (unless we've already got enough mods)
+		for (i = 0; i < dirchildren.num && list.num < MAX_MODS; i++)
+		{
+			const char *modname;
+
+			if (!HasValidPack(dirchildren.data[i]))
+			{
+				continue;
+			}
+
+			modname = strrchr(dirchildren.data[i], '/');
+			if (!modname)
+			{
+				continue;
+			}
+
+			modname++;
+
+			if (!StrList_Contains(&list, modname))
+			{
+				StrList_Append(&list, modname);
+			}
+		}
+
+		StrList_Free(&dirchildren);
+	}
+
+	if (list.num > 1)
+	{
+		qsort(list.data, list.num, sizeof(char *), Q_sort_modcmp);
+	}
+
+	return list;
+}
+
 /*
  * Directory listing.
  */

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -367,43 +367,6 @@ FS_FCloseFile(fileHandle_t f)
 	memset(handle, 0, sizeof(*handle));
 }
 
-qboolean
-FS_FileExists(const char *path, const char *file)
-{
-	char pathname[MAX_QPATH];
-	fileHandle_t handle;
-	int len;
-
-	if (!file)
-	{
-		return false;
-	}
-
-	if (!path)
-	{
-		path = file;
-	}
-	else
-	{
-		if (snprintf(pathname, sizeof(pathname), "%s/%s",
-			path, file) >= sizeof(pathname))
-		{
-			return false;
-		}
-
-		path = pathname;
-	}
-
-	len = FS_FOpenFile(path, &handle, false);
-
-	if (handle)
-	{
-		FS_FCloseFile(handle);
-	}
-
-	return (handle && len >= 0) ? true : false;
-}
-
 static int
 FS_SortPackCompare(const void *p1, const void *p2)
 {
@@ -795,24 +758,23 @@ FS_FRead(void *buffer, int size, int count, fileHandle_t f)
 }
 
 /*
- * Filename are reletive to the quake search path. A null buffer will just
- * return the file length without loading.
+ * Filename is reletive to the quake search path
+ * A null buffer will just return the file length
+ * pad adds bytes at the end of the buffer
+ * The buffer must be freed by the caller with FS_FreeFile
  */
 int
-FS_LoadFile(const char *path, void **buffer)
+FS_LoadFile2(const char *path, void **buffer, int pad)
 {
-	byte *buf; /* Buffer. */
-	int size; /* File size. */
-	fileHandle_t f; /* File handle. */
+	fileHandle_t f;
+	int size;
 
-	buf = NULL;
 	size = FS_FOpenFile(path, &f, false);
 
 	if (size <= 0)
 	{
-		if (size == 0)
+		if (!size)
 		{
-			/* empty file, close before exit*/
 			FS_FCloseFile(f);
 		}
 
@@ -824,19 +786,21 @@ FS_LoadFile(const char *path, void **buffer)
 		return size;
 	}
 
-	if (buffer == NULL)
+	if (buffer)
 	{
-		FS_FCloseFile(f);
-		return size;
+		*buffer = Z_Malloc(size + (pad < 0 ? 0 : pad));
+		FS_Read(*buffer, size, f);
 	}
 
-	buf = Z_Malloc(size);
-	*buffer = buf;
-
-	FS_Read(buf, size, f);
 	FS_FCloseFile(f);
 
 	return size;
+}
+
+int
+FS_LoadFile(const char *path, void **buffer)
+{
+	return FS_LoadFile2(path, buffer, 1); /* safety null byte */
 }
 
 void

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -715,6 +715,11 @@ char **FS_ListFiles2(const char *findname, int *numfiles,
 		unsigned musthave, unsigned canthave);
 void FS_FreeList(char **list, int nfiles);
 
+strlist_t FS_ListFilesx(const char *findname,
+		unsigned musthave, unsigned canthave);
+strlist_t FS_ListFilesx2(const char *findname,
+		unsigned musthave, unsigned canthave);
+
 void FS_InitFilesystem(void);
 void FS_ShutdownFilesystem(void);
 void FS_BuildGameSpecificSearchPath(const char *dir);

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -873,8 +873,6 @@ void Sys_SetupFPU(void);
 
 /* ======================================================================= */
 
-void Mods_NamesFinish(void);
-
 /* stringlist_t API
  * Store strings in a dynamic array
  */

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -701,7 +701,6 @@ typedef enum
 void FS_DPrintf(const char *format, ...);
 int FS_FOpenFile(const char *name, fileHandle_t *f, qboolean gamedir_only);
 void FS_FCloseFile(fileHandle_t f);
-qboolean FS_FileExists(const char *path, const char *file);
 int FS_Read(void *buffer, int size, fileHandle_t f);
 int FS_FRead(void *buffer, int size, int count, fileHandle_t f);
 
@@ -719,7 +718,9 @@ void FS_ShutdownFilesystem(void);
 void FS_BuildGameSpecificSearchPath(const char *dir);
 const char *FS_Gamedir(void);
 const char *FS_NextPath(const char *prevpath);
+int FS_LoadFile2(const char *path, void **buffer, int pad);
 int FS_LoadFile(const char *path, void **buffer);
+#define FS_FileExists(path) (FS_LoadFile2(path, NULL, 0) >= 0)
 qboolean FS_FileInGamedir(const char *file);
 qboolean FS_AddPAKFromGamedir(const char *pak);
 const char* FS_GetNextRawPath(const char* lastRawPath);

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -729,7 +729,7 @@ int FS_LoadFile(const char *path, void **buffer);
 qboolean FS_FileInGamedir(const char *file);
 qboolean FS_AddPAKFromGamedir(const char *pak);
 const char* FS_GetNextRawPath(const char* lastRawPath);
-char **FS_ListMods(int *nummods);
+strlist_t FS_ListMods(void);
 
 /* a null buffer will just return the file length without loading */
 /* a -1 length is not present */

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -709,15 +709,9 @@ int FS_FRead(void *buffer, int size, int count, fileHandle_t f);
 // returns NULL if f is no valid handle
 const char* FS_GetFilenameForHandle(fileHandle_t f);
 
-char **FS_ListFiles(const char *findname, int *numfiles,
+strlist_t FS_ListFiles(const char *findname,
 		unsigned musthave, unsigned canthave);
-char **FS_ListFiles2(const char *findname, int *numfiles,
-		unsigned musthave, unsigned canthave);
-void FS_FreeList(char **list, int nfiles);
-
-strlist_t FS_ListFilesx(const char *findname,
-		unsigned musthave, unsigned canthave);
-strlist_t FS_ListFilesx2(const char *findname,
+strlist_t FS_ListFiles2(const char *findname,
 		unsigned musthave, unsigned canthave);
 
 void FS_InitFilesystem(void);

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -1323,4 +1323,82 @@ typedef char bitlist_t;
 /* a realloc wrapper that initializes new memory to 0 */
 void *Q_realloc0(void *ptr, size_t prev_n, size_t new_n);
 
+/* strlist_t API - a dynamic string list object
+ *
+ * a NULL terminated list of char * pointers
+ *
+ *   similar to stringlist_t but uses malloc instead of Z_Malloc
+ *   (switch entirely to stringlist_t?)
+*/
+
+typedef struct
+{
+	char **data;
+	int num;
+	int cap;
+} strlist_t;
+
+/* sl_eqfunc
+ *   An equals test function used by StrList_Find
+ *   list_s is the string inside the list being tested
+ *   targ_s is the target string passed to StrList_Find
+ *   Return 0 if found, a non-0 value otherwise
+ */
+typedef int (*sl_eqfunc)(const char *list_s, const char *targ_s);
+
+/* StrList_Init
+ *   Initializes a strlist_t object to the starting capacity
+ *   A cap of 0 starts a blank list with no allocation
+ *   Note that the NULL terminator is not counted in the cap
+ *   If allocation fails, cap of 0 is used
+ */
+void StrList_Init(strlist_t *sl, int cap);
+
+/* StrList_Free
+ *   Frees all memory used by the list
+ *   and resets it to a blank state ready to be used again
+ */
+void StrList_Free(strlist_t *sl);
+
+/* StrList_Compress
+ *   Reduce capacity down to number of items if needed
+ *   The list is not modified if re-allocation fails
+ */
+void StrList_Compress(strlist_t *sl);
+
+/* StrList_Find
+ *   Search the list for s given the specified eq function
+  *  If eq is NULL, strcmp is used by default
+ *   Returns the index of the string if found
+ *   Returns total number of items if not found
+ */
+int StrList_Find(const strlist_t *sl, sl_eqfunc eq, const char *s);
+
+/* StrList_Contains
+ *   Evaluates to 1 if s is in the list, 0 otherwise
+ *   Use Contains2 to provide your own equals test function
+ */
+#define StrList_Contains(sl, s) (StrList_Find(sl, NULL, s) < (sl)->num)
+#define StrList_Contains2(sl, eq, s) (StrList_Find(sl, eq, s) < (sl)->num)
+
+/* StrList_Expand
+ *   Expands the list's capacity to the requested value if needed
+ *   If re-allocation fails the object is not modified
+ */
+void StrList_Expand(strlist_t *sl, int new_cap);
+
+/* StrList_Append
+ *   Adds s to the list
+ *   The list is dynamically resized if needed
+ *   If allocation fails, the list is still in a valid state
+ */
+void StrList_Append(strlist_t *sl, const char *s);
+
+/* StrList_Print
+ *   Prints the contents of the list
+ *   If no printfunc then Com_Printf is used
+ *   Explicitly prints the NULL terminator if it is there
+ */
+void StrList_Print(const strlist_t *sl, void (*printfunc)(const char *fmt, ...));
+
 #endif /* COMMON_SHARED_H */

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -346,8 +346,9 @@ int Q_strcasecmp(const char *s1, const char *s2);
 int Q_strncasecmp(const char *s1, const char *s2, int n);
 char *Q_strcasestr(const char *s1, const char *s2);
 
-/* portable string lowercase */
-char *Q_strlwr(char *s);
+/* portable string lowercase / uppercase */
+void Q_strlwr(char *s);
+void Q_strupr(char *s);
 
 /* portable safe string copy/concatenate */
 int Q_strlcpy(char *dst, const char *src, int size);

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -1320,4 +1320,7 @@ typedef char bitlist_t;
 /* test the value of bit i */
 #define BITLIST_ISSET(l, i) (l[(i) / BITLIST_BPU] & (1 << ((i) % BITLIST_BPU))) != 0
 
+/* a realloc wrapper that initializes new memory to 0 */
+void *Q_realloc0(void *ptr, size_t prev_n, size_t new_n);
+
 #endif /* COMMON_SHARED_H */

--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -1744,3 +1744,157 @@ Q_realloc0(void *ptr, size_t prev_n, size_t new_n)
 
 	return new_ptr;
 }
+
+/* strlist_t API */
+
+void
+StrList_Init(strlist_t *sl, int cap)
+{
+	memset(sl, 0, sizeof(*sl));
+
+	if (cap > 0)
+	{
+		/* allocating +1 ensures the list is always NULL terminated */
+		sl->data = calloc(cap + 1, sizeof(char *));
+
+		if (!sl->data)
+		{
+			return;
+		}
+
+		sl->cap = cap;
+	}
+}
+
+void
+StrList_Free(strlist_t *sl)
+{
+	if (sl->data)
+	{
+		int i;
+
+		for (i = 0; i < sl->num; i++)
+		{
+			if (sl->data[i])
+			{
+				free(sl->data[i]);
+			}
+		}
+
+		free(sl->data);
+		sl->data = NULL;
+	}
+
+	sl->cap = 0;
+	sl->num = 0;
+}
+
+void
+StrList_Compress(strlist_t *sl)
+{
+	char **new_data;
+
+	if (sl->cap <= sl->num)
+	{
+		return;
+	}
+
+	new_data = realloc(sl->data, (sl->num + 1) * sizeof(char *));
+	if (new_data)
+	{
+		sl->data = new_data;
+		sl->cap = sl->num;
+	}
+}
+
+int
+StrList_Find(const strlist_t *sl, sl_eqfunc eq, const char *s)
+{
+	int i;
+
+	if (!eq)
+	{
+		eq = strcmp;
+	}
+
+	for (i = 0; i < sl->num; i++)
+	{
+		if (!eq(sl->data[i], s))
+		{
+			return i;
+		}
+	}
+
+	return sl->num;
+}
+
+void
+StrList_Expand(strlist_t *sl, int new_cap)
+{
+	char **new_data;
+
+	if (new_cap <= sl->cap)
+	{
+		return;
+	}
+
+	new_data = Q_realloc0(sl->data,
+		!sl->cap ? 0 : ((sl->cap + 1) * sizeof(char *)),
+		(new_cap + 1) * sizeof(char *));
+
+	if (!new_data)
+	{
+		return;
+	}
+
+	sl->data = new_data;
+	sl->cap = new_cap;
+}
+
+void
+StrList_Append(strlist_t *sl, const char *s)
+{
+	char *new_s;
+
+	if (sl->num >= sl->cap)
+	{
+		StrList_Expand(sl, NextPow2gt(sl->cap));
+
+		if (sl->num >= sl->cap)
+		{
+			return;
+		}
+	}
+
+	new_s = strdup(s);
+	if (new_s)
+	{
+		sl->data[sl->num] = new_s;
+		sl->num++;
+	}
+}
+
+void
+StrList_Print(const strlist_t *sl, void (*printfunc)(const char *fmt, ...))
+{
+	int i;
+
+	if (!printfunc)
+	{
+		printfunc = Com_Printf;
+	}
+
+	printfunc("%d / %d items\n{\n", sl->num, sl->cap);
+
+	for (i = 0; i < sl->num; i++)
+	{
+		printfunc("  '%s'\n", sl->data[i]);
+	}
+
+	if (sl->num && !sl->data[sl->num])
+	{
+		printfunc("  NULL\n");
+	}
+
+	printfunc("}\n");
+}

--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -1256,18 +1256,22 @@ Com_sprintf(char *dest, int size, const char *fmt, ...)
 	}
 }
 
-char *
-Q_strlwr ( char *s )
+void
+Q_strlwr(char *s)
 {
-	char *p = s;
-
-	while ( *s )
+	for (; *s != '\0'; s++)
 	{
-		*s = tolower( (unsigned char)*s );
-		s++;
+		*s = tolower(*s);
 	}
+}
 
-	return ( p );
+void
+Q_strupr(char *s)
+{
+	for (; *s != '\0'; s++)
+	{
+		*s = toupper(*s);
+	}
 }
 
 int

--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -1726,3 +1726,21 @@ NextPow2gt(unsigned int i)
 {
 	return NextPow2(i + 1U);
 }
+
+void *
+Q_realloc0(void *ptr, size_t prev_n, size_t new_n)
+{
+	void *new_ptr = realloc(ptr, new_n);
+
+	if (!new_ptr)
+	{
+		return NULL;
+	}
+
+	if (new_n > prev_n)
+	{
+		memset((char *)new_ptr + prev_n, 0, new_n - prev_n);
+	}
+
+	return new_ptr;
+}

--- a/src/common/zone.c
+++ b/src/common/zone.c
@@ -172,18 +172,13 @@ Z_TagRealloc(void *ptr, size_t size, unsigned short tag)
 	}
 
 	size = size + sizeof(zhead_t);
-	zr = realloc(z, size);
+	zr = Q_realloc0(z, z->size, size);
 
 	if (!zr)
 	{
 		Com_Error(ERR_FATAL, "%s: failed to allocate " YQ2_COM_PRIdS " bytes",
 			__func__, size);
 		return NULL;
-	}
-
-	if (size > zr->size)
-	{
-		memset((byte *)zr + zr->size, 0, size - zr->size);
 	}
 
 	z_bytes -= zr->size;

--- a/src/server/sv_cmd.c
+++ b/src/server/sv_cmd.c
@@ -332,7 +332,7 @@ SV_ListMaps_f(void)
 
 	Com_Printf("\n");
 
-	userMapNames = FS_ListFilesx2("maps/*.bsp", 0, 0);
+	userMapNames = FS_ListFiles2("maps/*.bsp", 0, 0);
 
 	for (i = 0; i < userMapNames.num; i++)
 	{

--- a/src/server/sv_cmd.c
+++ b/src/server/sv_cmd.c
@@ -326,33 +326,31 @@ SV_Map_f(void)
 static void
 SV_ListMaps_f(void)
 {
-	char **userMapNames;
-	int nUserMaps = 0;
+	strlist_t userMapNames;
 	int i;
 	char* mapName, *lastsep;
 
 	Com_Printf("\n");
 
-	if ((userMapNames = FS_ListFiles2("maps/*.bsp", &nUserMaps, 0, 0)) != NULL)
+	userMapNames = FS_ListFilesx2("maps/*.bsp", 0, 0);
+
+	for (i = 0; i < userMapNames.num; i++)
 	{
-		for (i = 0; i < nUserMaps - 1; i++)
+		if ((lastsep = strrchr(userMapNames.data[i], '/')))
 		{
-			if ((lastsep = strrchr(userMapNames[i], '/')))
-			{
-				mapName = lastsep + 1;
-			}
-			else
-			{
-				mapName = userMapNames[i];
-			}
-
-			mapName = strtok(mapName, ".");
-
-			Com_Printf("%s\n", mapName);
+			mapName = lastsep + 1;
+		}
+		else
+		{
+			mapName = userMapNames.data[i];
 		}
 
-		FS_FreeList(userMapNames, nUserMaps);
+		mapName = strtok(mapName, ".");
+
+		Com_Printf("%s\n", mapName);
 	}
+
+	StrList_Free(&userMapNames);
 }
 
 /*

--- a/src/server/sv_cmd.c
+++ b/src/server/sv_cmd.c
@@ -308,7 +308,7 @@ SV_Map_f(void)
 	{
 		Com_sprintf(expanded, sizeof(expanded), "maps/%s.bsp", map);
 
-		if (FS_LoadFile(expanded, NULL) == -1)
+		if (!FS_FileExists(expanded))
 		{
 			Com_Printf("Can't find %s\n", expanded);
 			return;


### PR DESCRIPTION
While refactoring `menu.c` I was inspired to make a dynamic string list API when I saw the mess in functions like `PlayerModelFree`, `PlayerModelList` or the maplist code. I also saw `FS_ListFiles2`...

This PR adds a `strlist_t` API in shared and refactored several parts of the code to use it.

strlist_t
* Always maintain an implicit NULL entry at the end of the list (not counted in the list length or capacity)
* Ensure the list remains in a valid state if (re-)allocation fails
* `StrList_Init`: Initialize a new list object
* `StrList_Free`: Free and initialize a list to a blank list
* `StrList_Compress`: Reduce capacity to equal the length of the list
* `StrList_Find`: Return the index of a string if found, given a compare function (strcmp is used if NULL)
* `StrList_Contains`: 1 if string is in list, 0 otherwise
* `StrList_Contains2`: Additionally takes a comparator function
* `StrList_Append`: Add string to list
* `StrList_Expand`: Expand capacity to specified value if needed
* `StrList_Print`: Print out the list state and its contents, given a print function (Com_Printf is used if NULL)

FS_ListFiles / FS_ListFiles2 / FS_ListMods
* Now return a `strlist_t` object and rewritten to use the strlist_t API
* Rewrote the callers of these functions to understand and use the returned strlist_t object
* Removed `FS_FreeList` function
* `FS_FreeList2` no longer searches the filesystem if `search->path` is the empty string, like in the case of pak paths

Menu code rewrites

* A `M_Free` function is now called from `CL_Shutdowm` to ensure all menu memory is freed, such as mods lists, start server maplist and player model/skin lists
* `Bitmap_Draw` cleaned up

Player model code
* Removed the `strlist_t` struct definition as it is now in shared
* `s_directory` is now a local temporary list and `PlayerDirectory` returns a strlist_t object
* Rewrote `PlayerModelFree` to use `StrList_Free` and set the model and skin spin controls to NULL for added safety
* Rewrote `PlayerModelList` to use the strlist_t API
* Removed `HasSkinsInDir` and `HasSkinInDir` in favor of a `SkinsInDir` that adds entries to the specified strlist object

Player config menu
* `SelectedModelSkin` utility function for safely and easily getting the currently selected model and skin names
* Player icon path is now a static buffer: `player_icon_path`. A local buffer was being assigned to a static variable which is not a good idea
* Player icon path is now set in a new `SkinCallback` function. Drawing code should not be modifying state, only interpreting it
* Cleanup and stability for `PlayerConfig_MenuClose`
* Player config menu can now be drawn with empty/invalid model and skin selection
* Player config menu can now be opened with empty/invalid model and skin selection. The user will see a warning popup if no models were found. This menu should always be accessible since it contains other options
* Cleanup and optimized `PlayerConfig_MenuInit`. `imgname` is now a pointer instead of a buffer and moved `Cvar_GetValue("rate")` out of loop
* Cache `cl_model_preview_start/end` cvars used by model preview drawing code while the player config menu is open
 
Maplist code
* Renamed `GetMapsList` to `MapsInLst` and rewritten to return strlist_t object
* Renamed `GetMapsInFolder` to `MapsInFolder` and rewritten to add entries to the specified strlist_t object
* Removed `GetCompletedMapsList` as `MapsInFolder` takes care of that task

Mods code
* Display names list is now a static global list: `moddispnames` and it is now freed by `Mods_NamesFinish`
* `modnames` is now a strlist_t object
* `Mods_NameInit` now initializes both names and display names lists
* `Mods_NamesFinish` now uses `StrList_Free` and NULLs the mods list option for safety
* Stability improvements and minor rewrites of `ModsListFunc` and `ModsApplyActionFunc`

Other changes

Filesystem
* New `FS_LoadFile2` function that takes a pad value that lets the caller add bytes at the end of the buffer if needed
* `FS_LoadFile` now calls `FS_LoadFile2` with a pad of 1 (a safety null byte in case the buffer will be used as a string)
* `FS_FileExists` is now a macro over a NULL `FS_LoadFile2` call
* Replaced NULL `FS_LoadFile` calls with `FS_FileExists` throughout
* `Cmd_Exec_f` now calls `FS_LoadFile2` with a pad of 2 bytes instead of allocating a new buffer and copying to it
* `FS_Dir_f` cleanup and optimization. `wildcard` did not need to be a buffer and `findname` now uses `MAX_OSPATH` instead of a hardcoded 1024 bytes

New shared functions/macros
* `Q_realloc0` that memsets memory extension returned by `realloc`
* `Q_strupr` function for uppercasing a string

Needless to say this needs testing. Player config, mods and start server menus are primary test subjects. The FS_ListFiles changes also impact code such as the map command auto-complete and dir and listmaps commands.

Bug reports, code criticism or ideas for more places where strlist_t could be used are welcome.