### PR TITLE
New cvar to centralize SBC optimizations

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -530,9 +530,11 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   show. Defaults to `300`.  
   Related to this: *cl_maxfps* and *cl_async*.
 
-* **vid_pauseonfocuslost**: When set to `1` the game is paused as soon
-  as it's window looses focus. It will work only in situation were the
-  game can be paused, e.g. not in multiplayer games. Defaults to `0`.
+* **vid_pauseonfocuslost**: When set to `0` (default) the game is paused
+  as soon as its window loses focus. It will only work where the game can
+  be paused, e.g. not in multiplayer. If `1`, the game continues to run
+  in the background. Setting it as `2` is the same as `0`, but the game
+  will unpause right when its window gets back to being on focus.
 
 * **vid_renderer**: Selects the renderer library. Possible options are
   `gl3` (the default) for the OpenGL 3.2 renderer, `gles3` for the

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -603,16 +603,11 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   FOV when diving underwater. Can be any floating point number, `0`
   disables it (Vanilla Quake II look). Default `1.0`.
 
-* **gl1_lightmapcopies**: When enabled (`1`), keep 3 copies of the same
-  lightmap rotating, shifting to another one when drawing a new frame.
-  Meant for mobile/embedded devices, where changing textures just shown
-  (dynamic lighting) causes slowdown. By default in GL1 is disabled,
-  while in GLES1 is enabled. Needs `gl1_multitexture 1` & `vid_restart`.
-
-* **gl1_discardfb**: If `1`, clear color, depth and stencil buffers at
-  the start of a frame, and discard them at the end if possible. If
-  `2`, do only depth and stencil, no color. Increases performance in
-  mobile / embedded. Default in GL1 is `0`, while in GLES1 is `1`.
+* **gl1_tilerendering**: Available only in GL1, this controls whether
+  the optimizations included in GLES1 for *tile-based* rendering devices
+  (mainly SBCs) are also applied in GL1. These optimizations may backfire
+  on traditional *immediate mode* GPUs (desktop), so by default this is
+  `0`. Enabling this requires `gl1_multitexture 1` & `vid_restart`.
 
 
 ## Graphics (OpenGL 3.2 and OpenGL ES3 only)

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -552,9 +552,10 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   also used for looking underwater. Default is `1` (enabled).
 
 * **gl_znear**: Sets the distance to the *near depth clipping plane* of
-  the player view. Reducing it may allow some weapon animations to not
-  get "clipped" by the player view (e.g. railgun firing), at the risk
-  of heavy glitches with some hardware configurations. Default is `4`.
+  the player view. Default is `4`. Reducing it to `3.2` or similar may
+  allow some weapon animations to not get 'clipped' by the player view
+  (e.g. railgun recoil), at the risk of heavy glitches with some
+  hardware / driver configurations.
 
 * **gl_texturemode**: How textures are filtered.
 

--- a/src/client/input/sdl2.c
+++ b/src/client/input/sdl2.c
@@ -982,65 +982,69 @@ IN_Update(void)
 			}
 
 			case SDL_WINDOWEVENT:
-				if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST ||
-					event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+				switch (event.window.event)
 				{
-					Key_MarkAllUp();
-
-					if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+					case SDL_WINDOWEVENT_FOCUS_LOST:
 					{
+						Key_MarkAllUp();
 						S_Activate(false);
 
 						if (windowed_pauseonfocuslost->value != 1)
 						{
-						    Cvar_SetValue("paused", 1);
+							Cvar_SetValue("paused", 1);
 						}
 
 						/* pause music */
 						if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
-						    OGG_Status() == PLAY && cl.attractloop == false)
+							OGG_Status() == PLAY && cl.attractloop == false)
 						{
-						    Cbuf_AddText("ogg toggle\n");
+							Cbuf_AddText("ogg toggle\n");
 						}
+						break;
 					}
 
-					if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+					case SDL_WINDOWEVENT_FOCUS_GAINED:
 					{
 						S_Activate(true);
 
 						if (windowed_pauseonfocuslost->value == 2)
 						{
-						    Cvar_SetValue("paused", 0);
+							Cvar_SetValue("paused", 0);
 						}
 
 						/* play music */
 						if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
-						    OGG_Status() == PAUSE && cl.attractloop == false &&
-						    cl_paused->value == 0)
+							OGG_Status() == PAUSE && cl.attractloop == false &&
+							cl_paused->value == 0)
 						{
-						    Cbuf_AddText("ogg toggle\n");
+							Cbuf_AddText("ogg toggle\n");
 						}
-					}
-				}
-				else if (event.window.event == SDL_WINDOWEVENT_MOVED)
-				{
-					// make sure GLimp_GetRefreshRate() will query from SDL again - the window might
-					// be on another display now!
-					glimp_refreshRate = -1.0f;
-				}
-				else if (event.window.event == SDL_WINDOWEVENT_SHOWN)
-				{
-					if (cl_unpaused_scvis->value > 0)
-					{
-						Cvar_SetValue("paused", 0);
+						break;
 					}
 
-					/* play music */
-					if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
-					    OGG_Status() == PAUSE && cl.attractloop == false &&
-					    cl_paused->value == 0)
+					case SDL_WINDOWEVENT_MOVED:
 					{
-					    Cbuf_AddText("ogg toggle\n");
+						// make sure GLimp_GetRefreshRate() will query from SDL again - the window might
+						// be on another display now!
+						glimp_refreshRate = -1.0f;
+						break;
+					}
+
+					case SDL_WINDOWEVENT_SHOWN:
+					{
+						if (cl_unpaused_scvis->value > 0)
+						{
+							Cvar_SetValue("paused", 0);
+						}
+
+						/* play music */
+						if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
+							OGG_Status() == PAUSE && cl.attractloop == false &&
+							cl_paused->value == 0)
+						{
+							Cbuf_AddText("ogg toggle\n");
+						}
+						break;
 					}
 				}
 				break;

--- a/src/client/menu/videomenu.c
+++ b/src/client/menu/videomenu.c
@@ -296,6 +296,16 @@ CurrentRendererByCvar(void)
 	return ref_custom;
 }
 
