### PR TITLE
client: download filter, only check file presence after sanity checks

### DIFF
--- a/src/client/cl_download.c
+++ b/src/client/cl_download.c
@@ -553,22 +553,29 @@ CL_DownloadFileName(char *dest, int destlen, char *fn)
 static qboolean
 CL_DownloadFilter(const char *filename)
 {
-	if (FS_FileExists(filename))
-	{
-		/* it exists, no need to download */
-		return true;
-	}
+	size_t i;
+	static const char *extensions[] = {
+		".dll",
+		".dylib",
+		".lib",
+		".so",
+		".a",
+		NULL,
+	};
 
-	if (strstr(filename, "..") || strchr(filename, ':') || (*filename == '.') || (*filename == '/'))
+	if ((*filename == '.') || (*filename == '/') || strchr(filename, ':') || strstr(filename, ".."))
 	{
 		Com_Printf("Refusing to download a path containing '..' or ':' or starting with '.' or '/': %s\n", filename);
 		return true;
 	}
 
-	if (strstr(filename, ".dll") || strstr(filename, ".dylib") || strstr(filename, ".so"))
+	for (i = 0; extensions[i]; i++)
 	{
-		Com_Printf("Refusing to download a path containing '.dll', '.dylib' or '.so': %s\n", filename);
-		return true;
+		if (strstr(filename, extensions[i]))
+		{
+			Com_Printf("Refusing to download a path containing '%s': %s\n", extensions[i], filename);
+			return true;
+		}
 	}
 
 	char *nodownload = strdup(cl_nodownload_list->string);
@@ -585,6 +592,12 @@ CL_DownloadFilter(const char *filename)
 		nodownload_token = strtok(NULL, " ");
 	}
 	free(nodownload);
+
+	if (FS_FileExists(filename))
+	{
+		/* it exists, no need to download */
+		return true;
+	}
 
 	return false;
 }


### PR DESCRIPTION
Backport of yquake2remaster e70b076. The extension blocklist becomes a table (adding .lib and .a) and the local presence check is moved behind the path and blocklist checks, so a hostile path is rejected before it is looked up on the filesystem.