### PR TITLE
Make mute on focus loss optional

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -344,6 +344,9 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
   0.  Setting this cvar to `1` disables this behavior, the music keeps
   playing.
 
+* **ogg_pausewithgame**: When `1` the background is paused when the game
+  is paused. Defaults to `0`.
+
 * **ogg_shuffle**: Ogg/Vorbis playback mode. Supported modes are:
   - `0`: Loop the current track (the default).
   - `1`: Play the current track once, then stop.

--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -356,6 +356,10 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
 * **s_doppler**: If set to `1` doppler effects are enabled. This is only
   supported by the OpenAL sound backend.
 
+* **s_muteonfocusloss**: If set to `1` (the default) all sounds are
+  muted when the game looses focus. Sound are unmuted when the game
+  regains focus.
+
 * **s_openal**: Use OpenAL for sound playback. This is enabled by
   default. OpenAL gives a huge quality boost over the classic sound
   system and supports surround speakers and HRTF for headphones. OpenAL

--- a/src/client/input/sdl2.c
+++ b/src/client/input/sdl2.c
@@ -126,6 +126,7 @@ static cvar_t *m_filter;
 static cvar_t *windowed_pauseonfocuslost;
 static cvar_t *windowed_mouse;
 static cvar_t *haptic_feedback_filter;
+static cvar_t *s_muteonfocusloss;
 
 // ----
 
@@ -987,37 +988,42 @@ IN_Update(void)
 					case SDL_WINDOWEVENT_FOCUS_LOST:
 					{
 						Key_MarkAllUp();
-						S_Activate(false);
 
 						if (windowed_pauseonfocuslost->value != 1)
 						{
 							Cvar_SetValue("paused", 1);
 						}
 
-						/* pause music */
 						if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
 							OGG_Status() == PLAY && cl.attractloop == false)
 						{
 							Cbuf_AddText("ogg toggle\n");
+						}
+
+						if (s_muteonfocusloss->value == 1)
+						{
+							S_Activate(false);
 						}
 						break;
 					}
 
 					case SDL_WINDOWEVENT_FOCUS_GAINED:
 					{
-						S_Activate(true);
-
 						if (windowed_pauseonfocuslost->value == 2)
 						{
 							Cvar_SetValue("paused", 0);
 						}
 
-						/* play music */
 						if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
 							OGG_Status() == PAUSE && cl.attractloop == false &&
 							cl_paused->value == 0)
 						{
 							Cbuf_AddText("ogg toggle\n");
+						}
+
+						if (s_muteonfocusloss->value == 1)
+						{
+							S_Activate(true);
 						}
 						break;
 					}
@@ -2927,6 +2933,8 @@ IN_Init(void)
 
 	windowed_pauseonfocuslost = Cvar_Get("vid_pauseonfocuslost", "0", CVAR_USERINFO | CVAR_ARCHIVE);
 	windowed_mouse = Cvar_Get("windowed_mouse", "1", CVAR_USERINFO | CVAR_ARCHIVE);
+
+	s_muteonfocusloss = Cvar_Get("s_muteonfocusloss", "1", CVAR_ARCHIVE);
 
 	Cmd_AddCommand("+mlook", IN_MLookDown);
 	Cmd_AddCommand("-mlook", IN_MLookUp);

--- a/src/client/input/sdl3.c
+++ b/src/client/input/sdl3.c
@@ -129,6 +129,7 @@ static cvar_t *m_filter;
 static cvar_t *windowed_pauseonfocuslost;
 static cvar_t *windowed_mouse;
 static cvar_t *haptic_feedback_filter;
+static cvar_t *s_muteonfocusloss;
 
 // ----
 
@@ -966,37 +967,43 @@ IN_Update(void)
 			case SDL_EVENT_WINDOW_FOCUS_LOST:
 			{
 				Key_MarkAllUp();
-				S_Activate(false);
 
 				if (windowed_pauseonfocuslost->value != 1)
 				{
 					Cvar_SetValue("paused", 1);
 				}
 
-				/* pause music */
 				if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
 						OGG_Status() == PLAY && cl.attractloop == false)
 				{
 					Cbuf_AddText("ogg toggle\n");
+				}
+
+				if (s_muteonfocusloss->value == 1)
+				{
+					S_Activate(false);
 				}
 				break;
 			}
 
 			case SDL_EVENT_WINDOW_FOCUS_GAINED:
 			{
-				S_Activate(true);
 
 				if (windowed_pauseonfocuslost->value == 2)
 				{
 					Cvar_SetValue("paused", 0);
 				}
 
-				/* play music */
 				if (Cvar_VariableValue("ogg_pausewithgame") == 1 &&
 						OGG_Status() == PAUSE && cl.attractloop == false &&
 						cl_paused->value == 0)
 				{
 					Cbuf_AddText("ogg toggle\n");
+				}
+
+				if (s_muteonfocusloss->value == 1)
+				{
+					S_Activate(true);
 				}
 				break;
 			}
@@ -2894,6 +2901,8 @@ IN_Init(void)
 
 	windowed_pauseonfocuslost = Cvar_Get("vid_pauseonfocuslost", "0", CVAR_USERINFO | CVAR_ARCHIVE);
 	windowed_mouse = Cvar_Get("windowed_mouse", "1", CVAR_USERINFO | CVAR_ARCHIVE);
+
+	s_muteonfocusloss = Cvar_Get("s_muteonfocusloss", "1", CVAR_ARCHIVE);
 
 	Cmd_AddCommand("+mlook", IN_MLookDown);
 	Cmd_AddCommand("-mlook", IN_MLookUp);


### PR DESCRIPTION
Until now all sounds were muted when game lost focus. While that might be desired in many cases, there was a request to keep the background music playing. Since pausing only parts of the sound system is invasive and there aren't any sounds besides the background music when the game is paused, take the easy way and introduce a cvar `s_muteonfocusloss`. When `1` (the default) the sound gets muted, otherwise not.