+// See filter_names in VID_MenuInit()
+static const char *gl_filter_list[] = {
+	"GL_NEAREST",	// pixelated
+	"GL_LINEAR",	// linear
+	"GL_LINEAR_MIPMAP_NEAREST",	// standard
+	"GL_LINEAR_MIPMAP_LINEAR"	// trilinear
+};
+
+static const int gl_filter_list_len = ARRLEN(gl_filter_list);
+
 static void
 ApplyFilter(void* unused)
 {
@@ -303,17 +313,9 @@ ApplyFilter(void* unused)
 	{
 		case ref_gl3:
 		case ref_gl1:
-			if (s_filter_list.curvalue == 0)
+			if (s_filter_list.curvalue < gl_filter_list_len)
 			{
-				Cvar_Set("gl_texturemode", "GL_NEAREST");
-			}
-			else if (s_filter_list.curvalue == 1)
-			{
-				Cvar_Set("gl_texturemode", "GL_LINEAR_MIPMAP_NEAREST");
-			}
-			else if (s_filter_list.curvalue == 2)
-			{
-				Cvar_Set("gl_texturemode", "GL_LINEAR_MIPMAP_LINEAR");
+				Cvar_Set("gl_texturemode", gl_filter_list[s_filter_list.curvalue]);
 			}
 			break;
 		case ref_soft:
@@ -552,8 +554,10 @@ VID_MenuInit(void)
 		NULL
 	};
 
+	// This must match 'gl_filter_list' values (except "custom")
 	static const char *filter_names[] = {
 		"pixelated",
+		"linear",
 		"standard",
 		"trilinear",
 		"custom",
@@ -877,19 +881,15 @@ VID_MenuInit(void)
 			s_filter_list.itemnames = filter_names;
 
 			filter = Cvar_VariableString("gl_texturemode");
-			mode = 3;
+			mode = gl_filter_list_len;	// "custom" by default
 
-			if (Q_stricmp(filter, "GL_NEAREST") == 0)
+			for (int i = 0; i < gl_filter_list_len; i++)
 			{
-				mode = 0;
-			}
-			else if (Q_stricmp(filter, "GL_LINEAR_MIPMAP_NEAREST") == 0)
-			{
-				mode = 1;
-			}
-			else if (Q_stricmp(filter, "GL_LINEAR_MIPMAP_LINEAR") == 0)
-			{
-				mode = 2;
+				if (Q_stricmp(filter, gl_filter_list[i]) == 0)
+				{
+					mode = i;
+					break;
+				}
 			}
 			break;
 

--- a/src/client/refresh/gl1/gl1_buffer.c
+++ b/src/client/refresh/gl1/gl1_buffer.c
@@ -32,7 +32,7 @@
 #define GLBUFFER_RESET	vtx_ptr = idx_ptr = 0; gl_buf.vt = gl_buf.tx = gl_buf.cl = 0;
 
 glbuffer_t gl_buf;	// our drawing buffer, used globally
-int cur_lm_copy;	// which lightmap copy to use (when lightmapcopies=on)
+int cur_lm_copy;	// which lightmap copy to use (when tilerendering=on)
 
 static GLushort vtx_ptr, idx_ptr;	// pointers for array positions in gl_buf
 
@@ -184,7 +184,7 @@ R_ApplyGLBuffer(void)
 		{
 			// TMU 1: Lightmap texture
 			int lmtexture = gl_state.lightmap_textures + gl_buf.texture[1];
-			if (gl_config.lightmapcopies)
+			if (gl_config.tilerendering)
 			{
 				// Bind appropiate lightmap copy for this frame
 				lmtexture += MAX_LIGHTMAPS * cur_lm_copy;

--- a/src/client/refresh/gl1/gl1_buffer.c
+++ b/src/client/refresh/gl1/gl1_buffer.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 1997-2001 Id Software, Inc.
- * Copyright (C) 2024      Jaime Moreira
+ * Copyright (C) 2024-2025 Jaime Moreira
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
  * =======================================================================
  *
  * Drawing buffer: sort of a "Q3A shader" handler, allows to join multiple
- * draw calls into one, by grouping those which share the same
+ * draw calls into one, by grouping/batching those which share the same
  * characteristics (mostly the same texture).
  *
  * =======================================================================

--- a/src/client/refresh/gl1/gl1_image.c
+++ b/src/client/refresh/gl1/gl1_image.c
@@ -39,10 +39,6 @@ static cvar_t *intensity;
 unsigned d_8to24table[256];
 
 extern cvar_t *gl1_minlight;
-extern byte minlight[256];
-
-qboolean R_Upload8(byte *data, int width, int height,
-		qboolean mipmap, qboolean is_sky);
 
 #define Q2_GL_SOLID_FORMAT GL_RGB
 #define Q2_GL_ALPHA_FORMAT GL_RGBA
@@ -67,7 +63,7 @@ typedef struct
 	int minimize, maximize;
 } glmode_t;
 
-glmode_t modes[] = {
+static const glmode_t modes[] = {
 	{"GL_NEAREST", GL_NEAREST, GL_NEAREST},
 	{"GL_LINEAR", GL_LINEAR, GL_LINEAR},
 	{"GL_NEAREST_MIPMAP_NEAREST", GL_NEAREST_MIPMAP_NEAREST, GL_NEAREST},
@@ -75,8 +71,6 @@ glmode_t modes[] = {
 	{"GL_NEAREST_MIPMAP_LINEAR", GL_NEAREST_MIPMAP_LINEAR, GL_NEAREST},
 	{"GL_LINEAR_MIPMAP_LINEAR", GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR}
 };
-
-#define NUM_GL_MODES ARRLEN(modes)
 
 typedef struct
 {
@@ -86,19 +80,19 @@ typedef struct
 
 #ifdef YQ2_GL1_GLES
 
-gltmode_t gl_alpha_modes[] = {
+static const gltmode_t gl_alpha_modes[] = {
 	{"default", GL_RGBA},
 	{"GL_RGBA", GL_RGBA},
 };
 
-gltmode_t gl_solid_modes[] = {
+static const gltmode_t gl_solid_modes[] = {
 	{"default", GL_RGBA},
 	{"GL_RGBA", GL_RGBA},
 };
 
 #else
 
-gltmode_t gl_alpha_modes[] = {
+static const gltmode_t gl_alpha_modes[] = {
 	{"default", GL_RGBA},
 	{"GL_RGBA", GL_RGBA},
 	{"GL_RGBA8", GL_RGBA8},
@@ -107,7 +101,7 @@ gltmode_t gl_alpha_modes[] = {
 	{"GL_RGBA2", GL_RGBA2},
 };
 
-gltmode_t gl_solid_modes[] = {
+static const gltmode_t gl_solid_modes[] = {
 	{"default", GL_RGB},
 	{"GL_RGB", GL_RGB},
 	{"GL_RGB8", GL_RGB8},
@@ -117,9 +111,6 @@ gltmode_t gl_solid_modes[] = {
 };
 
 #endif
-
-#define NUM_GL_ALPHA_MODES ARRLEN(gl_alpha_modes)
-#define NUM_GL_SOLID_MODES ARRLEN(gl_solid_modes)
 
 static int upload_width, upload_height;
 static qboolean uploaded_paletted;
@@ -144,7 +135,7 @@ R_SetTexturePalette(const unsigned palette[256])
 	}
 }
 
-void
+static void
 R_SelectTexture(GLenum texture)
 {
 	if (!gl_config.multitexture || gl_state.currenttarget == texture)
@@ -162,7 +153,7 @@ R_SelectTexture(GLenum texture)
 void
 R_TexEnv(GLenum mode)
 {
-	static int lastmodes[2] = {-1, -1};
+	static int lastmodes[MAX_TEXTURE_UNITS] = {-1, -1};
 
 	if (mode != lastmodes[gl_state.currenttmu])
 	{
@@ -248,10 +239,11 @@ R_EnableMultitexture(qboolean enable)
 void
 R_TextureMode(const char *string)
 {
+	static const int num_modes = ARRLEN(modes);
 	int i, texnum;
 	image_t *glt;
 
-	for (i = 0; i < NUM_GL_MODES; i++)
+	for (i = 0; i < num_modes; i++)
 	{
 		if (!Q_stricmp(modes[i].name, string))
 		{
@@ -259,7 +251,7 @@ R_TextureMode(const char *string)
 		}
 	}
 
-	if (i == NUM_GL_MODES)
+	if (i == num_modes)
 	{
 		Com_Printf("bad filter name '%s'\n", string);
 		return;
@@ -359,9 +351,10 @@ R_TextureMode(const char *string)
 void
 R_TextureAlphaMode(const char *string)
 {
+	static const int num_alpha_modes = ARRLEN(gl_alpha_modes);
 	int i;
 
-	for (i = 0; i < NUM_GL_ALPHA_MODES; i++)
+	for (i = 0; i < num_alpha_modes; i++)
 	{
 		if (!Q_stricmp(gl_alpha_modes[i].name, string))
 		{
@@ -369,7 +362,7 @@ R_TextureAlphaMode(const char *string)
 		}
 	}
 
-	if (i == NUM_GL_ALPHA_MODES)
+	if (i == num_alpha_modes)
 	{
 		Com_Printf("bad alpha texture mode name\n");
 		return;
@@ -381,9 +374,10 @@ R_TextureAlphaMode(const char *string)
 void
 R_TextureSolidMode(const char *string)
 {
+	static const int num_solid_modes = ARRLEN(gl_solid_modes);
 	int i;
 
-	for (i = 0; i < NUM_GL_SOLID_MODES; i++)
+	for (i = 0; i < num_solid_modes; i++)
 	{
 		if (!Q_stricmp(gl_solid_modes[i].name, string))
 		{
@@ -391,7 +385,7 @@ R_TextureSolidMode(const char *string)
 		}
 	}
 
-	if (i == NUM_GL_SOLID_MODES)
+	if (i == num_solid_modes)
 	{
 		Com_Printf("bad solid texture mode name\n");
 		return;
@@ -825,7 +819,7 @@ R_Upload32(unsigned *data, size_t width, size_t height, qboolean mipmap)
 /*
  * Returns has_alpha
  */
-qboolean
+static qboolean
 R_Upload8(byte *data, int width, int height, qboolean mipmap, qboolean is_sky)
 {
 	if (gl_config.palettedtexture && is_sky)

--- a/src/client/refresh/gl1/gl1_light.c
+++ b/src/client/refresh/gl1/gl1_light.c
@@ -32,9 +32,9 @@ cplane_t *lightplane; /* used as shadow plane */
 vec3_t lightspot;
 static float s_blocklights[34 * 34 * 3];
 
-unsigned char minlight[256];
+byte minlight[256];
 
-void
+static void
 R_RenderDlight(dlight_t *light)
 {
 	const float rad = light->intensity * 0.35;
@@ -166,7 +166,7 @@ R_PushDlights(void)
 	}
 }
 
-int
+static int
 R_RecursiveLightPoint(mnode_t *node, vec3_t start, vec3_t end)
 {
 	float front, back, frac;
@@ -338,7 +338,7 @@ R_LightPoint(entity_t *currententity, vec3_t p, vec3_t color)
 	VectorScale(color, r_modulate->value, color);
 }
 
-void
+static void
 R_AddDynamicLights(msurface_t *surf)
 {
 	int lnum;

--- a/src/client/refresh/gl1/gl1_lightmap.c
+++ b/src/client/refresh/gl1/gl1_lightmap.c
@@ -105,7 +105,7 @@ LM_UploadBlock(qboolean dynamic)
 				0, GL_LIGHTMAP_FORMAT, GL_UNSIGNED_BYTE,
 				gl_lms.lightmap_buffer[buffer]);
 
-		if (gl_config.lightmapcopies && buffer != 0)
+		if (gl_config.tilerendering && buffer != 0)
 		{
 			// Upload to all lightmap copies
 			for (i = 1; i < MAX_LIGHTMAP_COPIES; i++)

--- a/src/client/refresh/gl1/gl1_lightmap.c
+++ b/src/client/refresh/gl1/gl1_lightmap.c
@@ -28,9 +28,6 @@
 
 extern gllightmapstate_t gl_lms;
 
-void R_SetCacheState(msurface_t *surf);
-void R_BuildLightMap(msurface_t *surf, byte *dest, int stride);
-
 void
 LM_FreeLightmapBuffers(void)
 {

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -87,8 +87,6 @@ cvar_t *gl1_particle_square;
 
 cvar_t *gl1_palettedtexture;
 cvar_t *gl1_pointparameters;
-cvar_t *gl1_lightmapcopies;
-cvar_t *gl1_discardfb;
 
 cvar_t *gl_drawbuffer;
 cvar_t *gl_lightmap;
@@ -143,6 +141,10 @@ cvar_t *gl1_stereo_convergence;
 static cvar_t *gl_znear;
 static cvar_t *gl1_multitexture;
 static cvar_t *gl1_waterwarp;
+
+#ifndef YQ2_GL1_GLES
+static cvar_t *gl1_tilerendering;	// this is always "forced on" in GLES1
+#endif
 
 refimport_t ri;
 
@@ -631,7 +633,7 @@ R_PolyBlend(void)
 static void
 R_ResetClearColor(void)
 {
-	if (gl1_discardfb->value == 1 && !r_clear->value)
+	if (gl_config.tilerendering && !r_clear->value)
 	{
 		glClearColor(0, 0, 0, 0.5);
 	}
@@ -876,19 +878,14 @@ R_Clear(void)
 		gldepthmax = 1;
 	}
 
-	switch ((int)gl1_discardfb->value)
+	if (gl_config.tilerendering)
 	{
-		case 1:
-			if (gl_state.stereo_mode == STEREO_MODE_NONE)
-			{
-				clearFlags |= GL_COLOR_BUFFER_BIT;
-			}
-			/* fall through */
-		case 2:
-			clearFlags |= GL_STENCIL_BUFFER_BIT;
-			/* fall through */
-		default:
-			break;
+		clearFlags |= GL_STENCIL_BUFFER_BIT;
+
+		if (gl_state.stereo_mode == STEREO_MODE_NONE)
+		{
+			clearFlags |= GL_COLOR_BUFFER_BIT;
+		}
 	}
 
 	if (clearFlags)
@@ -1217,9 +1214,9 @@ RI_RenderFrame(refdef_t *fd)
 }
 
 #ifdef YQ2_GL1_GLES
-#define GLES1_ENABLED_ONLY	"1"
+#define ONLY_ENABLED_IN_GL1   "0"
 #else
-#define GLES1_ENABLED_ONLY	"0"
+#define ONLY_ENABLED_IN_GL1   "1"
 #endif
 
 void
@@ -1276,10 +1273,11 @@ R_Register(void)
 	r_lockpvs = ri.Cvar_Get("r_lockpvs", "0", 0);
 
 	gl1_palettedtexture = ri.Cvar_Get("r_palettedtextures", "0", CVAR_ARCHIVE);
-	gl1_pointparameters = ri.Cvar_Get("gl1_pointparameters", "1", CVAR_ARCHIVE);
+	gl1_pointparameters = ri.Cvar_Get("gl1_pointparameters", ONLY_ENABLED_IN_GL1, CVAR_ARCHIVE);
 	gl1_multitexture = ri.Cvar_Get("gl1_multitexture", "1", CVAR_ARCHIVE);
-	gl1_lightmapcopies = ri.Cvar_Get("gl1_lightmapcopies", GLES1_ENABLED_ONLY, CVAR_ARCHIVE);
-	gl1_discardfb = ri.Cvar_Get("gl1_discardfb", GLES1_ENABLED_ONLY, CVAR_ARCHIVE);
+#ifndef YQ2_GL1_GLES
+	gl1_tilerendering = ri.Cvar_Get("gl1_tilerendering", "0", CVAR_ARCHIVE);
+#endif
 
 	gl_drawbuffer = ri.Cvar_Get("gl_drawbuffer", "GL_BACK", 0);
 	r_vsync = ri.Cvar_Get("r_vsync", "1", CVAR_ARCHIVE);
@@ -1319,7 +1317,7 @@ R_Register(void)
 	ri.Cmd_AddCommand("gl_strings", R_Strings);
 }
 
-#undef GLES1_ENABLED_ONLY
+#undef ONLY_ENABLED_IN_GL1
 
 /*
  * Used in the SetMode functions below, no need to have these in local.h
@@ -1711,35 +1709,13 @@ RI_Init(void)
 
 	// ----
 
-	/* Lightmap copies: keep multiple copies of "the same" lightmap on video memory.
-	 * All of them are actually different, because they are affected by different dynamic lighting,
-	 * in different frames. This is not meant for Immediate-Mode Rendering systems (desktop),
-	 * but for Tile-Based / Deferred Rendering ones (embedded / mobile), since active manipulation
-	 * of textures already being used in the last few frames can cause slowdown on these systems.
-	 * Needless to say, GPU memory usage is highly increased, so watch out in low memory situations.
-	 */
-
-	Com_Printf(" - Lightmap copies: ");
-	gl_config.lightmapcopies = false;
-	if (gl_config.multitexture && gl1_lightmapcopies->value)
-	{
-		gl_config.lightmapcopies = true;
-		Com_Printf("Okay\n");
-	}
-	else
-	{
-		Com_Printf("Disabled\n");
-	}
-
-	// ----
-
 	/* Discard framebuffer: Enables the use of a "performance hint" to the graphic
 	 * driver in GLES1, to get rid of the contents of the different framebuffers.
 	 * Useful for some GPUs that may attempt to keep them and/or write them back to
 	 * external/uniform memory, actions that are useless for Quake 2 rendering path.
 	 * https://registry.khronos.org/OpenGL/extensions/EXT/EXT_discard_framebuffer.txt
-	 * This extension is used by 'gl1_discardfb', and regardless of its existence,
-	 * that cvar will enable glClear at the start of each frame, helping mobile GPUs.
+	 * Regardless of the existence of this extension, if gl_config.tilerendering is
+	 * true, glClear() will run at the start of each frame, helping mobile GPUs.
 	 */
 
 #ifdef YQ2_GL1_GLES
@@ -1751,22 +1727,51 @@ RI_Init(void)
 				RI_GetProcAddress ("glDiscardFramebufferEXT");
 	}
 
-	if (gl1_discardfb->value)
+	if (qglDiscardFramebufferEXT)	// enough to verify availability
 	{
-		if (qglDiscardFramebufferEXT)	// enough to verify availability
-		{
-			Com_Printf("Okay\n");
-		}
-		else
-		{
-			Com_Printf("Failed\n");
-		}
+		Com_Printf("Okay\n");
 	}
 	else
 	{
-		Com_Printf("Disabled\n");
+		Com_Printf("Failed\n");
 	}
 #endif
+
+	// ----
+
+	/* Tile-Based Rendering optimizations
+	 * ----------------------------------
+	 * Controlled by the `gl1_tilerendering` cvar, this in meant for Tile-Based / Deferred Rendering
+	 * GPUs (embedded / mobile / SoCs), which differ from Immediate-Mode Rendering ones (desktop).
+	 * Imply two alterations in rendering:
+	 *
+	 * 1.- Lightmap copies: keep multiple copies of "the same" lightmap on video memory. All of
+	 * them are actually different, because they are affected by different dynamic lighting, in
+	 * different frames. In TBR, active manipulation of textures already being used in the last
+	 * few frames can cause slowdown, so we avoid using them after being just changed. Note that
+	 * this requires mtex support, so may not work on VERY old GL ES 1.0 devices (1.1 is safe).
+	 * Watch out in low VRAM situations.
+	 *
+	 * 2.- Discard framebuffers / glClear before rendering every frame: explained above in
+	 * "Discard framebuffer".
+	*/
+
+	Com_Printf("Optimizations target: ");
+	gl_config.tilerendering = false;
+
+	if ( gl_config.multitexture
+#ifndef YQ2_GL1_GLES
+		&& gl1_tilerendering->value
+#endif
+	)
+	{
+		gl_config.tilerendering = true;
+		Com_Printf("SBC / embedded (TBR)\n");
+	}
+	else
+	{
+		Com_Printf("Desktop (IMR)\n");
+	}
 
 	// ----
 

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -87,7 +87,6 @@ cvar_t *gl1_particle_square;
 
 cvar_t *gl1_palettedtexture;
 cvar_t *gl1_pointparameters;
-cvar_t *gl1_multitexture;
 cvar_t *gl1_lightmapcopies;
 cvar_t *gl1_discardfb;
 
@@ -142,13 +141,12 @@ cvar_t *gl1_stereo_anaglyph_colors;
 cvar_t *gl1_stereo_convergence;
 
 static cvar_t *gl_znear;
+static cvar_t *gl1_multitexture;
 static cvar_t *gl1_waterwarp;
 
 refimport_t ri;
 
-void LM_FreeLightmapBuffers(void);
-void Scrap_Init(void);
-
+extern void LM_FreeLightmapBuffers(void);
 extern void R_SetDefaultState(void);
 extern void R_ResetGLBuffer(void);
 
@@ -1552,15 +1550,13 @@ RI_Init(void)
 
 	sscanf(gl_config.version_string, "%d.%d", &gl_config.major_version, &gl_config.minor_version);
 
-	if (refresher == rf_opengl14 && gl_config.major_version == 1)
+	if ( refresher == rf_opengl14 &&
+		gl_config.major_version == 1 && gl_config.minor_version < 4 )
 	{
-		if (gl_config.minor_version < 4)
-		{
-			QGL_Shutdown();
-			Com_Printf("Support for OpenGL 1.4 is not available\n");
+		QGL_Shutdown();
+		Com_Printf("Support for OpenGL 1.4 is not available\n");
 
-			return false;
-		}
+		return false;
 	}
 
 	Com_Printf("\n\nProbing for OpenGL extensions:\n");
@@ -1616,8 +1612,8 @@ RI_Init(void)
 	if (strstr(gl_config.extensions_string, "GL_EXT_paletted_texture") &&
 		strstr(gl_config.extensions_string, "GL_EXT_shared_texture_palette"))
 	{
-			qglColorTableEXT = (void (APIENTRY *)(GLenum, GLenum, GLsizei, GLenum, GLenum, const GLvoid * ))
-					RI_GetProcAddress ("glColorTableEXT");
+		qglColorTableEXT = (void (APIENTRY *)(GLenum, GLenum, GLsizei, GLenum, GLenum, const GLvoid * ))
+				RI_GetProcAddress ("glColorTableEXT");
 	}
 
 	gl_config.palettedtexture = false;

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -1324,6 +1324,18 @@ R_Register(void)
 #undef GLES1_ENABLED_ONLY
 
 /*
+ * Used in the SetMode functions below, no need to have these in local.h
+ */
+typedef enum
+{
+	rserr_ok,
+
+	rserr_invalid_mode,
+
+	rserr_unknown
+} rserr_t;
+
+/*
  * Changes the video mode
  */
 static int
@@ -1356,8 +1368,8 @@ SetMode_impl(int *pwidth, int *pheight, int mode, int fullscreen)
 		return rserr_invalid_mode;
 	}
 
-	/* This is totaly obscure: For some strange reasons the renderer
-	   maintains two(!) repesentations of the resolution. One comes
+	/* This is totally obscure: For some strange reasons the renderer
+	   maintains two(!) representations of the resolution. One comes
 	   from the client and is saved in r_newrefdef. The other one
 	   is determined here and saved in vid. Several calculations take
 	   both representations into account.

--- a/src/client/refresh/gl1/gl1_mesh.c
+++ b/src/client/refresh/gl1/gl1_mesh.c
@@ -45,8 +45,6 @@ float shadelight[3];
 float *shadedots = r_avertexnormal_dots[0];
 extern vec3_t lightspot;
 
-extern unsigned char minlight[256];
-
 static void
 R_LerpVerts(entity_t *currententity, int nverts, dtrivertx_t *v, dtrivertx_t *ov,
 		dtrivertx_t *verts, float *lerp, float move[3],

--- a/src/client/refresh/gl1/gl1_model.c
+++ b/src/client/refresh/gl1/gl1_model.c
@@ -36,10 +36,10 @@ static int mod_max = 0;
 int registration_sequence;
 
 static void Mod_LoadBrushModel(model_t *mod, void *buffer, int modfilelen);
-void LM_BuildPolygonFromSurface(model_t *currentmodel, msurface_t *fa);
-void LM_CreateSurfaceLightmap(msurface_t *surf);
-void LM_EndBuildingLightmaps(void);
-void LM_BeginBuildingLightmaps(model_t *m);
+extern void LM_BuildPolygonFromSurface(model_t *currentmodel, msurface_t *fa);
+extern void LM_CreateSurfaceLightmap(msurface_t *surf);
+extern void LM_EndBuildingLightmaps(void);
+extern void LM_BeginBuildingLightmaps(model_t *m);
 
 //===============================================================================
 

--- a/src/client/refresh/gl1/gl1_sdl.c
+++ b/src/client/refresh/gl1/gl1_sdl.c
@@ -38,8 +38,6 @@ static SDL_GLContext context = NULL;
 qboolean IsHighDPIaware = false;
 static qboolean vsyncActive = false;
 
-extern cvar_t *gl1_discardfb;
-
 // ----
 
 /*
@@ -51,21 +49,11 @@ RI_EndFrame(void)
 	R_ApplyGLBuffer();	// to draw buffered 2D text
 
 #ifdef YQ2_GL1_GLES
-	static const GLenum attachments[3] = {GL_COLOR_EXT, GL_DEPTH_EXT, GL_STENCIL_EXT};
+	static const GLenum attachments[] = {GL_COLOR_EXT, GL_DEPTH_EXT, GL_STENCIL_EXT};
 
-	if (qglDiscardFramebufferEXT)
+	if (qglDiscardFramebufferEXT && gl_config.tilerendering)
 	{
-		switch ((int)gl1_discardfb->value)
-		{
-			case 1:
-				qglDiscardFramebufferEXT(GL_FRAMEBUFFER_OES, 3, &attachments[0]);
-				break;
-			case 2:
-				qglDiscardFramebufferEXT(GL_FRAMEBUFFER_OES, 2, &attachments[1]);
-				break;
-			default:
-				break;
-		}
+		qglDiscardFramebufferEXT(GL_FRAMEBUFFER_OES, 3, attachments);
 	}
 #endif
 

--- a/src/client/refresh/gl1/gl1_surf.c
+++ b/src/client/refresh/gl1/gl1_surf.c
@@ -45,9 +45,6 @@ void LM_InitBlock(void);
 void LM_UploadBlock(qboolean dynamic);
 qboolean LM_AllocBlock(int w, int h, int *x, int *y);
 
-void R_SetCacheState(msurface_t *surf);
-void R_BuildLightMap(msurface_t *surf, byte *dest, int stride);
-
 static void
 R_DrawGLPoly(msurface_t *fa)
 {

--- a/src/client/refresh/gl1/gl1_surf.c
+++ b/src/client/refresh/gl1/gl1_surf.c
@@ -595,7 +595,7 @@ R_RegenAllLightmaps()
 		return;
 	}
 
-	if (gl_config.lightmapcopies)
+	if (gl_config.tilerendering)
 	{
 		cur_lm_copy = (cur_lm_copy + 1) % MAX_LIGHTMAP_COPIES;	// select the next lightmap copy
 		lmtex = MAX_LIGHTMAPS * cur_lm_copy;	// ...and its corresponding texture
@@ -662,7 +662,7 @@ dynamic_surf:
 			R_BuildLightMap(surf, base, BLOCK_WIDTH * LIGHTMAP_BYTES);
 
 			surf->dirty_lightmap = (surf->dlightframe == r_framecount);
-			if (!surf->dirty_lightmap || gl_config.lightmapcopies)
+			if (!surf->dirty_lightmap || gl_config.tilerendering)
 			{
 				for (map = 0; map < MAXLIGHTMAPS && surf->styles[map] != 255; map++)
 				{
@@ -676,12 +676,12 @@ dynamic_surf:
 			R_JoinAreas(&current, &best);
 		}
 
-		if (!gl_config.lightmapcopies && !affected_lightmap)
+		if (!gl_config.tilerendering && !affected_lightmap)
 		{
 			continue;
 		}
 
-		if (gl_config.lightmapcopies)
+		if (gl_config.tilerendering)
 		{
 			// Add all the changes that have happened in the last few frames,
 			// at least just for consistency between them.

--- a/src/client/refresh/gl1/gl1_warp.c
+++ b/src/client/refresh/gl1/gl1_warp.c
@@ -85,7 +85,7 @@ int vec_to_st[6][3] = {
 float skymins[2][6], skymaxs[2][6];
 float sky_min, sky_max;
 
-void
+static void
 R_BoundPoly(int numverts, float *verts, vec3_t mins, vec3_t maxs)
 {
 	int i, j;
@@ -112,7 +112,7 @@ R_BoundPoly(int numverts, float *verts, vec3_t mins, vec3_t maxs)
 	}
 }
 
-void
+static void
 R_SubdividePolygon(int numverts, float *verts)
 {
 	int i, j, k;
@@ -317,7 +317,7 @@ R_EmitWaterPolys(msurface_t *fa)
 	}
 }
 
-void
+static void
 R_DrawSkyPolygon(int nump, vec3_t vecs)
 {
 	int i, j;
@@ -437,7 +437,7 @@ R_DrawSkyPolygon(int nump, vec3_t vecs)
 	}
 }
 
-void
+static void
 R_ClipSkyPolygon(int nump, vec3_t vecs, int stage)
 {
 	float *norm;
@@ -576,7 +576,7 @@ R_ClearSkyBox(void)
 	}
 }
 
-void
+static void
 R_MakeSkyVec(float s, float t, int axis)
 {
 	vec3_t v, b;

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -416,7 +416,7 @@ typedef struct
 	qboolean palettedtexture;
 	qboolean pointparameters;
 	qboolean multitexture;
-	qboolean lightmapcopies;	// many copies of same lightmap, for embedded
+	qboolean tilerendering;	// see "Tile-Based Rendering optimizations" in gl1_main.c
 
 	// ----
 

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -115,15 +115,6 @@ typedef struct image_s
 
 typedef enum
 {
-	rserr_ok,
-
-	rserr_invalid_mode,
-
-	rserr_unknown
-} rserr_t;
-
-typedef enum
-{
 	buf_2d,
 	buf_singletex,
 	buf_mtex,
@@ -145,7 +136,7 @@ typedef struct	//	832k aprox.
 
 	GLushort idx[MAX_INDICES];	// indices for the draw call
 
-	GLuint vt, tx, cl;	// indices for GLfloat arrays above
+	GLuint vt, tx, cl;	// indices for the first 3 arrays above
 
 	int	texture[MAX_TEXTURE_UNITS];
 	int	flags;	// entity flags

--- a/src/client/refresh/gl1/header/local.h
+++ b/src/client/refresh/gl1/header/local.h
@@ -187,7 +187,6 @@ extern cvar_t *gl1_overbrightbits;
 
 extern cvar_t *gl1_palettedtexture;
 extern cvar_t *gl1_pointparameters;
-extern cvar_t *gl1_multitexture;
 
 extern cvar_t *gl1_particle_min_size;
 extern cvar_t *gl1_particle_max_size;
@@ -248,17 +247,19 @@ extern int c_visible_textures;
 
 extern float r_world_matrix[16];
 
-extern unsigned char gammatable[256];
+extern byte gammatable[256];
+extern byte minlight[256];
 
 qboolean R_Bind(int texnum);
 
 void R_TexEnv(GLenum value);
-void R_SelectTexture(GLenum);
 void R_MBind(GLenum target, int texnum);
 void R_EnableMultitexture(qboolean enable);
 
 void R_LightPoint(entity_t *currententity, vec3_t p, vec3_t color);
 void R_PushDlights(void);
+void R_SetCacheState(msurface_t *surf);
+void R_BuildLightMap(msurface_t *surf, byte *dest, int stride);
 
 extern model_t *r_worldmodel;
 extern unsigned d_8to24table[256];

--- a/src/client/refresh/gl1/qgl.c
+++ b/src/client/refresh/gl1/qgl.c
@@ -49,7 +49,7 @@ void (APIENTRY *qglDiscardFramebufferEXT) (GLenum target,
 
 /* ========================================================================= */
 
-void QGL_EXT_Reset ( void )
+static void QGL_EXT_Reset ( void )
 {
 	qglPointParameterf     = NULL;
 	qglPointParameterfv    = NULL;

--- a/src/client/refresh/gl3/gl3_draw.c
+++ b/src/client/refresh/gl3/gl3_draw.c
@@ -588,11 +588,8 @@ void GL3_EndFrame(void)
 	}
 
 #ifdef YQ2_GL3_GLES
-	if (gl_discardfb->value)
-	{
-		static const GLenum attachments[] = {GL_COLOR_ATTACHMENT0, GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT};
-		glInvalidateFramebuffer(GL_FRAMEBUFFER, 3, attachments);
-	}
+	static const GLenum attachments[] = {GL_COLOR_ATTACHMENT0, GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT};
+	glInvalidateFramebuffer(GL_FRAMEBUFFER, 3, attachments);
 #endif
 
 	GL3_SwapWindow();

--- a/src/client/refresh/gl3/gl3_image.c
+++ b/src/client/refresh/gl3/gl3_image.c
@@ -168,6 +168,7 @@ GL3_TextureMode(char *string)
 	const char* nolerplist = gl_nolerp_list->string;
 	const char* lerplist = r_lerp_list->string;
 	qboolean unfiltered2D = r_2D_unfiltered->value != 0;
+	GL3_SelectTMU(GL_TEXTURE0);
 
 	/* change all the existing texture objects */
 	for (i = 0, glt = gl3textures; i < numgl3textures; i++, glt++)
@@ -184,8 +185,11 @@ GL3_TextureMode(char *string)
 			nolerp = true;
 		}
 
-		GL3_SelectTMU(GL_TEXTURE0);
-		GL3_Bind(glt->texnum);
+		if ( !GL3_Bind(glt->texnum) )
+		{
+			continue;	// don't bother changing anything if texture was already set
+		}
+
 		if ((glt->type != it_pic) && (glt->type != it_sky)) /* mipmapped texture */
 		{
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, gl_filter_min);
@@ -216,7 +220,7 @@ GL3_TextureMode(char *string)
 	}
 }
 
-void
+qboolean
 GL3_Bind(GLuint texnum)
 {
 	extern gl3image_t *draw_chars;
@@ -228,12 +232,13 @@ GL3_Bind(GLuint texnum)
 
 	if (gl3state.currenttexture == texnum)
 	{
-		return;
+		return false;
 	}
 
 	gl3state.currenttexture = texnum;
 	GL3_SelectTMU(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, texnum);
+	return true;
 }
 
 void

--- a/src/client/refresh/gl3/gl3_image.c
+++ b/src/client/refresh/gl3/gl3_image.c
@@ -130,7 +130,7 @@ GL3_Scrap_AllocBlock(int w, int h, int *x, int *y, const unsigned *pic)
 void
 GL3_TextureMode(char *string)
 {
-	const int num_modes = ARRLEN(modes);
+	static const int num_modes = ARRLEN(modes);
 	int i;
 
 	for (i = 0; i < num_modes; i++)
@@ -177,9 +177,9 @@ GL3_TextureMode(char *string)
 		if (unfiltered2D && glt->type == it_pic)
 		{
 			// exception to that exception: stuff on the r_lerp_list
-			nolerp = (lerplist== NULL) || (strstr(lerplist, glt->name) == NULL);
+			nolerp = (lerplist == NULL) || (strstr(lerplist, glt->name) == NULL);
 		}
-		else if(nolerplist != NULL && strstr(nolerplist, glt->name) != NULL)
+		else if (nolerplist != NULL && strstr(nolerplist, glt->name) != NULL)
 		{
 			nolerp = true;
 		}

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -130,10 +130,6 @@ cvar_t *r_palettedtexture;
 cvar_t *r_validation;
 cvar_t *gl3_usefbo;
 
-#ifdef YQ2_GL3_GLES
-cvar_t *gl_discardfb;
-#endif
-
 cvar_t *gl3_show_draw_stats;
 
 static cvar_t *gl_znear;
@@ -297,10 +293,6 @@ GL3_Register(void)
 	r_speeds = ri.Cvar_Get("r_speeds", "0", 0);
 	gl_finish = ri.Cvar_Get("gl_finish", "0", CVAR_ARCHIVE);
 	gl_znear = ri.Cvar_Get("gl_znear", "4", CVAR_ARCHIVE);
-
-#ifdef YQ2_GL3_GLES
-	gl_discardfb = ri.Cvar_Get("gl_discardfb", "1", CVAR_ARCHIVE);
-#endif
 
 	gl3_usefbo = ri.Cvar_Get("gl3_usefbo", "1", CVAR_ARCHIVE); // use framebuffer object for postprocess effects (water)
 
@@ -537,7 +529,7 @@ static void
 GL3_ResetClearColor(void)
 {
 #ifdef YQ2_GL3_GLES
-	if (gl_discardfb->value && !r_clear->value)
+	if (!r_clear->value)
 		glClearColor(0, 0, 0, 0.5);
 	else
 #endif
@@ -2085,10 +2077,7 @@ GL3_Clear(void)
 #endif // 0
 
 #ifdef YQ2_GL3_GLES
-	if (gl_discardfb->value)
-	{
-		clearFlags |= GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
-	}
+	clearFlags |= GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
 #endif
 
 	glClear(clearFlags);

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -425,8 +425,8 @@ SetMode_impl(int *pwidth, int *pheight, int mode, int fullscreen)
 		GL3_BindVBO(0);
 	}
 
-	/* This is totaly obscure: For some strange reasons the renderer
-	   maintains two(!) repesentations of the resolution. One comes
+	/* This is totally obscure: For some strange reasons the renderer
+	   maintains two(!) representations of the resolution. One comes
 	   from the client and is saved in r_newrefdef. The other one
 	   is determined here and saved in vid. Several calculations take
 	   both representations into account.
@@ -532,9 +532,6 @@ GL3_SetMode(void)
 
 	return true;
 }
-
-// only needed (and allowed!) if using OpenGL compatibility profile, it's not in 3.2 core
-enum { QGL_POINT_SPRITE = 0x8861 };
 
 static void
 GL3_ResetClearColor(void)
@@ -2187,7 +2184,7 @@ GL3_BeginFrame(float camera_separation)
 #ifdef YQ2_GL3_GLES
 		// OpenGL ES3 only supports GL_NONE, GL_BACK and GL_COLOR_ATTACHMENT*
 		// so this doesn't make sense here, see https://docs.gl/es3/glDrawBuffers
-		Com_Printf("NOTE: gl_drawbuffer not supported by OpenGL ES!\n");
+		Com_Printf("NOTE: gl_drawbuffer not supported by OpenGL ES.\n");
 #else // Desktop GL
 		// TODO: stereo stuff
 		//if ((gl3state.camera_separation == 0) || gl3state.stereo_mode != STEREO_MODE_OPENGL)

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -649,10 +649,6 @@ extern cvar_t *r_fixsurfsky;
 extern cvar_t *r_palettedtexture;
 extern cvar_t *r_validation;
 
-#ifdef YQ2_GL3_GLES
-extern cvar_t *gl_discardfb;
-#endif
-
 extern cvar_t *gl3_debugcontext;
 extern cvar_t *gl3_show_draw_stats;
 

--- a/src/client/refresh/gl3/header/local.h
+++ b/src/client/refresh/gl3/header/local.h
@@ -527,7 +527,7 @@ GL3_SelectTMU(GLenum tmu)
 }
 
 extern void GL3_TextureMode(char *string);
-extern void GL3_Bind(GLuint texnum);
+extern qboolean GL3_Bind(GLuint texnum);
 extern void GL3_BindLightmap(int lightmapnum);
 extern gl3image_t *GL3_LoadPic(char *name, byte *pic, int width, int realwidth,
                                int height, int realheight, size_t data_size,

--- a/src/client/refresh/soft/sw_main.c
+++ b/src/client/refresh/soft/sw_main.c
@@ -2546,8 +2546,8 @@ SWimp_SetMode(int *pwidth, int *pheight, int mode, int fullscreen )
 		return rserr_invalid_mode;
 	}
 
-	/* This is totaly obscure: For some strange reasons the renderer
-	   maintains three(!) repesentations of the resolution. One comes
+	/* This is totally obscure: For some strange reasons the renderer
+	   maintains three(!) representations of the resolution. One comes
 	   from the client and is saved in r_newrefdef. The other one
 	   is determined here and saved in vid. The third one is used by
 	   the backbuffer. Some calculations take all three representations


### PR DESCRIPTION
In #1128 I added two new cvars to handle two different optimization options for SoC / embedded devices. Since they both are used towards the same final purpose (optimize for SoC or not), and both are always enabled or disabled simultaneously, I believe the user would be more comfortable using only one.

The new cvar, `gl1_tilerendering`, is only available for GL1. This is mainly for two reasons:
1. New (official) Raspberry Pi OS versions have taken out the possibility to use GLES1. Having this switch makes practical for those OSs to enable the needed optimizations for this hardware.
2. GLES1 operates as if `gl1_tilerendering` is always enabled, just to avoid "_the paradox of choice_", since if you want this option disabled, using GL1 is probably the best choice from the start.

Related to this last point, I took the liberty to delete the `gl_discardfb` cvar of GLES3, recently added in #1339, and based in the now "removed" `gl1_discardfb`. Again, now it operates like it's "always 1", since you'll always need these _tile rendering_ optimizations if you have to choose GLES3 over GL3. It didn't have documentation anyway.

Also included in this PR:

- GL1 general code cleanup, plus a little bit of the same on GL3.
- Removed a few unnecesary OpenGL calls on GL3 init.
- Default for `gl1_pointparameters` in GLES1 is now `0`; in GL1 it remains `1`. Newer GPU drivers for SBCs show the needed extension as "_supported_" but [they actually don't do it](https://youtu.be/Wbp7OPADyUc?t=181).
- Fixed `vid_pauseonfocuslost` documentation. This didn't follow how it actually operates, according to the old menu option (31db2f7f).
- Added `GL_LINEAR` to the "_texture filter_" option in the Video menu. It's a user-friendly way to solve a graphical bug on Intel G41 Express Chipset ([see discussion](https://www.reddit.com/r/quake/comments/1tdhfot/help_quake_2_lighting_problem/)).