### PR TITLE
workflows: disable openal for win32

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
       run: |
         sed -i 's|option(SDL3_SUPPORT "Build against SDL 3 instead of SDL2" ON)|option(SDL3_SUPPORT "Build against SDL 3 instead of SDL2" OFF)|g' CMakeLists.txt
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@v4.37.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@v4.37.4
       with:
         category: "/language:${{ matrix.language }}"

--- a/.github/workflows/linux_aarch64.yml
+++ b/.github/workflows/linux_aarch64.yml
@@ -40,14 +40,20 @@ jobs:
         # Public runners come with 4 CPUs.
         make WITH_SDL3=no -j4
         make WITH_SDL3=no -j4 ref_gles1
+        # Debug version
+        make WITH_SDL3=no DEBUG=1 -j4
+        make WITH_SDL3=no DEBUG=1 -j4 ref_gles1
     - name: Create testbuild package
       run: |
         # Create release directory tree
         mkdir -p publish/quake2-linux_aarch64-${{github.sha}}/misc/docs
+        mkdir -p publish/quake2-linux_aarch64-${{github.sha}}/debug
         # Copy release assets
         cp -r release/* publish/quake2-linux_aarch64-${{github.sha}}/
+        cp -r debug/* publish/quake2-linux_aarch64-${{github.sha}}/debug/
         # Copy misc assets
         cp -r stuff/yq2.cfg publish/quake2-linux_aarch64-${{github.sha}}/misc/yq2.cfg
+        cp -r stuff/models publish/quake2-linux_aarch64-${{github.sha}}/misc
         cp -r stuff/mapfixes publish/quake2-linux_aarch64-${{github.sha}}/misc
         cp LICENSE publish/quake2-linux_aarch64-${{github.sha}}/misc/docs/LICENSE.txt
         cp README.md publish/quake2-linux_aarch64-${{github.sha}}/misc/docs/README.txt
@@ -70,8 +76,9 @@ jobs:
       run: |
         cppcheck -j 4 --enable=all --output-format=sarif \
           --output-file=cppcheck_results.sarif --inconclusive --library=posix \
+          --suppress=missingIncludeSystem \
           -DYQ2OSTYPE=\"Linux\" src
     - name: Upload SARIF to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@v4.37.4
       with:
         sarif_file: cppcheck_results.sarif

--- a/.github/workflows/linux_x86_64.yml
+++ b/.github/workflows/linux_x86_64.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         apt update
         apt install -y libgl1-mesa-dev libsdl3-dev libopenal-dev libcurl4-openssl-dev \
-            build-essential cppcheck
+            build-essential
     - name: Check out repository code
       uses: actions/checkout@v7
     - name: Build
@@ -47,6 +47,7 @@ jobs:
         cp -r release/* publish/quake2-linux_x86_64-${{github.sha}}/
         # Copy misc assets
         cp -r stuff/yq2.cfg publish/quake2-linux_x86_64-${{github.sha}}/misc/yq2.cfg
+        cp -r stuff/models publish/quake2-linux_x86_64-${{github.sha}}/misc
         cp -r stuff/mapfixes publish/quake2-linux_x86_64-${{github.sha}}/misc
         cp LICENSE publish/quake2-linux_x86_64-${{github.sha}}/misc/docs/LICENSE.txt
         cp README.md publish/quake2-linux_x86_64-${{github.sha}}/misc/docs/README.txt

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,6 +43,7 @@ jobs:
         cp -r release/* publish/quake2-macos-${{github.sha}}/
         # Copy misc assets
         cp -r stuff/yq2.cfg publish/quake2-macos-${{github.sha}}/misc/yq2.cfg
+        cp -r stuff/models publish/quake2-macos-${{github.sha}}/misc
         cp -r stuff/mapfixes publish/quake2-macos-${{github.sha}}/misc
         cp LICENSE publish/quake2-macos-${{github.sha}}/misc/docs/LICENSE.txt
         cp README.md publish/quake2-macos-${{github.sha}}/misc/docs/README.txt

--- a/.github/workflows/win32.yml
+++ b/.github/workflows/win32.yml
@@ -37,17 +37,17 @@ jobs:
           mingw-w64-${{matrix.env}}-curl
           mingw-w64-${{matrix.env}}-gcc
           mingw-w64-${{matrix.env}}-make
-          mingw-w64-${{matrix.env}}-openal
           mingw-w64-${{matrix.env}}-pkgconf
     - name: Check out repository code
       uses: actions/checkout@v7
     - name: Build
       shell: msys2 {0}
       run: |
+        sed -i 's|WITH_OPENAL:=yes|WITH_OPENAL:=no|g' Makefile
         # Download and extract SDL3 devel files.
-        curl -o SDL3-devel-3.4.12-mingw.tar.gz -L https://github.com/libsdl-org/SDL/releases/download/release-3.4.12/SDL3-devel-3.4.12-mingw.tar.gz
-        tar xf SDL3-devel-3.4.12-mingw.tar.gz
-        mv SDL3-3.4.12 SDL3
+        curl -o SDL3-devel-3.4.14-mingw.tar.gz -L https://github.com/libsdl-org/SDL/releases/download/release-3.4.14/SDL3-devel-3.4.14-mingw.tar.gz
+        tar xf SDL3-devel-3.4.14-mingw.tar.gz
+        mv SDL3-3.4.14 SDL3
         # Public runners come with 4 CPUs.
         PKG_CONFIG_PATH=SDL3/i686-w64-mingw32/lib/pkgconfig make -j4
         PKG_CONFIG_PATH=SDL3/i686-w64-mingw32/lib/pkgconfig make -j4 ref_gles1
@@ -60,6 +60,7 @@ jobs:
         cp -r release/* publish/quake2-win32-${{github.sha}}/
         # Copy misc assets
         cp -r stuff/yq2.cfg publish/quake2-win32-${{github.sha}}/misc/yq2.cfg
+        cp -r stuff/models publish/quake2-win32-${{github.sha}}/misc
         cp -r stuff/mapfixes publish/quake2-win32-${{github.sha}}/misc
         cp LICENSE publish/quake2-win32-${{github.sha}}/misc/docs/LICENSE.txt
         cp README.md publish/quake2-win32-${{github.sha}}/misc/docs/README.txt
@@ -74,10 +75,6 @@ jobs:
         cp doc/090_filelists.md publish/quake2-win32-${{github.sha}}/misc/docs/090_filelists.md
         # SDL3
         cp SDL3/i686-w64-mingw32/bin/SDL3.dll publish/quake2-win32-${{github.sha}}/
-        # openal-soft
-        curl -o openal-soft-1.24.3-bin.zip -L https://github.com/kcat/openal-soft/releases/download/1.24.3/openal-soft-1.24.3-bin.zip
-        unzip -o openal-soft-1.24.3-bin.zip
-        cp openal-soft-1.24.3-bin/bin/Win32/soft_oal.dll publish/quake2-win32-${{github.sha}}/openal32.dll
         # curl (releases use a custom build curl.dll)
         curl -o libcurl-4.dll -L "https://github.com/dhewm/dhewm3-libs/raw/refs/heads/master/i686-w64-mingw32/bin/libcurl-4.dll"
         cp libcurl-4.dll publish/quake2-win32-${{github.sha}}/curl.dll

--- a/.github/workflows/win64.yml
+++ b/.github/workflows/win64.yml
@@ -49,9 +49,9 @@ jobs:
       shell: msys2 {0}
       run: |
         # Download and extract SDL3 devel files.
-        curl -o SDL3-devel-3.4.12-mingw.tar.gz -L "https://github.com/libsdl-org/SDL/releases/download/release-3.4.12/SDL3-devel-3.4.12-mingw.tar.gz"
-        tar xf SDL3-devel-3.4.12-mingw.tar.gz
-        mv SDL3-3.4.12 SDL3
+        curl -o SDL3-devel-3.4.14-mingw.tar.gz -L "https://github.com/libsdl-org/SDL/releases/download/release-3.4.14/SDL3-devel-3.4.14-mingw.tar.gz"
+        tar xf SDL3-devel-3.4.14-mingw.tar.gz
+        mv SDL3-3.4.14 SDL3
         # Public runners come with 4 CPUs.
         PKG_CONFIG_PATH=SDL3/x86_64-w64-mingw32/lib/pkgconfig make -j4
         PKG_CONFIG_PATH=SDL3/x86_64-w64-mingw32/lib/pkgconfig make -j4 ref_gles1

--- a/.github/workflows/win_msvc.yml
+++ b/.github/workflows/win_msvc.yml
@@ -66,6 +66,7 @@ jobs:
         cd ../../..
         # Copy misc assets
         cp -r stuff/yq2.cfg publish/$PKGDIR/misc/yq2.cfg
+        cp -r stuff/models publish/$PKGDIR/misc
         cp -r stuff/mapfixes publish/$PKGDIR/misc
         cp LICENSE publish/$PKGDIR/misc/docs/LICENSE.txt
         cp README.md publish/$PKGDIR/misc/docs/README.txt
@@ -147,6 +148,7 @@ jobs:
         cd ../../..
         # Copy misc assets
         cp -r stuff/yq2.cfg publish/$PKGDIR/misc/yq2.cfg
+        cp -r stuff/models publish/$PKGDIR/misc
         cp -r stuff/mapfixes publish/$PKGDIR/misc
         cp LICENSE publish/$PKGDIR/misc/docs/LICENSE.txt
         cp README.md publish/$PKGDIR/misc/docs/README.txt
@@ -183,6 +185,6 @@ jobs:
         buildConfiguration: RelWithDebInfo
         ruleset: NativeRecommendedRules.ruleset
     - name: Upload SARIF to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@v4.37.4
       with:
         sarif_file: ${{ steps.run-analysis.outputs.sarif }}


### PR DESCRIPTION
* Build artifacts are not unused for final release, disable OpenAL for win32 should be safe, as OpenAL also used in win64 and should catch possible regressions.
* Update SDL3 and workflow dependencies. 
* Add skip system include check for cppcheck
* Put crosschar model to build artifacts.
* Build debug version additionally to release version.